### PR TITLE
Handle QA env in AssetHelper inlined/encode

### DIFF
--- a/app/helpers/asset_helper.rb
+++ b/app/helpers/asset_helper.rb
@@ -18,7 +18,7 @@ module AssetHelper
     end
 
     def inlined(path)
-      if Rails.env.development? || Rails.env.test?
+      if Rails.env.development? || Rails.env.test? || Rails.env.qa?
         asset = Rails.application.assets.find_asset(path)
       else
         filesystem_path = Rails.application.assets_manifest.assets[path]
@@ -30,7 +30,7 @@ module AssetHelper
     private
 
     def encode(path)
-      if Rails.env.development? || Rails.env.test?
+      if Rails.env.development? || Rails.env.test? || Rails.env.qa?
         asset = Rails.application.assets.find_asset(path)
         content_type = asset&.content_type
       elsif (filesystem_path = Rails.application.assets_manifest.assets[path])


### PR DESCRIPTION
## Summary
- QA is deployed via Cloud66 without running `assets:precompile`, so `public/assets` and the asset manifest do not exist there.
- `AssetHelper.inlined` and `AssetHelper#encode` previously fell through to reading files from `public/assets` for any non-`development`/`test` environment, which raised in QA.
- Treat QA the same way as `development` and `test`, resolving assets in memory via `Rails.application.assets.find_asset`.

## Test plan
- [x] Deploy the branch to QA and verify pages that call `AssetHelper.inlined` (e.g. LaTeX/PDF rendering paths) load without errors
- [x] Confirm `development` and `test` behavior is unchanged (local boot + RSpec green)
- [ ] Confirm production behavior is unchanged (precompiled `public/assets` path still used)