### PR TITLE
Refactor gdoc and pdf styles for Lesson specification

### DIFF
--- a/app/assets/stylesheets/gdoc.scss
+++ b/app/assets/stylesheets/gdoc.scss
@@ -1,21 +1,31 @@
 @charset "utf-8";
 
-@import url("https://fonts.googleapis.com/css2?family=Lexend:wght@400;700&family=Nunito:wght@400;700&family=Roboto:wght@400;700&display=swap");
-
 // =========================================================================
-// LCMS Core PDF defaults
+// LCMS Core Google Doc export defaults
 // =========================================================================
 // Spec: "LCMS Core Styling Defaults". Open items live in
 // docs/core/styling-defaults-needs-clarification.md.
 //
-// Note on !important: imported Google-Doc HTML carries inline style="..." on
-// every <p>/<span> (font-family, font-size, color, line-height). Inline styles
-// beat any class selector, so spec-mandated overrides ("always overwrite color
-// and size to the preset body style") must use !important until the source-doc
-// CSS normalization pass (Q6) strips those inline attributes per-element.
-// Once that lands, !important here can be removed.
+// Loaded by app/views/layouts/gdoc.html.erb via inlined_asset('gdoc.css').
+// The HTML is uploaded to Google Drive with mime_type "application/vnd.
+// google-apps.document"; Google Drive imports it into a Google Doc.
+//
+// Notes on Google Docs HTML import:
+//   * Tag selectors (h1, p, body) are honored on import.
+//   * Class selectors are inconsistently honored — for styling that must
+//     survive in the Gdoc, the safer path is to inline `style="..."` on
+//     elements in the doc_template renderers (see Q-Gdoc-inline in the
+//     clarification doc).
+//   * @import url(...) for Google Fonts is unreliable on import. Lexend is
+//     a native Google Fonts family in Google Docs, so naming it in
+//     `font-family` is sufficient.
+//   * @page / page-setup rules are ignored — Google Docs uses its own page
+//     settings.
+//   * Source-doc inline styles still ship through @document.css_styles in
+//     the layout body. !important keeps our defaults visible until the
+//     normalization pass (Q6) lands.
 
-// --- Design tokens -------------------------------------------------------
+// --- Design tokens (kept in sync with pdf.scss) --------------------------
 
 $font-family-body: "Lexend", Arial, sans-serif !default;
 $font-family-heading: $font-family-body !default;
@@ -34,8 +44,8 @@ $font-size-h4: 13pt !default;
 $font-size-h5: 12pt !default;
 $font-size-h6: 11pt !default;
 
-$space-heading-large: 6pt !default;  // H1, H2 paragraph-after
-$space-heading-medium: 4pt !default; // H3 paragraph-after
+$space-heading-large: 6pt !default;
+$space-heading-medium: 4pt !default;
 
 // --- Base / body ---------------------------------------------------------
 
@@ -68,8 +78,6 @@ ol {
 }
 
 // --- Highlighting --------------------------------------------------------
-// Spec: not included by default; clients must request.
-// Strip Google-Doc inline background-color on inline text elements.
 
 span,
 p {
@@ -129,14 +137,11 @@ h6 {
 }
 
 // --- Images --------------------------------------------------------------
-// Caption rendered by lib/doc_template/templates/image.html.erb as
-// <figcaption>. The "credit" element from the spec is not yet present in
-// the template markup (tracked in clarification doc, Q7).
+// Caption rendered by lib/doc_template/templates/gdoc/image.html.erb as a
+// <td class="o-ld-image__caption"> inside a layout table. Class-based, so
+// may be brittle through Google Docs import — verify per render.
 
-figure {
-  margin: 0;
-}
-
+.o-ld-image__caption,
 figcaption {
   font-family: $font-family-body !important;
   font-size: $font-size-caption !important;
@@ -145,16 +150,15 @@ figcaption {
 }
 
 // --- Material tag --------------------------------------------------------
-// Rendered by lib/doc_template/tags/material_tag.rb as
-// <a class="o-ld-material">.
 
 .o-ld-material {
   font-style: italic !important;
 }
 
 // --- Lesson banner -------------------------------------------------------
-// Rendered by app/views/documents/pdf/_header.html.erb. Top-of-document
-// strip: brandmark | lesson type / estimated time, divider, H1, standards.
+// Rendered by app/views/documents/gdoc/_header.html.erb. Mirrors the PDF
+// banner; class-selector support in Google Docs is limited, so we also
+// add tag-level rules via the H1 ladder above.
 
 .c-lesson-banner__strip {
   width: 100%;
@@ -200,7 +204,6 @@ figcaption {
 }
 
 .c-lesson-banner__title {
-  // Inherits H1 defaults above; class exists for view-level targeting.
   margin-bottom: $space-heading-large;
 }
 
@@ -212,8 +215,6 @@ figcaption {
 }
 
 // --- Lesson overview (description bullets) -------------------------------
-// Rendered by app/views/documents/pdf/_header.html.erb, fed by the
-// description-past / description / description-future metadata.
 
 .c-lesson-overview__list {
   margin: 0 0 $space-heading-large 0;
@@ -235,15 +236,8 @@ figcaption {
 }
 
 // --- Callout — inline (1-row 2-col) variant ------------------------------
-// Rendered by lib/doc_template/templates/callout_inline.html.erb when the
-// authored callout table has exactly one row. Side-by-side: icon+label on
-// the left, content on the right. The legacy 3-row shape uses
-// callout.html.erb and the existing .o-ld-callout / .o-ld-callout__header
-// styles (untouched).
 
 // --- Lesson materials summary (aggregated from activity-metadata) --------
-// Rendered above the activities by app/views/documents/pdf/_header.html.erb.
-// 5-row label/value table — empty values render as "None".
 
 .c-lesson-materials__heading {
   margin-bottom: 4pt;
@@ -273,9 +267,6 @@ figcaption {
 }
 
 // --- Activity (flowing layout) -------------------------------------------
-// Rendered by lib/doc_template/templates/activity.html.erb. Drops the
-// legacy bordered-table wrapping in favor of an H3 heading + plain text
-// meta lines + body content, per the spec mockup.
 
 .o-ld-activity {
   margin: $space-heading-large 0 0;
@@ -287,7 +278,6 @@ figcaption {
   }
 
   &__heading {
-    // Inherits H3 typography (14pt bold #434343) from headings ladder above.
     margin-bottom: 4pt;
   }
 

--- a/app/assets/stylesheets/pdf_plain.scss
+++ b/app/assets/stylesheets/pdf_plain.scss
@@ -1,1 +1,64 @@
 @charset "utf-8";
+
+@import url("https://fonts.googleapis.com/css2?family=Lexend:wght@400;700&display=swap");
+
+// =========================================================================
+// LCMS Core PDF footer / "plain" chrome
+// =========================================================================
+// Loaded by app/views/layouts/pdf_plain.erb, which wraps the Grover
+// footer template (app/views/documents/pdf/_footer.erb). Grover renders
+// this in a separate Chromium document, so we re-declare the body font
+// and footer-specific styles here.
+
+$footer-font-family: "Lexend", Arial, sans-serif;
+$footer-color: #000000;
+$footer-color-muted: #434343;
+$footer-size-small: 9pt;
+$footer-size-bold: 10pt;
+
+body {
+  font-family: $footer-font-family;
+  color: $footer-color;
+  margin: 0;
+  padding: 0;
+}
+
+.c-lesson-footer {
+  font-family: $footer-font-family;
+  width: 100%;
+}
+
+.c-lesson-footer__copyright {
+  font-family: $footer-font-family;
+  font-size: $footer-size-small;
+  font-weight: 400;
+  color: $footer-color;
+  margin: 0 0 2pt 0;
+  padding: 0;
+}
+
+.c-lesson-footer__line {
+  width: 100%;
+  border-collapse: collapse;
+  border-top: 0.5pt solid $footer-color-muted;
+  margin-top: 2pt;
+
+  td {
+    padding: 4pt 0 0 0;
+    border: 0;
+    vertical-align: middle;
+    font-family: $footer-font-family;
+    font-size: $footer-size-bold;
+    font-weight: bold;
+    color: $footer-color;
+  }
+}
+
+.c-lesson-footer__breadcrumb {
+  text-align: left;
+}
+
+.c-lesson-footer__page {
+  text-align: right;
+  width: 36pt;
+}

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -5,9 +5,10 @@ module Admin
     def index; end
 
     def update
+      processed_params = process_image_uploads(params)
+
       SETTINGS.each do |group, types|
         permitted_keys = types.keys.map(&:to_s)
-        processed_params = process_image_uploads(params)
         new_settings = processed_params.permit(permitted_keys).to_h
         changes = new_settings.select { |key, value| @all_settings[group][key.to_sym] != value }
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -14,8 +14,8 @@ class DocumentsController < Admin::AdminController
   def preview_pdf
     link_keys = %w(preview pdf)
 
-    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) && (url = @document.preview_links.dig(*link_keys)).present?
-      return redirect_to url
+    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) && (url = @document.preview_links.dig(*link_keys, "url")).present?
+      return redirect_to url, allow_other_host: true
     end
 
     job_options = {
@@ -33,8 +33,8 @@ class DocumentsController < Admin::AdminController
   def preview_gdoc
     link_keys = %w(preview gdoc)
 
-    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) &&  (url = @document.preview_links.dig(*link_keys)).present?
-      return redirect_to url
+    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) && (url = @document.preview_links.dig(*link_keys, "url")).present?
+      return redirect_to url, allow_other_host: true
     end
 
     job_options = {

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -8,8 +8,8 @@ class MaterialsController < Admin::AdminController
   def preview_pdf
     link_keys = %w(preview pdf)
 
-    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) && (url = @material.preview_links.dig(*link_keys)).present?
-      return redirect_to url
+    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) && (url = @material.preview_links.dig(*link_keys, "url")).present?
+      return redirect_to url, allow_other_host: true
     end
 
     job_options = {
@@ -27,8 +27,8 @@ class MaterialsController < Admin::AdminController
   def preview_gdoc
     link_keys = %w(preview gdoc)
 
-    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) &&  (url = @material.preview_links.dig(*link_keys)).present?
-      return redirect_to url
+    if !ENV.fetch("FORCE_PREVIEW_GENERATION", false) && (url = @material.preview_links.dig(*link_keys, "url")).present?
+      return redirect_to url, allow_other_host: true
     end
 
     job_options = {

--- a/app/helpers/asset_helper.rb
+++ b/app/helpers/asset_helper.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
+require "open-uri"
+
 module AssetHelper
   REDIS_PREFIX = "ub-b64-asset"
+  DATA_URI_FETCH_LIMIT = 5.megabytes
+  DATA_URI_OPEN_TIMEOUT = 5
+  DATA_URI_READ_TIMEOUT = 10
 
   class << self
     def base64_encoded(path, cache: false)
@@ -15,6 +20,33 @@ module AssetHelper
       b64_asset = encode path
       redis.set key, b64_asset, ex: 1.day.to_i if cache
       b64_asset
+    end
+
+    # Fetches a remote (or local) URL and returns a base64 data URI suitable
+    # for embedding in HTML that gets imported by Google Drive (which strips
+    # or fails to fetch external image references during HTML→Gdoc import).
+    # Returns nil and logs a warning on failure so callers can fall back.
+    def inline_data_uri(url, cache: false)
+      return nil if url.blank?
+
+      key = "#{REDIS_PREFIX}-data-uri:#{Digest::SHA1.hexdigest(url)}"
+      if cache
+        cached = redis.get(key)
+        return cached if cached.present?
+      end
+
+      content = fetch_remote(url)
+      return nil if content.blank?
+
+      mime = mime_for(url, content)
+      encoded = Base64.strict_encode64(content)
+      data_uri = "data:#{mime};base64,#{encoded}"
+
+      redis.set(key, data_uri, ex: 1.day.to_i) if cache
+      data_uri
+    rescue StandardError => e
+      Rails.logger.warn "AssetHelper.inline_data_uri failed for #{url}: #{e.message}"
+      nil
     end
 
     def inlined(path)
@@ -46,6 +78,35 @@ module AssetHelper
 
     def redis
       Rails.application.config.redis
+    end
+
+    def fetch_remote(url)
+      uri = URI.parse(url)
+      case uri.scheme
+      when "http", "https"
+        uri.open(
+          open_timeout: DATA_URI_OPEN_TIMEOUT,
+          read_timeout: DATA_URI_READ_TIMEOUT,
+          content_length_proc: ->(size) {
+            if size && size > DATA_URI_FETCH_LIMIT
+              raise "remote asset too large: #{size} bytes"
+            end
+          }
+        ) { |io| io.read(DATA_URI_FETCH_LIMIT + 1) }.then do |body|
+          raise "remote asset exceeds #{DATA_URI_FETCH_LIMIT} bytes" if body.bytesize > DATA_URI_FETCH_LIMIT
+
+          body
+        end
+      else
+        raise "unsupported URL scheme: #{uri.scheme.inspect}"
+      end
+    end
+
+    def mime_for(url, content)
+      ext = File.extname(URI.parse(url).path).delete_prefix(".").downcase
+      return "image/svg+xml" if ext == "svg" || content.byteslice(0, 256).to_s.lstrip.start_with?("<svg", "<?xml")
+
+      Mime::Type.lookup_by_extension(ext)&.to_s || "application/octet-stream"
     end
   end
 end

--- a/app/jobs/concerns/pdf_exportable.rb
+++ b/app/jobs/concerns/pdf_exportable.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Shared PDF exporter selection for jobs that render content to PDF.
+#
+# Each including job declares its default (Grover/Chromium) exporter:
+#
+#   class DocumentPdfJob < ApplicationJob
+#     include PdfExportable
+#     pdf_exporter ::Exporters::Pdf::Document
+#   end
+#
+# and renders via:
+#
+#   pdf = pdf_exporter_class.new(presenter, options).export
+#
+module PdfExportable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Declares the default (Grover/Chromium) PDF exporter for this job.
+    def pdf_exporter(klass)
+      @pdf_exporter = klass
+    end
+
+    def default_pdf_exporter
+      @pdf_exporter
+    end
+  end
+
+  private
+
+  # Spike toggle: when PDF_VIA_GDOC_EXPORT is set, render the PDF by creating a
+  # Google Doc and exporting it via the Drive API instead of Grover/Chromium.
+  def pdf_exporter_class
+    if ENV["PDF_VIA_GDOC_EXPORT"].present?
+      ::Exporters::Pdf::ViaGdoc
+    else
+      self.class.default_pdf_exporter
+    end
+  end
+end

--- a/app/jobs/document_pdf_job.rb
+++ b/app/jobs/document_pdf_job.rb
@@ -64,4 +64,16 @@ class DocumentPdfJob < ApplicationJob
       end
     end
   end
+
+  private
+
+  # Spike toggle: when PDF_VIA_GDOC_EXPORT is set, render the PDF by creating a
+  # Google Doc and exporting it via Drive API instead of Grover/Chromium.
+  def pdf_exporter_class
+    if ENV["PDF_VIA_GDOC_EXPORT"].present?
+      ::Exporters::Pdf::ViaGdoc
+    else
+      ::Exporters::Pdf::Document
+    end
+  end
 end

--- a/app/jobs/document_pdf_job.rb
+++ b/app/jobs/document_pdf_job.rb
@@ -3,10 +3,13 @@
 class DocumentPdfJob < ApplicationJob
   include DocumentRescuableJob
   include ResqueJob
+  include PdfExportable
 
   queue_as :default
 
   LINK_KEY = "pdf"
+
+  pdf_exporter ::Exporters::Pdf::Document
 
   # Generates a PDF file for a document and uploads it to S3.
   #
@@ -31,7 +34,7 @@ class DocumentPdfJob < ApplicationJob
     content_type = options[:content_type].to_sym
     document = DocumentPresenter.new(entry, content_type:)
 
-    pdf = Exporters::Pdf::Document.new(document, options).export
+    pdf = pdf_exporter_class.new(document, options).export
 
     s3_path = ""
     s3_path += "#{options[:folder]}/" if options[:folder].present?

--- a/app/jobs/material_pdf_job.rb
+++ b/app/jobs/material_pdf_job.rb
@@ -3,10 +3,13 @@
 class MaterialPdfJob < ApplicationJob
   include MaterialRescuableJob
   include ResqueJob
+  include PdfExportable
 
   queue_as :default
 
   LINK_KEY = "pdf"
+
+  pdf_exporter ::Exporters::Pdf::Material
 
   # Generates a PDF file for a material and uploads it to S3.
   #
@@ -32,7 +35,7 @@ class MaterialPdfJob < ApplicationJob
     entry = Material.find(entry_id)
     material = MaterialPresenter.new(entry, content_type:)
 
-    pdf = ::Exporters::Pdf::Material.new(material, options).export
+    pdf = pdf_exporter_class.new(material, options).export
     thumb = ::Exporters::Thumbnail.new(pdf).export
 
     s3_path = ""

--- a/app/jobs/material_pdf_job.rb
+++ b/app/jobs/material_pdf_job.rb
@@ -69,4 +69,16 @@ class MaterialPdfJob < ApplicationJob
       end
     end
   end
+
+  private
+
+  # Spike toggle: when PDF_VIA_GDOC_EXPORT is set, render the PDF by creating a
+  # Google Doc and exporting it via Drive API instead of Grover/Chromium.
+  def pdf_exporter_class
+    if ENV["PDF_VIA_GDOC_EXPORT"].present?
+      ::Exporters::Pdf::ViaGdoc
+    else
+      ::Exporters::Pdf::Material
+    end
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,13 +82,7 @@ class Document < ApplicationRecord
   def clean_curriculum_metadata
     return unless metadata.present?
 
-    # downcase subjects
     metadata["subject"] = metadata["subject"]&.downcase
-
-    # to store only the lesson number
-    # or alphanumeric - needed by OPR type, see https://github.com/learningtapestry/unbounded/issues/557
-    lesson = metadata["lesson"]
-    metadata["lesson"] = lesson.match(/lesson (\w+)/i).try(:[], 1) || lesson if lesson.present?
   end
 
   def destroy_connected_resource

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -3,8 +3,60 @@
 class DocumentPresenter < ContentPresenter
   include Rails.application.routes.url_helpers
 
-  delegate :cc_attribution, :grade, :subject, :lesson_title, :lesson_number, :section_number, :teaser, :unit_id,
+  delegate :cc_attribution, :description_future, :description_past, :estimated_time, :grade,
+           :lesson_title, :lesson_number, :lesson_type, :section_number, :subject, :unit_id,
+           :vocabulary, :teaser,
            to: :base_metadata
+
+  MATERIALS_ROWS = {
+    "Individual Student Materials" => "activity-materials-student",
+    "Pair Materials" => "activity-materials-pair",
+    "Small Group Materials" => "activity-materials-group",
+    "Class Materials" => "activity-materials-class",
+    "Teacher Materials" => "activity-metadata-teacher"
+  }.freeze
+
+  def brandmark_url
+    raw = Setting.get(:documents, include_defaults: true)&.dig(:brandmark)
+    return nil if raw.blank?
+
+    # Inline as data URI so the image survives HTML→Gdoc import (and
+    # PDF_VIA_GDOC_EXPORT, which routes PDF through Drive). Falls back
+    # to the raw URL if the fetch fails — works for Grover/Chromium.
+    AssetHelper.inline_data_uri(raw, cache: ViewHelper::ENABLE_BASE64_CACHING) || raw
+  end
+
+  def copyright_text
+    Setting.get(:documents, include_defaults: true)&.dig(:copyright_text).presence
+  end
+
+  # Bold breadcrumb line used in the lesson footer.
+  # @return [String, nil] e.g. "Grade 6/Course • Unit Title • Lesson 2"
+  def footer_breadcrumb
+    parts = [grade_label, unit_title, lesson_label].compact_blank
+    parts.any? ? parts.join(" • ") : nil
+  end
+
+  # Aggregates activity-metadata material fields into the 5-row lesson
+  # Materials summary table. Each row collects values across all
+  # activities, dedupes, joins, and resolves any [material: id] tokens
+  # to italicized identifier links (matching how MaterialTag renders
+  # inline). Empty rows render as "None".
+  #
+  # @return [Hash{String => String}] heading => joined materials HTML.
+  #   Returns {} when the document has no activity metadata so the view
+  #   can skip the Materials block entirely.
+  def materials_summary
+    activities = Array.wrap(activity_metadata)
+    return {} if activities.empty?
+
+    MATERIALS_ROWS.transform_values do |key|
+      values = activities.flat_map { |a| split_list(a[key]) }.uniq.compact_blank
+      next "None" if values.empty?
+
+      values.map { |v| resolve_material_tokens(v) }.join(", ")
+    end
+  end
 
   def content_for(context_type, options = {})
     render_content(context_type, options)
@@ -17,12 +69,23 @@ class DocumentPresenter < ContentPresenter
   # Footer data for Google Apps Script post-processing.
   # Used in Google::ScriptService#parameters.
   #
+  # NOTE: kept at the original 2-row shape. The R2 footer design (copyright
+  # line + breadcrumb) is fully implemented in the PDF footer. To land it in
+  # generated Gdocs we need to (a) update the Apps Script template doc in
+  # Drive to use new placeholders AND (b) extend this array. Doing only (b)
+  # makes the Apps Script post-processing hang on unfamiliar args.
+  #
   # @return [Array<Array<String>>] 2D array with placeholder/value pairs:
   #   [["{placeholder}"], [replacement_value]]
   def gdoc_footer
     [
       ["{attribution}"],
-      [cc_attribution.presence || "Copyright attribution here"]
+      [
+        [copyright_text.presence, cc_attribution.presence]
+          .compact
+          .join(" — ")
+          .presence || "Copyright attribution here"
+      ]
     ]
   end
 
@@ -83,5 +146,46 @@ class DocumentPresenter < ContentPresenter
 
   def standards
     base_metadata.standards
+  end
+
+  private
+
+  def grade_label
+    return nil if grade.blank?
+
+    "Grade #{grade}/Course"
+  end
+
+  def unit_title
+    resource&.ancestors&.find(&:unit?)&.title.presence ||
+      (unit_id.present? ? "Unit #{unit_id.to_s.upcase}" : nil)
+  end
+
+  def lesson_label
+    lesson_number.to_i.positive? ? "Lesson #{lesson_number}" : nil
+  end
+
+  def split_list(value)
+    return [] if value.blank?
+
+    value.to_s.split(",").map(&:strip).reject(&:blank?)
+  end
+
+  # Replaces `[material: id]` tokens in raw activity-metadata text with the
+  # italicized identifier markup that MaterialTag emits inline. Plain text
+  # is passed through unchanged.
+  MATERIAL_TOKEN_RE = /\[material:\s*([^\]]+)\]/i
+
+  def resolve_material_tokens(text)
+    text.to_s.gsub(MATERIAL_TOKEN_RE) do
+      identifier = ::Regexp.last_match(1).to_s.strip
+      next identifier if identifier.blank?
+
+      if ::Material.exists?(identifier: identifier.downcase)
+        %(<a class="o-ld-material">#{identifier}</a>)
+      else
+        identifier
+      end
+    end
   end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -3,7 +3,7 @@
 class DocumentPresenter < ContentPresenter
   include Rails.application.routes.url_helpers
 
-  delegate :cc_attribution, :grade, :subject, :lesson_title, :lesson_number, :section_number, :unit_id,
+  delegate :cc_attribution, :grade, :subject, :lesson_title, :lesson_number, :section_number, :teaser, :unit_id,
            to: :base_metadata
 
   def content_for(context_type, options = {})

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -121,7 +121,8 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
           "tr" => %w(style)
         },
         protocols: {
-          "a" => { "href" => ["http", "https", :relative] }
+          "a" => { "href" => ["http", "https", :relative] },
+          "img" => { "src" => ["data", "http", "https", :relative] }
         },
         css: {
           properties: %w(background-color border-bottom-width border-left-width border-right-width border-top-width
@@ -233,8 +234,10 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
     end
 
     def fix_inline_img(node)
-      # TODO: test if it's working fine with all inline images
-      node["src"] = node["src"].gsub!(/%(20|0A)/, "") if node["src"].to_s.start_with?("data:")
+      return unless node["src"].to_s.start_with?("data:")
+
+      # `gsub!` returns nil when nothing matches — guard against wiping a clean src.
+      node["src"] = node["src"].gsub(/%(20|0A)/, "")
     end
 
     def fix_googlechart_img(node)

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -336,16 +336,13 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
       css = ":not(.u-ld-not-image-wrap) > img:not([src*=googleapis]):not(.o-ld-icon):not(.o-ld-latex)"
       nodes.css(css).each do |img|
         img = img.parent.replace(img) if %w(span p).include?(img.parent.name)
+        # Use a <div> wrapper (not a <table>) so Drive's HTML→Gdoc import
+        # doesn't add a border around the image. Matches the PDF wrapping
+        # in #post_processing_images.
         img.replace(%(
-          <table class='o-simple-table o-ld-image-wrap--math'>
-            <tr>
-              <td class="o-ld-image-wrap__img u-gdoc-margin-vertical--small u-gdoc-padding-vertical--small">
-                <div class="u-text--centered">
-                  #{img}
-                </div>
-              </td>
-            </tr>
-          </table>
+          <div class="o-ld-image-wrap--math u-text--centered u-gdoc-margin-vertical--small u-gdoc-padding-vertical--small">
+            #{img}
+          </div>
           <p class="do-not-strip"></p>
         ))
       end

--- a/app/services/section_resource_upsert_service.rb
+++ b/app/services/section_resource_upsert_service.rb
@@ -35,12 +35,12 @@ class SectionResourceUpsertService
 
   def context_metadata
     {
-      description: description_summary,
-      grade: metadata[:grade].to_s,
-      section: metadata[:section_number].to_s,
-      subject: metadata[:subject],
-      title:,
-      unit: metadata[:unit_id].to_s
+      "description" => description_summary,
+      "grade" => metadata[:grade].to_s,
+      "section-number" => metadata[:section_number].to_s,
+      "subject" => metadata[:subject],
+      "title" => title,
+      "unit-id" => metadata[:unit_id].to_s
     }
   end
 

--- a/app/services/unit_resource_upsert_service.rb
+++ b/app/services/unit_resource_upsert_service.rb
@@ -34,11 +34,11 @@ class UnitResourceUpsertService
 
   def context_metadata
     {
-      description: description_summary,
-      grade: metadata[:grade],
-      subject: metadata[:subject],
-      title:,
-      unit: short_title
+      "description" => description_summary,
+      "grade" => metadata[:grade],
+      "subject" => metadata[:subject],
+      "title" => title,
+      "unit-id" => short_title
     }
   end
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -14,6 +14,21 @@ class ImageUploader < CarrierWave::Uploader::Base
     "uploads/settings"
   end
 
+  # When stored on S3, return the unsigned public URL so that the URL
+  # persisted to Setting (and later embedded in PDF/Gdoc exports) doesn't
+  # expire. With fog_public = false (required by buckets that have ACLs
+  # disabled), CarrierWave's default url returns a short-lived presigned
+  # URL, which would break image embeds in generated documents.
+  def url(*args)
+    return super unless self.class.storage == CarrierWave::Storage::Fog
+
+    bucket = ENV.fetch("AWS_S3_BUCKET_NAME", nil)
+    return super if bucket.blank? || path.blank?
+
+    region = ENV.fetch("AWS_REGION", "us-east-1")
+    "https://#{bucket}.s3.#{region}.amazonaws.com/#{path}"
+  end
+
   def filename
     ext = original_filename.present? ? File.extname(original_filename) : extension_fallback
     @filename_cache ||= "#{SecureRandom.hex(8)}#{ext}"

--- a/app/views/admin/documents/_header.html.erb
+++ b/app/views/admin/documents/_header.html.erb
@@ -5,7 +5,7 @@
         <div class="o-title u-text--uppercase">
           <span class="o-title__type"><%= document.short_title %></span>
         </div>
-        <h1><%= document.title %></h1>
+        <h1><%= document.lesson_title %></h1>
         <div class="u-txt--teaser o-social-sharing__teaser">
           <%= raw(document.teaser) %>
         </div>

--- a/app/views/admin/settings/show/_text.html.erb
+++ b/app/views/admin/settings/show/_text.html.erb
@@ -1,0 +1,8 @@
+<input
+  type="text"
+  class="form-control"
+  name="<%= setting_key %>"
+  form="<%= form_id %>"
+  value="<%= setting_value %>"
+  placeholder="<%= t("admin.settings.labels.documents.#{setting_key}", default: '') %>"
+>

--- a/app/views/documents/export_gdoc.html.erb
+++ b/app/views/documents/export_gdoc.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title @document.title.html_safe %>
+<% set_page_title @document.lesson_title.html_safe %>
 
 <style >
   <%= raw(@document.css_styles) %>

--- a/app/views/documents/gdoc/_content.html.erb
+++ b/app/views/documents/gdoc/_content.html.erb
@@ -1,5 +1,1 @@
-<% if document.description.present? %>
-  <h1>Lesson Summary</h1>
-  <span class="u-txt--header-teaser"><%= raw document.description %></span>
-<% end %>
 <%= raw document.content_for(:gdoc, options) %>

--- a/app/views/documents/gdoc/_header.html.erb
+++ b/app/views/documents/gdoc/_header.html.erb
@@ -1,12 +1,51 @@
-<p class="title u-txt--title"><span><%= document.lesson_title %></span></p>
-<% if document.teaser.present? %>
-  <p class="subtitle u-txt--header-teaser">
-    <%= raw document.teaser  %>
-  </p>
-<% end %>
+<table class="c-lesson-banner__strip">
+  <tr>
+    <td class="c-lesson-banner__brand" rowspan="2">
+      <% if document.brandmark_url.present? %>
+        <img class="c-lesson-banner__brand-img" src="<%= document.brandmark_url %>" alt="" width="160" height="48">
+      <% end %>
+    </td>
+    <td class="c-lesson-banner__type">
+      <%= document.lesson_type.to_s.titleize %>
+    </td>
+  </tr>
+  <tr>
+    <td class="c-lesson-banner__time">
+      <% if document.estimated_time.present? %>
+        <%= t("lesson.banner.estimated_time_label") %>: <%= document.estimated_time %>
+      <% end %>
+    </td>
+  </tr>
+</table>
+<hr class="c-lesson-banner__divider">
+<h1 class="c-lesson-banner__title"><%= document.lesson_title %></h1>
 <% if document.standards.present? %>
-  <p><strong>STANDARDS: </strong><%= document.standards&.upcase %></p>
+  <p class="c-lesson-banner__standards"><%= document.standards %></p>
 <% end %>
-<div class="o-ld-hr--l1">
-  <hr>
-</div>
+
+<% overview_items = [document.description_past, document.description, document.description_future].reject(&:blank?) %>
+<% if overview_items.any? %>
+  <h2 class="c-lesson-overview__heading"><%= t("lesson.overview.heading") %></h2>
+  <ul class="c-lesson-overview__list">
+    <% overview_items.each do |item| %>
+      <li><%= raw item %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if document.vocabulary.present? %>
+  <p class="c-lesson-vocabulary"><%= t("lesson.vocabulary.label") %>: <%= document.vocabulary %></p>
+<% end %>
+
+<% materials_summary = document.materials_summary %>
+<% if materials_summary.any? %>
+  <h2 class="c-lesson-materials__heading"><%= t("lesson.materials.heading") %></h2>
+  <table class="c-lesson-materials__table">
+    <% materials_summary.each do |label, value| %>
+      <tr>
+        <th class="c-lesson-materials__label"><%= label %></th>
+        <td class="c-lesson-materials__value"><%= raw value %></td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/app/views/documents/gdoc/_header.html.erb
+++ b/app/views/documents/gdoc/_header.html.erb
@@ -1,4 +1,4 @@
-<p class="title u-txt--title"><span><%= document.title %></span></p>
+<p class="title u-txt--title"><span><%= document.lesson_title %></span></p>
 <% if document.teaser.present? %>
   <p class="subtitle u-txt--header-teaser">
     <%= raw document.teaser  %>

--- a/app/views/documents/pdf/_footer.erb
+++ b/app/views/documents/pdf/_footer.erb
@@ -1,24 +1,14 @@
 <!DOCTYPE html>
 <body>
-  <div style="<%= @document.footer_margin_styles %>">
-    <table class="c-pdf-footer c-pdf-footer--material">
+  <div class="c-lesson-footer" style="<%= @document.footer_margin_styles %>">
+    <% if @document.copyright_text.present? %>
+      <p class="c-lesson-footer__copyright"><%= @document.copyright_text %></p>
+    <% end %>
+    <table class="c-lesson-footer__line">
       <tr>
-        <td class="c-pdf-footer__logo u-padding-left--zero">
-          <div class="c-pdf-footer__logo c-pdf-ub-logo">
-          </div>
-        </td>
-        <td class="c-pdf-footer__cc-logo">
-          <div class="c-pdf-footer__cc-logo c-pdf-cc-logo">
-          </div>
-        </td>
-        <td class="u-pdf-txt--m-footer-small">
-          <%= @document.cc_attribution %>
-        </td>
-        <td class="u-pdf-txt--m-footer-small">
-          <%= link_to document_url(@document), document_url(@document), class: 'u-pdf-txt--m-footer-small' %>
-        </td>
-        <td class="c-pdf-footer__page u-pdf-txt--m-footer-page u-padding-right--zero">
-          p. <span class="pageNumber"></span> of <span class="totalPages u-padding-left--tiny"></span>
+        <td class="c-lesson-footer__breadcrumb"><%= @document.footer_breadcrumb %></td>
+        <td class="c-lesson-footer__page">
+          <span class="pageNumber"></span>
         </td>
       </tr>
     </table>

--- a/app/views/documents/pdf/_header.html.erb
+++ b/app/views/documents/pdf/_header.html.erb
@@ -1,11 +1,53 @@
-<div class="c-ld__header--pdf o-page--pdf-ld" style="<%= document.padding_styles %>">
-  <h1 class="u-pdf-txt--ld-h1"><%= document.lesson_title %></h1>
-  <div class="u-txt--teaser">
-    <%= raw document.teaser %>
-  </div>
-  <div class="u-padding-top--large">
-    <% if document.standards.present? %>
-      <p class="u-text--uppercase"><strong>Standards: </strong><%= document.standards %></p>
-    <% end %>
-  </div>
+<div class="c-lesson-banner" style="<%= document.padding_styles %>">
+  <table class="c-lesson-banner__strip">
+    <tr>
+      <td class="c-lesson-banner__brand" rowspan="2">
+        <% if document.brandmark_url.present? %>
+          <img class="c-lesson-banner__brand-img" src="<%= document.brandmark_url %>" alt="" width="160" height="48">
+        <% end %>
+      </td>
+      <td class="c-lesson-banner__type">
+        <%= document.lesson_type.to_s.titleize %>
+      </td>
+    </tr>
+    <tr>
+      <td class="c-lesson-banner__time">
+        <% if document.estimated_time.present? %>
+          <%= t("lesson.banner.estimated_time_label") %>: <%= document.estimated_time %>
+        <% end %>
+      </td>
+    </tr>
+  </table>
+  <hr class="c-lesson-banner__divider">
+  <h1 class="c-lesson-banner__title"><%= document.lesson_title %></h1>
+  <% if document.standards.present? %>
+    <p class="c-lesson-banner__standards"><%= document.standards %></p>
+  <% end %>
+
+  <% overview_items = [document.description_past, document.description, document.description_future].reject(&:blank?) %>
+  <% if overview_items.any? %>
+    <h2 class="c-lesson-overview__heading"><%= t("lesson.overview.heading") %></h2>
+    <ul class="c-lesson-overview__list">
+      <% overview_items.each do |item| %>
+        <li><%= raw item %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if document.vocabulary.present? %>
+    <p class="c-lesson-vocabulary"><%= t("lesson.vocabulary.label") %>: <%= document.vocabulary %></p>
+  <% end %>
+
+  <% materials_summary = document.materials_summary %>
+  <% if materials_summary.any? %>
+    <h2 class="c-lesson-materials__heading"><%= t("lesson.materials.heading") %></h2>
+    <table class="c-lesson-materials__table">
+      <% materials_summary.each do |label, value| %>
+        <tr>
+          <th class="c-lesson-materials__label"><%= label %></th>
+          <td class="c-lesson-materials__value"><%= raw value %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
 </div>

--- a/app/views/documents/pdf/_header.html.erb
+++ b/app/views/documents/pdf/_header.html.erb
@@ -1,5 +1,5 @@
 <div class="c-ld__header--pdf o-page--pdf-ld" style="<%= document.padding_styles %>">
-  <h1 class="u-pdf-txt--ld-h1"><%= document.title %></h1>
+  <h1 class="u-pdf-txt--ld-h1"><%= document.lesson_title %></h1>
   <div class="u-txt--teaser">
     <%= raw document.teaser %>
   </div>

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -13,7 +13,10 @@ CarrierWave.configure do |config|
       region: ENV.fetch("AWS_REGION", nil)
     }
     config.fog_directory = ENV.fetch("AWS_S3_BUCKET_NAME", nil)
-    config.fog_public = true
+    # Bucket has "Bucket owner enforced" ownership — ACLs are disabled.
+    # Sending x-amz-acl on upload would 400. Public read is granted via
+    # bucket policy; ImageUploader#url returns the unsigned public URL.
+    config.fog_public = false
     config.storage = :fog
   end
 

--- a/config/initializers/lcms_constants.rb
+++ b/config/initializers/lcms_constants.rb
@@ -44,6 +44,10 @@ SETTINGS = {
     header_dropdown_bg_color: :color,
     header_active_item_color: :color,
     header_logo: :image
+  },
+  documents: {
+    brandmark: :image,
+    copyright_text: :text
   }
 }.freeze
 
@@ -54,5 +58,9 @@ SETTINGS_DEFAULTS = {
     header_dropdown_bg_color: "#ffffff",
     header_active_item_color: "#0d6efd",
     header_logo: nil
+  },
+  documents: {
+    brandmark: nil,
+    copyright_text: ""
   }
 }.freeze

--- a/config/initializers/lcms_constants.rb
+++ b/config/initializers/lcms_constants.rb
@@ -26,10 +26,14 @@ MATERIAL_TYPES = {
 }.freeze
 
 SUBJECTS = {
-  math: "Mathematics"
+  ela: "English Language Arts",
+  math: "Mathematics",
+  science: "Science"
 }.with_indifferent_access.freeze
 SUBJECTS_SHORT = {
-  math: "MATH"
+  ela: "ELA",
+  math: "MATH",
+  science: "SCI"
 }.with_indifferent_access.freeze
 SUBJECT_DEFAULT = "math"
 

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -309,8 +309,10 @@ en:
       invalid_group: Invalid settings group.
       groups:
         appearance: Appearance
+        documents: Documents
       descriptions:
         appearance: Customize the appearance of the admin panel interface.
+        documents: Defaults applied to document and material exports (PDF and Google Doc).
       labels:
         appearance:
           header_bg_color: Header Background Color
@@ -318,6 +320,9 @@ en:
           header_dropdown_bg_color: Header Dropdown Background Color
           header_active_item_color: Header Active Item Color
           header_logo: Header Logo
+        documents:
+          brandmark: Brandmark
+          copyright_text: Copyright Text (e.g., "© Company Name, Spring 2026")
       index:
         key: Key
         value: Value

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,15 @@ en:
     "application/msword": doc
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": openoffice document
     "application/vnd.ms-powerpoint": powerpoint
+  lesson:
+    banner:
+      estimated_time_label: "Estimated Time"
+    materials:
+      heading: "Materials"
+    overview:
+      heading: "Overview"
+    vocabulary:
+      label: "Vocabulary"
   grades:
     ela:
       grade_9: Grade 9

--- a/docs/core/lesson-metadata-specs.md
+++ b/docs/core/lesson-metadata-specs.md
@@ -9,10 +9,12 @@
 | lesson-title-Spanish | text; can be blank |
 | lesson-label | Options: required, optional; can be blank |
 | lesson-type | text Options: |
+| estimated-time | text; free-form duration shown in the lesson banner (e.g., "2 Class Periods", "45 minutes"); can be blank |
 | standards | unique alphanumeric codes; comma separated list (e.g., MS-ESS2-4, MS-ESS2-5); codes will connect to spreadsheet with standards language for rendering |
 | description | text that describes the lesson: “In this lesson, we…” |
 | description-past | text that describes the lesson in past tense language; “In the previous lesson, we…”; will be blank for the last lesson of a unit |
 | description-future | text that describes the lesson in future tense language; “In the next lesson, we will…”; will be blank for Lesson 1 |
+| vocabulary | text, comma separated list; lesson-level vocabulary shown in the lesson banner (e.g., "word 1, word 2, word 3"); can be blank. Distinct from activity-metadata `vocabulary`. |
 | learning-targets | text  |
 | lms-enabled | Yes or No |
 | lms-summary | text; blank if not LMS enabled |

--- a/docs/core/styling-defaults-needs-clarification.md
+++ b/docs/core/styling-defaults-needs-clarification.md
@@ -1,0 +1,501 @@
+# LCMS Core Styling Defaults — Needs Clarification
+
+Working notes for the "LCMS Core Styling Defaults" initiative. The source spec
+("LCMS Core Styling Defaults" — Google Doc) is mostly clear at the typography
+and page-layout level. This file tracks open questions, decisions already made,
+and items that must be answered before the corresponding implementation phase
+can start.
+
+## Scope (working assumption)
+
+This initiative covers the **default Grover/Chromium-rendered** Lesson, Material,
+and Bundle exports (PDF + Google Doc). PrinceXML is **out of scope** here and
+will be delivered as a separate plugin in its own PR/branch.
+
+---
+
+## Resolved decisions
+
+### R1. PrinceXML — out of scope
+PrinceXML support will be implemented in a separate PR and branch. The defaults
+shipped by this initiative target the existing Grover/Chromium pipeline only.
+
+### R2. Lesson document footer — confirmed design
+Footer placement: bottom of page, separated from page content by a horizontal
+rule above the footer block.
+
+Footer contents (two rows under the divider line, left-aligned with page number
+right-aligned on the second row):
+
+- Row 1: `© <Company Name>, <Season Year>` — regular weight, small (~9–10 pt).
+  - Example: `© Company Name, Spring 2026`.
+- Row 2 (bold):
+  - Left: `<Grade>/Course • <Title of Unit> • Lesson <N>`
+  - Right: `<page number>`
+
+Open follow-ups for the footer (deferred to Q-related items below):
+- Source of `Company Name` and `Season Year` — config? unit/lesson metadata?
+- Whether the same footer pattern applies to **Materials** and **Bundles**, or
+  if those get their own designs (see Q2 below).
+
+### R3. Phase-1 SCSS uses `!important` as a temporary hammer
+The first SCSS pass in `app/assets/stylesheets/pdf.scss` uses `!important` on
+font-family, font-size, color, and line-height for body/paragraph/span/li/td/th
+and on heading rules. Reason: imported Google-Doc HTML carries inline
+`style="font-family: ...; font-size: ...; color: ..."` on every element, and
+inline styles beat any class selector. Without `!important`, our defaults have
+no effect.
+
+This is consistent with the spec's "we will always overwrite color and size to
+the preset body style" requirement. However, it **also** force-overrides the
+per-element allowlist preservation (an author using Arial — which is on the
+allowlist — will still be rendered in Lexend). That trade-off is removed once
+the source-doc CSS normalization pass (Q6) ships and strips the inline style
+attributes per-element; at that point the `!important` modifiers can be
+removed.
+
+Also delivered in this slice: Lexend loaded via Google Fonts `@import` (per
+user choice on Q5 — answered for this phase only; full Q5 stays open).
+
+### R4. Google Doc export defaults — parallel stylesheet shipped
+Before this slice, `app/views/layouts/gdoc.html.erb` referenced `gdoc.css`
+via `inlined_asset('gdoc.css')` but **no such file existed and the build
+chain didn't compile one** — Gdoc exports shipped with zero LCMS-applied
+styling. This slice adds:
+
+- `app/assets/stylesheets/gdoc.scss` with the same design tokens as
+  `pdf.scss` (Lexend body, H1–H6, image caption, material tag, italic).
+- A new compile entry and `build:css:prefix:gdoc` step in `package.json`.
+
+Key deviations from `pdf.scss`:
+
+- **No Google Fonts `@import url(...)`** — Google Drive's HTML→Gdoc import
+  doesn't reliably honor it. Lexend is recognized as a native Google Fonts
+  family in Google Docs, so naming it in `font-family` is enough.
+- **No `@page` rule** — Google Docs ignores page-setup from imported HTML.
+- **`o-ld-image__caption`** (used by the Gdoc image template) is targeted in
+  addition to `figcaption`.
+
+Known caveat (tracked as Q-Gdoc-inline below): Google Docs' HTML import
+honors **tag selectors** reliably but is inconsistent with **class
+selectors**. So `.o-ld-material`, `.o-ld-image__caption`, etc. may not
+survive into the rendered Gdoc. For class-driven styling we'd need to
+inline `style="..."` directly in the `lib/doc_template/templates/gdoc/*`
+renderers.
+
+### Q-Gdoc-inline. Inline styles for class-driven Gdoc rules
+Google Docs' HTML import doesn't reliably apply class selectors. Decide:
+
+- (a) Accept that class-based rules (material tag italic, image caption
+  formatting, etc.) may not appear in the Gdoc until authors manually
+  re-style; rely only on tag-targeted defaults.
+- (b) Update the Gdoc renderers in `lib/doc_template/templates/gdoc/` and
+  `lib/doc_template/tags/material_tag.rb` (and others) to emit inline
+  `style="font-style: italic; ..."` so the styling survives import.
+
+Option (b) is more reliable but adds duplication between the stylesheet
+and the template emitters.
+
+### R5. Source-doc analysis: "Copy of LCMS Core Styling Designs Lesson Portrait"
+Source: Google Doc `1xR70p8EzqKGKvjEImIKgDTKEkCdIrSJWtw7jiqzaKZk`.
+
+**Confirmed by inspection** (all 180 inline `font-family` declarations are
+Lexend; the only colors are `#000000`, `#434343`, and 2 link colors):
+
+| Element | Doc value | Spec value | Match |
+| --- | --- | --- | --- |
+| Body | Lexend 11pt #000 lh 1.15 | same | ✅ |
+| H1 | Lexend 22pt bold #000 padding-bottom 6pt | same | ✅ |
+| H2 | Lexend 18pt bold #000 padding-bottom 6pt | same | ✅ |
+| H3 | Lexend 14pt bold #434343 padding-bottom 4pt | same | ✅ |
+| H4–H6 | not exercised in this doc | (defined in spec) | unverified |
+| Material refs | italic spans | "italicized" | ✅ |
+| Highlighting | none | default-off | ✅ |
+
+The H1–H3 numbers in `pdf.scss` / `gdoc.scss` therefore already match the
+intended visual. Remaining work is structural (header banner, standards
+line, tables, vocabulary line), not typographic.
+
+### R6. Slice plan (post-analysis decisions)
+
+Decisions captured from user Q&A on 2026-05-27:
+
+1. **Brandmark scope** → system-wide setting (admin Settings). Single
+   upload, reused for every lesson PDF/Gdoc.
+2. **Estimated-time field** → new `estimated-time` (text) field on
+   lesson-metadata. Author writes free-form (e.g. "2 Class Periods").
+3. **Standards display** → only the **header strip** under H1 changes to a
+   bare comma-separated list. Inline `[standard: ...]` tags inside the
+   body keep their existing dropdown behavior.
+4. **Callout shape** → keep both the existing 3-row `callout_tag` shape
+   (legacy) AND add a new 1-row 2-col variant (matches the design
+   mockup). Authors can use either.
+5. **Materials toggle UI** → remove entirely. PDF/Gdoc/web all render the
+   materials table as a plain table without expand/collapse.
+6. **Vocabulary inline** → new `vocabulary` (comma-separated text) field
+   on lesson-metadata for the lesson-level inline line. Activity-level
+   `vocabulary` field stays as-is for activity context.
+
+**Slices (each a separable PR):**
+
+- **Slice 1 — Lesson header banner.** New Settings setting for brandmark;
+  new `estimated-time` and `vocabulary` fields parsed off lesson-metadata;
+  rewrite `_header.html.erb` (PDF + Gdoc) to emit the
+  brandmark+lesson-type+estimated-time strip → `<hr>` → `<h1>` → bare
+  comma standards. New SCSS for the banner.
+- **Slice 2 — Standards header rendering.** Bare comma list (no
+  "Standards:" prefix, no dropdown). Splits cleanly from slice 1 only if
+  we want to ship the banner first.
+- **Slice 3 — Callout 1-row variant.** Extend `callout_tag.rb` to detect
+  shape and dispatch to either the legacy 3-row parser or the new 1-row
+  parser. New PDF + Gdoc templates for the 1-row form. New SCSS.
+- **Slice 4 — Materials plain table.** Replace `materials.html.erb` with
+  a plain 5-row 2-col table (label / value). Remove the toggle UI and
+  the `o-ld-materials__toggler` JS. New SCSS rules for the table.
+- **Slice 5 — Lesson-level vocabulary line.** Render the "Vocabulary:
+  ..." line from the new lesson-metadata field, between the Overview
+  block and the next H2.
+- **Slice 6 — Overview block.** Render the H2 Overview + 3-bullet list
+  from `description-past` / `description` / `description-future`
+  metadata. Depends on slice 1 (header strip) being in place.
+- **Slice 7 — H4/H5/H6 verification.** Get a second source doc that
+  actually uses these levels; visually verify the spec values render
+  correctly.
+
+**Out of scope for this initiative** (existing R1):
+- PrinceXML renderer (separate plugin/PR).
+- Image alt-text policy (Q4 below).
+- Other spec gaps tracked under Q1, Q3, Q7.
+
+### R10. Slice 9 — Lesson footer (R2 design) implemented
+PDF footer ([app/views/documents/pdf/_footer.erb](app/views/documents/pdf/_footer.erb))
+rewritten to the R2 layout:
+
+```
+© <copyright_text>
+─────────────────────────────────
+<Grade N/Course • Unit Title • Lesson N>          <page#>   (bold)
+```
+
+- **`copyright_text`** is a new free-form `Setting` (Documents group) —
+  authors type the full line, e.g. `© Acme Corp, Spring 2026`.
+- **Breadcrumb** is computed by `DocumentPresenter#footer_breadcrumb`:
+  `Grade {N}/Course • {unit title} • Lesson {N}`. Unit title comes from
+  `document.resource.ancestors.find(&:unit?).title`, falling back to
+  `Unit {unit_id}` if the resource graph isn't populated.
+- **PDF**: a new `pdf_plain.scss` (previously empty) provides Lexend +
+  the footer block styles. Grover renders the footer template via a
+  separate Chromium document, so styles must live there, not in
+  `pdf.scss`.
+- **Gdoc**: `DocumentPresenter#gdoc_footer` still returns the original
+  2-row shape (`{attribution}` placeholder + value). The value now
+  merges `copyright_text` with `cc_attribution` (joined by ` — `) so
+  the publisher copyright shows up in the Gdoc footer; the breadcrumb
+  line does **not** land in Gdocs yet.
+
+  **Why not the expanded 6-row payload?** Initial implementation passed
+  three placeholders (`{attribution}`, `{copyright}`, `{breadcrumb}`).
+  Deployed to staging, this caused `DocumentGdocJob` to hang during
+  Apps Script post-processing — the external Apps Script function
+  expects the original argument arity and chokes on the extra rows,
+  combined with `Retriable.retriable(base_interval: 5, tries: 10)` in
+  `app/services/google/script_service.rb` it appears as a multi-minute
+  job hang. Until the Apps Script template doc in Drive is updated to
+  use new placeholders AND the script can accept the extra args, the
+  Ruby side must keep the 2-row shape.
+
+  **Path to full Gdoc parity**: (1) update the Apps Script function
+  outside this repo to accept additional `[placeholder, value]` pairs
+  variadically and to map `{copyright}` / `{breadcrumb}` into the
+  footer template, (2) update the Drive template doc with the new
+  placeholders, (3) extend `gdoc_footer` again. Until then, treat the
+  Gdoc footer as a PDF-only feature.
+
+A new `_text.html.erb` partial under `app/views/admin/settings/show/`
+backs the new `:text` Settings field type so admins can edit
+`copyright_text` from `/admin/settings`.
+
+### R11. Slice 10 — Lesson Materials summary aggregator
+`DocumentPresenter#materials_summary` walks `Document#activity_metadata`
+(JSONB column populated at import time by
+[lib/lt/lcms/metadata/service.rb:50](lib/lt/lcms/metadata/service.rb#L50))
+and aggregates each activity's material fields into the 5 canonical
+buckets the spec mockup shows:
+
+| Row | Source field |
+| --- | --- |
+| Individual Student Materials | `activity-materials-student` |
+| Pair Materials | `activity-materials-pair` |
+| Small Group Materials | `activity-materials-group` |
+| Class Materials | `activity-materials-class` |
+| Teacher Materials | `activity-metadata-teacher` |
+
+Each row dedupes within its bucket and joins with `, `. Empty rows
+render as **None** (matching the mockup). The whole block is skipped if
+the document has no `activity_metadata` at all (e.g., during early
+import or for material documents).
+
+Rendered above the activities by both `documents/pdf/_header.html.erb`
+and `documents/gdoc/_header.html.erb`, right after the inline
+Vocabulary line. SCSS adds `.c-lesson-materials__*` rules: full-width
+table, 1pt cell borders, 30% left column for labels, body-text for
+values.
+
+**Material tag tokens are resolved** (post staging QA fix): a regex pass
+in `DocumentPresenter#resolve_material_tokens` strips
+`[material: <id>]` brackets and, when the referenced `Material` record
+exists, wraps the identifier in `<a class="o-ld-material">` (italicized
+via SCSS, matching how the inline `MaterialTag` renders). Unknown
+identifiers fall through to plain text without brackets.
+
+### R12. Slice 9/10 staging fixes
+Two issues showed up after the first staging QA pass and were patched:
+
+1. **`DocumentGdocJob` hung at Apps Script post-processing.** The
+   expanded `gdoc_footer` (3 placeholders) confused the external Apps
+   Script function and, with `Retriable.retriable(base_interval: 5,
+   tries: 10)`, the job appeared stuck for minutes. Reverted
+   `gdoc_footer` to the original 2-row shape but merged
+   `copyright_text` into the `{attribution}` value so the publisher
+   copyright still lands in the Gdoc footer. The breadcrumb line
+   remains a PDF-only feature until the Apps Script template doc and
+   function are updated externally.
+
+2. **Empty bordered rectangle below the Materials block in Gdoc.** The
+   new activity template emitted `<hr class="o-ld-activity__divider">`
+   above each activity heading. Google Drive's HTML→Gdoc importer
+   converted that styled `<hr>` into a 1-row full-width bordered
+   table, producing a phantom empty rectangle. Removed the `<hr>` from
+   the **Gdoc** activity template; activities now flow with margin
+   spacing only. The PDF template keeps the `<hr>` (Chromium handles
+   it correctly).
+
+### R9. Slice 8 — Activity rendering refactored to flowing layout
+The legacy `activity.html.erb` (PDF) and `gdoc/activity.html.erb` (Gdoc)
+templates wrapped each `activity-metadata` block in a bordered
+`<table class="o-simple-table cs-bg--math-activity-bg">` with a
+subject-colored bar, an UPPERCASE kicker (`activity-type`), title row,
+and a separate time cell. That table-box design came from the older
+math-curriculum conventions and didn't match the spec mockup.
+
+Slice 8 replaces both templates with a flowing layout:
+
+- `<hr>` divider between activities.
+- `<h3>` heading: `{activity-title} ({time} minutes)` — `Optional:`
+  prefix when `activity-label = optional`.
+- Meta line: `{activity-type} ({student-grouping})` when present
+  (e.g. "Discussion (Whole Class)").
+- Materials line: `Materials: ...` aggregated from
+  `activity-materials` / `-student` / `-pair` / `-group` / `-class`
+  (comma-joined, blanks dropped).
+- Metacognition / Guidance / Standards rendered as plain paragraphs.
+- Body content (`@tmpl[:content]`) passes through unchanged.
+
+SCSS lives under `.o-ld-activity__*` in `pdf.scss` and `gdoc.scss`
+(plain margins; the guidance block gets a thin left border so it still
+reads as a callout-style block without a colored background).
+
+Side effect: this also masks the pre-existing **"type / text"
+bleed-through bug** in the activity-metadata parser. The legacy template
+emitted the unconsumed rows inside its `<table>`; the new template
+doesn't render those raw rows at all because it only reads the parsed
+attributes. The underlying parser bug in
+`lib/doc_template/tables/activity.rb` is still latent and worth fixing
+separately, but it no longer affects rendered output.
+
+**Risk**: any curriculum or plugin that relied on the legacy
+`.o-ld-activity-wrapper > table.cs-bg--math-*` markup or class names
+for additional styling (e.g. dese-lcms) will need to update its styles.
+The data-id / data-tag / anchor / data-optional attributes are
+preserved on the new wrapper div.
+
+### R7. Slice 4 discovery — Materials toggle was dead code, materials section is author-authored
+While implementing slice 4 ("Materials plain table"), inspection revealed:
+
+- The `o-ld-materials__toggler` collapse/expand markup in
+  `lib/doc_template/templates/materials.html.erb` had **no JavaScript or
+  CSS** anywhere in the codebase to make it work.
+- `lib/doc_template/tags/materials_tag.rb#parse` calls
+  `content_until_break(node)` and **discards the result** — the template
+  was never actually rendered. The `TEMPLATE = "materials.html.erb"`
+  constant was unused.
+- The materials_tag spec only asserts that the section between
+  `[materials]` and the next stop tag is **stripped**, with no rendered
+  output verified.
+
+Conclusion: today's `[materials]` tag strips content; the "Materials"
+section shown in the source-doc mockup is **hand-authored HTML in the
+Google Doc** (an H2 heading + a 2-column table the author types). That
+flows through the renderer unchanged.
+
+Slice 4 therefore reduced to dead-code cleanup:
+- Deleted `lib/doc_template/templates/materials.html.erb`.
+- Removed the unused `TEMPLATE` constant from `MaterialsTag`.
+
+### R8. Slice 3 — Callout 1-row variant authoring convention
+The legacy callout shape is preserved verbatim (3 rows: marker → header →
+content, rendered by `lib/doc_template/templates/callout.html.erb`).
+
+The **new 1-row 2-column shape** is detected automatically by row count
+and dispatched to the new inline templates
+(`callout_inline.html.erb` for PDF, `gdoc/callout_inline.html.erb`).
+Layout: icon+label cell on the left, content cell on the right, separated
+by a vertical rule.
+
+Authoring convention for the 1-row shape:
+
+| Col 1 (label)                | Col 2 (content)                 |
+| ---------------------------- | ------------------------------- |
+| `[callout: <subject>]` + the visible icon + label text, each on its own paragraph in the cell | The callout body (HTML preserved) |
+
+The `[callout: <subject>]` marker is stripped from the rendered cell, so
+the visible output is the icon + label only. The subject (e.g. `math`,
+`science`, `ela`) is applied as a CSS modifier class on the wrapper for
+subject-colored borders/icons.
+
+**Implementation**: `CalloutTag#inline_shape?` checks `tr` count;
+`fetch_content` preserves col 1 `inner_html` for the inline shape so the
+icon-above-label paragraphs survive into the rendered output.
+
+If authors prefer not to type the marker into the label cell, the
+shape-detection logic can be moved up (e.g., into the Template's tag
+discovery), but that's outside the scope of slice 3.
+
+### Q-Materials-aggregator. (New) Materials table aggregator
+The spec's Materials section design implies a structured 5-row table
+(Individual / Pair / Small Group / Class / Teacher). Today this requires
+authors to hand-author a `<table>` in the Google Doc. The
+activity-metadata schema already has the source fields:
+`activity-materials-student`, `activity-materials-pair`,
+`activity-materials-group`, `activity-materials-class`, and
+`activity-metadata-teacher`.
+
+**Decision required**: should the LCMS aggregate those activity-level
+fields into a per-lesson Materials table, rendering it automatically? If
+so, this is a new tag/feature (a separate slice from the styling work),
+not part of slice 4.
+
+---
+
+## Open questions
+
+### Q1. H1 vs H2 when bundling individual assets
+The spec itself raises this as open: "How to handle H1 versus H2 when bundling
+individual assets? (e.g., Acknowledgements and materials that get bundled into
+a single document?)"
+
+**Decision required**: when an asset that owns its own H1 is embedded into a
+bundle that also has an H1 (front matter / acknowledgements), do we
+(a) demote the asset's H1 to H2, (b) keep both H1s and rely on TOC structure,
+or (c) something else?
+
+Affects: bundle front-matter implementation, TOC, and any heading-based
+navigation in PDF/Gdoc exports.
+
+### Q2. Header / footer defaults for Materials and Bundles
+The Lesson footer (R2) is confirmed. Still need:
+
+- **Header** for Lesson documents — the spec says "we will provide sensible
+  defaults" but does not define what they are. Provide a design or confirm
+  "no header" as the default.
+- **Material** footer/header — the current code reuses the same footer template
+  as documents. Should Materials match Lesson footer (R2) or have their own
+  design (e.g., different metadata: Unit / Section / Material title)?
+- **Bundle** footer/header — likely needs a different layout because each
+  embedded asset would otherwise need its own footer string. Provide design.
+- **Gdoc constraint**: Google Docs cannot switch header/footer mid-document.
+  What's the policy when a phase or per-asset footer is desired in a Gdoc
+  export? Pick one footer or split into multiple Gdoc files?
+
+### Q3. Bundle front matter, divider pages, blank pages
+The spec links a design doc ("LCMS Core Styling Designs Bundle Front Matter")
+but the text in the spec does not describe the actual layout. Need:
+
+- Bundle front matter layout (cover-page design, fields, branding).
+- Divider page layout (what triggers one, what it contains).
+- "Purposefully blank" page layout (text shown, when inserted — e.g., before
+  duplex section start).
+
+These are needed before the bundle-styling phase can be built.
+
+### Q4. Image alt tags
+Listed under Accessibility in the spec, no concrete requirement. Need:
+
+- Where does the alt text come from? (image `alt` attribute carried through
+  from the source Google Doc, a separate metadata field, or both?)
+- Failure mode when alt text is missing — block export, warn, or silently
+  emit empty `alt=""`?
+- Does this also apply to icons and decorative images, or only content
+  images?
+
+### Q5. Font delivery for Lexend
+The default body font (Lexend) is not a Chromium built-in. Choose one:
+
+- **Self-host**: ship Lexend WOFF2 files in `vendor/` or `node_modules`,
+  reference via `@font-face`. Works offline and with the existing base64
+  asset-embed pipeline.
+- **Google Fonts CDN**: `@import` from `fonts.googleapis.com`. Simpler but
+  needs network at PDF-render time and may not coexist with
+  `ENABLE_BASE64_CACHING`.
+
+Same question applies to the allowlisted alternates (Arial, Nunito, Roboto,
+Tahoma, Verdana) — Arial/Tahoma/Verdana are typically system fonts and may
+not be present in the Chromium PDF environment.
+
+### Q6. Scope of the source-doc CSS normalization pass
+The spec requires that exports **override** color and size from source docs,
+**replace** non-allowlist font families with the body style, and **strip**
+text highlighting by default. Today, `DocTemplate::Template#parse`
+(`lib/doc_template/template.rb:84`) sanitizes the Google-Doc `<style>` block
+and passes it through verbatim via `@document.css_styles`.
+
+**Decision required**: is the normalization pass part of this initiative, or
+is it a separate ticket? If part of this work:
+
+- Implement as a post-sanitization pass over `css_styles` (regex/CSS parser),
+  or as an inline transformation on style attributes in the rendered body?
+- Which approach is acceptable to the team given the existing sanitizer
+  pipeline?
+
+### Q7. Tag styling details — incomplete in spec
+The spec lists the following tags but only Callouts and Images have full
+specifications:
+
+- Material tag — "Normal text, but italicized" (clear)
+- Icons — not specified
+- Callouts — visual example given (clear enough)
+- Page break — not specified (CSS `page-break-before: always`?)
+- Line (horizontal rule) — not specified (weight, color, spacing?)
+- Checkbox (clickable) — not specified (size, behavior in PDF vs Gdoc?)
+- Video (URL) — not specified (link only? preview thumbnail? icon?)
+- Heading — covered by H1–H6 defaults
+- Line break — not specified (different from paragraph spacing?)
+- Images — specified (clear)
+- Answer (teacher version only) — not specified visually (highlighted box?
+  inline italic? different color?)
+- Thumbnail — not specified (size, alignment, caption rules?)
+
+For each unspecified tag: need a visual design or "use sensible default and
+review later" sign-off.
+
+### Q8. Initiative-level scoping
+The spec text mixes engineering work with non-engineering items
+(cost model, IP ownership in the "To Discuss" section). For the engineering
+portion, propose splitting into the following tickets so they can be reviewed
+and shipped independently:
+
+1. Core SCSS defaults (Lexend body, H1–H6, page setup, image caption/credit,
+   wire the dangling BEM classes already referenced in views).
+2. Source-doc CSS normalization (Q6).
+3. Tag styling pass (Q7).
+4. Bundle styling — front matter, dividers, blank pages (Q3).
+5. Heading-collision rule for bundling (Q1).
+6. Image alt-text handling (Q4).
+
+Confirm whether to ship as a single PR or split per above.
+
+### Q9. `config/pdf.yml` `handout` profile
+The spec mandates 0.5" margins as the default. The current `handout` profile
+in `config/pdf.yml` uses 1.25" margins, which contradicts the spec. Is the
+`handout` profile being retired, kept as a customization escape hatch, or
+should it be updated to the new defaults?

--- a/lib/doc_template/objects/lesson.rb
+++ b/lib/doc_template/objects/lesson.rb
@@ -7,6 +7,7 @@ module DocTemplate
       attribute :description, :string, default: ""
       attribute :description_past, :string, default: ""
       attribute :description_future, :string, default: ""
+      attribute :estimated_time, :string, default: ""
       attribute :grade, :integer
       attribute :learning_targets, :string, default: ""
       attribute :lesson, :string, default: ""
@@ -31,6 +32,7 @@ module DocTemplate
       attribute :type, :string, default: "core"
       attribute :unit, :string, default: ""
       attribute :unit_id, :string, default: ""
+      attribute :vocabulary, :string, default: ""
 
       attr_accessor :lesson_prep
 

--- a/lib/doc_template/tables/lms_materials.rb
+++ b/lib/doc_template/tables/lms_materials.rb
@@ -8,8 +8,9 @@ module DocTemplate
 
       # Parses the first lms-materials table found in the fragment.
       # Returns an Array of { "material-id" => ..., "access-type" => ... } hashes.
+      # Accepts both bare ("lms-materials") and bracketed ("[lms-materials]") header forms.
       def parse(fragment, *_args)
-        el = fragment.at_xpath(xpath_meta_headers, XpathFunctions.new)
+        el = fragment.at_xpath(".//table/*/tr[1]/td[1][contains(., '#{self.class::HEADER_LABEL}')]")
         return [] unless el
 
         table = self.class.flatten_table(el.ancestors("table").first)

--- a/lib/doc_template/tags/callout_tag.rb
+++ b/lib/doc_template/tags/callout_tag.rb
@@ -4,19 +4,34 @@ module DocTemplate
   module Tags
     class CalloutTag < TableTag
       TAG_NAME = "callout"
+      # Legacy 3-row shape: tr[1] marker, tr[2] header, tr[3] content.
       TEMPLATES = {
         default: "callout.html.erb",
         gdoc: "gdoc/callout.html.erb"
       }.freeze
+      # New 1-row 2-col shape: col[1] icon+label (with marker), col[2] content.
+      INLINE_TEMPLATES = {
+        default: "callout_inline.html.erb",
+        gdoc: "gdoc/callout_inline.html.erb"
+      }.freeze
 
       def parse_table(table)
-        header, content = fetch_content(table)
+        inline = inline_shape?(table)
+        header, content = fetch_content(table, inline:)
         params = {
           content:,
           header:,
-          subject: @opts[:metadata].subject
+          subject: @opts[:metadata].subject,
+          # Tells the inline template whether the author supplied an
+          # icon/label as authored HTML (1-row 2-col shape) or just a
+          # plain category label (3-row shapes — renderer adds a default
+          # decoration).
+          authored_label: inline
         }
-        new_content = parse_template params, template_name(@opts)
+        # All callouts render with the inline horizontal visual per the
+        # LCMS Core spec, regardless of how the author structured the
+        # source table.
+        new_content = parse_template params, inline_template_name
 
         @opts[:parent_node] = new_content
         parsed_content = parse_nested new_content, @opts
@@ -31,9 +46,53 @@ module DocTemplate
 
       private
 
-      def fetch_content(node)
-        [node.at_xpath(".//tr[2]/td").try(:content) || "",
-         node.at_xpath(".//tr[3]/td").try(:inner_html) || ""]
+      def inline_shape?(node)
+        node.xpath(".//tr").size == 1
+      end
+
+      def fetch_content(node, inline:)
+        if inline
+          cells = node.xpath(".//tr[1]/td")
+          [
+            strip_tag_marker(cells[0]&.inner_html.to_s),
+            cells[1]&.inner_html.to_s
+          ]
+        else
+          # Legacy 3-row shape supports two authoring variants:
+          #   (a) 3-row 1-col: tr[2]/td=header, tr[3]/td=content
+          #   (b) 3-row 2-col labeled: tr[2] = "type" | <subject>,
+          #                            tr[3] = "text" | <body>
+          # Prefer td[2] (value column) when present; fall back to td[1].
+          [
+            value_cell_content(node, 2),
+            value_cell_inner_html(node, 3)
+          ]
+        end
+      end
+
+      def value_cell_content(node, row_index)
+        row = node.at_xpath(".//tr[#{row_index}]")
+        return "" unless row
+
+        value = row.at_xpath("./td[2]").try(:content).to_s.squish
+        value.presence || row.at_xpath("./td[1]").try(:content).to_s
+      end
+
+      def value_cell_inner_html(node, row_index)
+        row = node.at_xpath(".//tr[#{row_index}]")
+        return "" unless row
+
+        value = row.at_xpath("./td[2]").try(:inner_html).to_s
+        value.strip.presence || row.at_xpath("./td[1]").try(:inner_html).to_s
+      end
+
+      def strip_tag_marker(html)
+        html.gsub(/\[\s*#{Regexp.escape(self.class::TAG_NAME)}[^\]]*\]/i, "")
+      end
+
+      def inline_template_name
+        context = @opts.fetch(:context_type, :default).to_s
+        INLINE_TEMPLATES[context.to_sym]
       end
 
       def previous_non_empty(node)

--- a/lib/doc_template/tags/helpers.rb
+++ b/lib/doc_template/tags/helpers.rb
@@ -18,6 +18,25 @@ module DocTemplate
         config = Tags.config[self.class::TAG_NAME.downcase]
         Array.wrap(config["priority_descriptions"])[priority - 1]
       end
+
+      # Replaces `[material: id]` tokens in plain text with the italicized
+      # identifier markup that MaterialTag emits inline. Used in the
+      # activity Materials line so authored tokens render the same as in
+      # the body. Unknown identifiers fall through to bare identifier text.
+      MATERIAL_TOKEN_RE = /\[material:\s*([^\]]+)\]/i
+
+      def resolve_material_tokens(text)
+        text.to_s.gsub(MATERIAL_TOKEN_RE) do
+          identifier = ::Regexp.last_match(1).to_s.strip
+          next identifier if identifier.blank?
+
+          if ::Material.exists?(identifier: identifier.downcase)
+            %(<a class="o-ld-material">#{identifier}</a>)
+          else
+            identifier
+          end
+        end
+      end
     end
   end
 end

--- a/lib/doc_template/tags/material_tag.rb
+++ b/lib/doc_template/tags/material_tag.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DocTemplate
+  module Tags
+    class MaterialTag < BaseTag
+      TAG_NAME = "material"
+
+      def parse(node, opts = {})
+        @opts = opts
+        identifier = opts[:value].to_s.strip.downcase
+        material = ::Material.find_by(identifier: identifier)
+
+        @content =
+          if material
+            %(<a href="/materials/#{material.id}" class="o-ld-material" target="_blank" rel="noopener">) \
+              "#{identifier}</a>"
+          else
+            %(<span class="badge text-bg-danger">Unknown material: #{identifier}</span>)
+          end
+
+        replace_tag node
+        self
+      end
+    end
+  end
+
+  Template.register_tag(Tags::MaterialTag::TAG_NAME, Tags::MaterialTag)
+end

--- a/lib/doc_template/tags/materials_tag.rb
+++ b/lib/doc_template/tags/materials_tag.rb
@@ -4,7 +4,6 @@ module DocTemplate
   module Tags
     class MaterialsTag < BaseTag
       TAG_NAME = "materials"
-      TEMPLATE = "materials.html.erb"
 
       def parse(node, _opts = {})
         # we have to collect all the next siblings until next activity-metadata

--- a/lib/doc_template/templates/activity.html.erb
+++ b/lib/doc_template/templates/activity.html.erb
@@ -1,64 +1,55 @@
-<div class="o-ld-activity-wrapper"
-  data-id="<%= @tmpl[:activity].anchor %>"
+<%
+  activity = @tmpl[:activity]
+  type_label = activity.activity_type.to_s.strip
+  group_label = activity.student_grouping.to_s.strip
+  materials_list = [
+    activity.activity_materials,
+    activity.activity_materials_student,
+    activity.activity_materials_pair,
+    activity.activity_materials_group,
+    activity.activity_materials_class
+  ].compact.map(&:to_s).reject(&:blank?).join(", ")
+%>
+<div class="o-ld-activity"
+  id="<%= activity.anchor %>"
+  data-id="<%= activity.anchor %>"
   data-tag="<%= @tmpl[:placeholder] %>"
-  <%= 'data-optional' if @tmpl[:activity].optional %>>
-  <hr class='o-ld-hr--l2'>
+  <%= "data-optional" if activity.optional %>>
 
-  <% if @tmpl[:activity].alert.present? %>
-      <div class="o-ld-activity__optional text-center">
-        <%= @tmpl[:activity].alert %>
-      </div>
+  <hr class="o-ld-activity__divider">
+
+  <% if activity.alert.present? %>
+    <p class="o-ld-activity__alert"><%= activity.alert %></p>
   <% end %>
 
-  <div id="<%= @tmpl[:activity].anchor %>" class="o-ld-activity c-ld-toc">
-    <div>
-      <div class="u-pdf-nobreak o-ld-activity__title u-text--uppercase cs-txt--math-base u-txt--ld-activity-kicker u-margin-bottom--xs">
-        <%= @tmpl[:activity].activity_type %>
-      </div>
-      <h3 class="o-ld-title">
-        <div class="o-ld-title__title o-ld-title__title--h3">
-          <%= 'Optional: ' if @tmpl[:activity].optional %>
-          <%= @tmpl[:activity].activity_title %>
-          <% if @tmpl[:activity].activity_priority.present? %>
-            <% priority_id = "o-ld-p_#{SecureRandom.hex(4)}" %>
-            <div class="o-ld-icon__wrapper" data-toggle="<%= priority_id %>">
-              <span class="o-ld-icon o-ld-icon--base o-ld-icon--priority<%= @tmpl[:activity].activity_priority %>"></span>
-            </div>
-            <span class="dropdown-pane o-ld-dropdown bottom"
-                  data-dropdown
-                  data-hover="true"
-                  data-hover-delay="0"
-                  data-hover-pane="true"
-                  data-v-offset="8"
-                  id="<%= priority_id %>">
-              <%= @tmpl[:priority_description] %>
-            </span>
-          <% end %>
-        </div>
-        <div class="o-ld-title__time o-ld-title__time--h3"><%= @tmpl[:activity].time.zero? ? '&mdash;' : "#{@tmpl[:activity].time} mins" %></div>
-      </h3>
+  <h3 class="o-ld-activity__heading">
+    <%= "Optional: " if activity.optional %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %>
+  </h3>
 
-      <% if @tmpl[:activity].activity_metacognition.present? %>
-        <div class="o-ld-activity__metacognition u-txt--ld-activity-teaser u-margin-bottom--base">
-          <%= @tmpl[:activity].activity_metacognition %>
-        </div>
-      <% end %>
+  <% if type_label.present? || group_label.present? %>
+    <p class="o-ld-activity__meta">
+      <%= type_label %><% if type_label.present? && group_label.present? %> <% end %><% if group_label.present? %>(<%= group_label %>)<% end %>
+    </p>
+  <% end %>
 
-      <% if @tmpl[:activity].activity_guidance.present? %>
-        <div class="o-ld-activity__guidance">
-          <strong class="o-ld-activity__guidance--title u-text--uppercase cs-txt--math-base u-txt--title-type">Guidance</strong>
-          <%= @tmpl[:activity].activity_guidance %>
-        </div>
-      <% end %>
+  <% if materials_list.present? %>
+    <p class="o-ld-activity__materials">Materials: <%= raw resolve_material_tokens(materials_list) %></p>
+  <% end %>
 
-      <% if @tmpl[:activity].activity_standard.present? %>
-        <p>
-          <strong>Standards: </strong>
-          <span><%= @tmpl[:activity].activity_standard %></span>
-        </p>
-      <% end %>
+  <% if activity.activity_metacognition.present? %>
+    <p class="o-ld-activity__metacognition"><%= raw activity.activity_metacognition %></p>
+  <% end %>
+
+  <% if activity.activity_guidance.present? %>
+    <div class="o-ld-activity__guidance">
+      <p><strong>Guidance:</strong></p>
+      <%= raw activity.activity_guidance %>
     </div>
-  </div>
+  <% end %>
+
+  <% if activity.activity_standard.present? %>
+    <p class="o-ld-activity__standard"><strong>Standards:</strong> <%= activity.activity_standard %></p>
+  <% end %>
 
   <%= @tmpl[:content] %>
 

--- a/lib/doc_template/templates/callout_inline.html.erb
+++ b/lib/doc_template/templates/callout_inline.html.erb
@@ -1,0 +1,17 @@
+<div class="o-ld-callout o-ld-callout--inline o-ld-callout--<%= @tmpl[:subject] %>">
+  <table class="o-ld-callout__layout">
+    <tr>
+      <td class="o-ld-callout__label">
+        <% if @tmpl[:authored_label] %>
+          <%= @tmpl[:header].html_safe %>
+        <% else %>
+          <div class="o-ld-callout__icon">+</div>
+          <div class="o-ld-callout__type"><%= @tmpl[:header].html_safe %></div>
+        <% end %>
+      </td>
+      <td class="o-ld-callout__body">
+        <%= @tmpl[:content].html_safe %>
+      </td>
+    </tr>
+  </table>
+</div>

--- a/lib/doc_template/templates/gdoc/activity.html.erb
+++ b/lib/doc_template/templates/gdoc/activity.html.erb
@@ -1,68 +1,49 @@
-<div class="o-ld-activity-wrapper" data-id="<%= @tmpl[:activity].anchor %>" data-tag="<%= @tmpl[:placeholder] %>">
-  <div class="o-ld-hr--l2">
-    <hr>
-  </div>
+<%
+  activity = @tmpl[:activity]
+  type_label = activity.activity_type.to_s.strip
+  group_label = activity.student_grouping.to_s.strip
+  materials_list = [
+    activity.activity_materials,
+    activity.activity_materials_student,
+    activity.activity_materials_pair,
+    activity.activity_materials_group,
+    activity.activity_materials_class
+  ].compact.map(&:to_s).reject(&:blank?).join(", ")
+%>
+<div class="o-ld-activity" id="<%= activity.anchor %>" data-id="<%= activity.anchor %>" data-tag="<%= @tmpl[:placeholder] %>">
 
-  <% if @tmpl[:activity].alert.present? %>
-      <table class="o-ld-activity__optional text-center o-simple-table">
-        <tr>
-          <td><%= @tmpl[:activity].alert %></td>
-        </tr>
-      </table>
+  <% if activity.alert.present? %>
+    <p class="o-ld-activity__alert"><%= activity.alert %></p>
   <% end %>
 
-  <table id="<%= @tmpl[:activity].anchor %>" class="o-simple-table cs-bg--math-activity-bg %>">
-    <tr>
-      <td class="u-table-wrap--l2 cs-border-top--math">
-        <table class="o-simple-table u-pdf-nobreak u-pdf-nobreak--around">
-          <% if @tmpl[:activity].activity_type.present? %>
-            <tr>
-              <td colspan="2" class="cs-txt--math-base u-txt--title-type">
-                <%= @tmpl[:activity].activity_type.upcase %>
-              </td>
-            </tr>
-          <% end %>
-          <tr>
-            <td class="o-ld-title__title">
-              <h3 class="o-ld-title__title--h3">
-                <%= 'Optional: ' if @tmpl[:activity].optional %>
-                <%= @tmpl[:activity].activity_title %>
-              </h3>
-            </td>
-            <td class="o-ld-title__time o-ld-title__time--h3 u-text--right"><%= @tmpl[:activity].time.zero? ? '&mdash;' : "#{@tmpl[:activity].time} mins" %></td>
-          </tr>
-        </table>
+  <h3 class="o-ld-activity__heading" style="font-family:'Lexend',Arial,sans-serif;font-size:14pt;font-weight:bold;color:#434343;line-height:1.15;margin:0 0 4pt 0;padding:0;">
+    <%= "Optional: " if activity.optional %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %>
+  </h3>
 
-        <% if @tmpl[:activity].activity_metacognition.present? %>
-          <span class="u-txt--ld-activity-teaser">
-            <%= @tmpl[:activity].activity_metacognition %>
-          </span>
-        <% end %>
+  <% if type_label.present? || group_label.present? %>
+    <p class="o-ld-activity__meta">
+      <%= type_label %><% if type_label.present? && group_label.present? %> <% end %><% if group_label.present? %>(<%= group_label %>)<% end %>
+    </p>
+  <% end %>
 
-        <% if @tmpl[:activity].activity_guidance.present? %>
-          <table class="o-simple-table cs-bg--math-activity-guidance-bg">
-            <tr>
-              <td class="u-table-wrap">
-                <p class="cs-txt--math-base u-txt--title-type u-padding-bottom--xs">
-                  <strong>GUIDANCE</strong>
-                </p>
-                <%= @tmpl[:activity].activity_guidance %>
-              </td>
-            </tr>
-          </table>
-          <p class="do-not-strip"></p>
-        <% end %>
+  <% if materials_list.present? %>
+    <p class="o-ld-activity__materials">Materials: <%= raw resolve_material_tokens(materials_list) %></p>
+  <% end %>
 
-        <% if @tmpl[:activity].activity_standard.present? %>
-            <p>
-              <strong>Standard: </strong>
-              <span><%= @tmpl[:activity].activity_standard %></span>
-            </p>
-        <% end %>
+  <% if activity.activity_metacognition.present? %>
+    <p class="o-ld-activity__metacognition"><%= raw activity.activity_metacognition %></p>
+  <% end %>
 
-        <%= @tmpl[:content] %>
+  <% if activity.activity_guidance.present? %>
+    <div class="o-ld-activity__guidance">
+      <p><strong>Guidance:</strong></p>
+      <%= raw activity.activity_guidance %>
+    </div>
+  <% end %>
 
-      </td>
-    </tr>
-  </table>
+  <% if activity.activity_standard.present? %>
+    <p class="o-ld-activity__standard"><strong>Standards:</strong> <%= activity.activity_standard %></p>
+  <% end %>
+
+  <%= @tmpl[:content] %>
 </div>

--- a/lib/doc_template/templates/gdoc/callout_inline.html.erb
+++ b/lib/doc_template/templates/gdoc/callout_inline.html.erb
@@ -1,0 +1,18 @@
+<div class="o-ld-callout o-ld-callout--inline">
+  <table class="o-simple-table o-ld-callout__layout">
+    <tr>
+      <td class="o-ld-callout__label cs-border-left--<%= @tmpl[:subject] %>">
+        <% if @tmpl[:authored_label] %>
+          <%= @tmpl[:header].html_safe %>
+        <% else %>
+          <div class="o-ld-callout__icon">+</div>
+          <div class="o-ld-callout__type"><%= @tmpl[:header].html_safe %></div>
+        <% end %>
+      </td>
+      <td class="o-ld-callout__body o-ld-callout__content--<%= @tmpl[:subject] %>">
+        <%= @tmpl[:content].html_safe %>
+      </td>
+    </tr>
+  </table>
+  <p class="do-not-strip"></p>
+</div>

--- a/lib/doc_template/templates/materials.html.erb
+++ b/lib/doc_template/templates/materials.html.erb
@@ -1,7 +1,0 @@
-<div class="o-ld-materials">
-  <div class="o-ld-materials__content--hidden"><%= @tmpl %></div>
-  <div class="o-ld-materials__toggler">
-    <span class="o-ld-materials__toggler--hide"><strong>Collapse Materials</strong></span>
-    <span class="o-ld-materials__toggler--show"><strong>Expand Materials</strong></span>
-  </div>
-</div>

--- a/lib/exporters/gdoc/base.rb
+++ b/lib/exporters/gdoc/base.rb
@@ -19,12 +19,16 @@ module Exporters
       GOOGLE_API_RATE_RETRIABLE_ERRORS = [Google::Apis::ServerError, Google::Apis::RateLimitError].freeze
       VERSION_RE = /_v\d+$/i
 
-      attr_reader :document, :options
+      attr_reader :document, :id, :options
 
       class << self
         def url_for(file_id)
           "https://drive.google.com/open?id=#{file_id}"
         end
+      end
+
+      def drive_service
+        @drive_service ||= Google::DriveService.build(document, options)
       end
 
       def create_gdoc_folders(folder)
@@ -120,10 +124,6 @@ module Exporters
 
           drive_service.service.delete_file file.id
         end
-      end
-
-      def drive_service
-        @drive_service ||= Google::DriveService.build(document, options)
       end
 
       def gdoc_folder

--- a/lib/exporters/pdf/via_gdoc.rb
+++ b/lib/exporters/pdf/via_gdoc.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Exporters
+  module Pdf
+    # Generates a PDF by first creating a Google Doc (via the Gdoc exporter for the
+    # presenter type) and then asking Drive to export that doc as application/pdf.
+    #
+    # Trades Grover/Chromium rendering for visual parity with the corresponding Gdoc,
+    # at the cost of always creating a Drive file (the doc is post-processed by
+    # Google::ScriptService for header/footer before export).
+    class ViaGdoc
+      GDOC_EXPORTERS = {
+        "MaterialPresenter" => ::Exporters::Gdoc::Material,
+        "DocumentPresenter" => ::Exporters::Gdoc::Document
+      }.freeze
+
+      def initialize(presenter, options = {})
+        @presenter = presenter
+        @options = options
+      end
+
+      def export
+        gdoc = build_gdoc_exporter.export
+        io = StringIO.new.binmode
+        gdoc.drive_service.service.export_file(gdoc.id, "application/pdf", download_dest: io)
+        io.string
+      end
+
+      private
+
+      def build_gdoc_exporter
+        klass = GDOC_EXPORTERS[@presenter.class.name] or
+          raise ArgumentError, "Unsupported presenter for Pdf::ViaGdoc: #{@presenter.class.name}"
+        klass.new(@presenter, @options)
+      end
+    end
+  end
+end

--- a/lib/lt/lcms/metadata/context.rb
+++ b/lib/lt/lcms/metadata/context.rb
@@ -147,49 +147,45 @@ module Lt
         end
 
         def lesson
-          @lesson ||=
-            if (value = context[:lesson].to_s.downcase) =~ RE_NUMBER
-              value.to_i
-            else
-              value
-            end
+          @lesson ||= numerize(context["lesson-number"])
         end
 
         def unit
-          @unit ||=
-            if (value = context[:unit].to_s.downcase) =~ RE_NUMBER
-              value.to_i
-            else
-              value
-            end
+          @unit ||= numerize(context["unit-id"])
         end
 
         def subject
           @subject ||= begin
-            value = context[:subject]&.downcase
-            value if SUBJECTS.include?(value)
+            value = context["subject"]&.downcase
+            if value.blank?
+              nil
+            elsif SUBJECTS.include?(value)
+              value
+            else
+              raise "Unsupported subject #{value.inspect}; allowed: #{SUBJECTS.keys.join(', ')}"
+            end
           end
         end
 
         def teaser
-          context[:teaser]
+          context["teaser"]
         end
 
         def title
-          context[:title].presence || default_title
+          context["title"].presence || default_title
         end
 
         def type
-          context[:type]&.downcase
+          context["type"]&.downcase
         end
 
         def section
-          @section ||=
-            if (value = context[:section].to_s.downcase) =~ RE_NUMBER
-              value.to_i
-            else
-              value
-            end
+          @section ||= numerize(context["section-number"])
+        end
+
+        def numerize(value)
+          value = value.to_s.downcase
+          value =~ RE_NUMBER ? value.to_i : value
         end
 
         def update(resource)
@@ -205,9 +201,13 @@ module Lt
         end
 
         def set_lesson_position(parent, resource)
+          raise "Cannot place lesson without parent resource (insufficient curriculum metadata: #{directory.inspect})" \
+            if parent.nil?
+
+          current_lesson = lesson.to_s[RE_NUM].to_i
           next_lesson = parent.children.detect do |r|
             # first lesson with a bigger lesson num
-            r.metadata["lesson"].to_s[RE_NUM].to_i > context[:lesson].to_s[RE_NUM].to_i
+            r.metadata["lesson"].to_s[RE_NUM].to_i > current_lesson
           end
           next_lesson ? next_lesson.prepend_sibling(resource) : resource.save!
         end

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.js --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets --loader:.js=jsx",
-    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css ./app/assets/stylesheets/pdf.scss:./app/assets/builds/pdf.css ./app/assets/stylesheets/pdf_plain.scss:./app/assets/builds/pdf_plain.css --no-source-map --load-path=node_modules",
+    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css ./app/assets/stylesheets/pdf.scss:./app/assets/builds/pdf.css ./app/assets/stylesheets/pdf_plain.scss:./app/assets/builds/pdf_plain.css ./app/assets/stylesheets/gdoc.scss:./app/assets/builds/gdoc.css --no-source-map --load-path=node_modules",
     "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
     "build:css:prefix:pdf": "postcss ./app/assets/builds/pdf.css --use=autoprefixer --output=./app/assets/builds/pdf.css",
     "build:css:prefix:pdf_plain": "postcss ./app/assets/builds/pdf_plain.css --use=autoprefixer --output=./app/assets/builds/pdf_plain.css",
-    "build:css": "yarn build:css:compile && yarn build:css:prefix && yarn build:css:prefix:pdf && yarn build:css:prefix:pdf_plain",
+    "build:css:prefix:gdoc": "postcss ./app/assets/builds/gdoc.css --use=autoprefixer --output=./app/assets/builds/gdoc.css",
+    "build:css": "yarn build:css:compile && yarn build:css:prefix && yarn build:css:prefix:pdf && yarn build:css:prefix:pdf_plain && yarn build:css:prefix:gdoc",
     "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\""
   },
   "dependencies": {

--- a/spec/fixtures/tables/lms-materials-bracketed.html
+++ b/spec/fixtures/tables/lms-materials-bracketed.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="content-type">
+</head>
+<body>
+  <table>
+    <tbody>
+      <tr>
+        <td colspan="2"><span>[lms-materials]</span></td>
+      </tr>
+      <tr>
+        <td><span>mat-handout-1</span></td>
+        <td><span>individual-submission</span></td>
+      </tr>
+      <tr>
+        <td><span>mat-reference-1</span></td>
+        <td><span>view-only</span></td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>

--- a/spec/lib/doc_template/objects/lesson_spec.rb
+++ b/spec/lib/doc_template/objects/lesson_spec.rb
@@ -16,8 +16,10 @@ describe DocTemplate::Objects::Lesson do
         "lesson-title" => "Exploring Ecosystems",
         "lesson-label" => "required",
         "lesson-type" => "core",
+        "estimated-time" => "2 Class Periods",
         "standards" => "MS-LS2-1, MS-LS2-2",
         "description" => "<p>In this lesson, we explore ecosystems.</p>",
+        "vocabulary" => "ecosystem, biome, habitat",
         "lms-enabled" => "Yes",
         "lms-summary" => "Explore ecosystems"
       }
@@ -31,8 +33,22 @@ describe DocTemplate::Objects::Lesson do
       expect(subject.unit_id).to eq "u1"
       expect(subject.lesson_title).to eq "Exploring Ecosystems"
       expect(subject.lesson_type).to eq "core"
+      expect(subject.estimated_time).to eq "2 Class Periods"
       expect(subject.standards).to eq "MS-LS2-1, MS-LS2-2"
       expect(subject.description).to eq "<p>In this lesson, we explore ecosystems.</p>"
+      expect(subject.vocabulary).to eq "ecosystem, biome, habitat"
+    end
+
+    context "when estimated-time and vocabulary are absent" do
+      before do
+        data.delete("estimated-time")
+        data.delete("vocabulary")
+      end
+
+      it "defaults to blank strings" do
+        expect(subject.estimated_time).to eq ""
+        expect(subject.vocabulary).to eq ""
+      end
     end
 
     context "when lms-enabled is No" do

--- a/spec/lib/doc_template/tables/lms_materials_spec.rb
+++ b/spec/lib/doc_template/tables/lms_materials_spec.rb
@@ -22,6 +22,18 @@ describe DocTemplate::Tables::LmsMaterials do
       end
     end
 
+    context "when the header is bracketed ([lms-materials]) per the lesson spec" do
+      let(:data) { file_fixture("tables/lms-materials-bracketed.html").read }
+
+      it "extracts entries and removes the table" do
+        expect(subject).to eq([
+          { "material-id" => "mat-handout-1", "access-type" => "individual-submission" },
+          { "material-id" => "mat-reference-1", "access-type" => "view-only" }
+        ])
+        expect(fragment.to_html).not_to include("lms-materials")
+      end
+    end
+
     context "when lms-materials table is absent" do
       let(:data) { "<html><body><p>No table here</p></body></html>" }
 

--- a/spec/lib/doc_template/tags/callout_tag_spec.rb
+++ b/spec/lib/doc_template/tags/callout_tag_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DocTemplate::Tags::CalloutTag do
+  let(:metadata) { instance_double(DocTemplate::Objects::Lesson, subject: "math") }
+  let(:opts) { { metadata:, context_type: :default } }
+  let(:tag) { described_class.new }
+  let(:node) do
+    html = Nokogiri::HTML(original_content)
+    html.at_xpath("*//td[contains(., '[#{described_class::TAG_NAME}')]")
+  end
+
+  subject { tag.parse(node, opts).content }
+
+  describe "legacy 3-row 1-col shape (renders with inline visual + default + icon)" do
+    let(:original_content) do
+      <<-HTML
+        <table>
+          <tr><td>[#{described_class::TAG_NAME}: math]</td></tr>
+          <tr><td>Header Text</td></tr>
+          <tr><td>Body <strong>content</strong></td></tr>
+        </table>
+      HTML
+    end
+
+    it "renders the inline horizontal callout layout" do
+      expect(subject).to include("o-ld-callout--inline")
+      expect(subject).to include("o-ld-callout__label")
+      expect(subject).to include("o-ld-callout__body")
+    end
+
+    it "renders the default + icon and the type label" do
+      expect(subject).to include("o-ld-callout__icon")
+      expect(subject).to include("o-ld-callout__type")
+      expect(subject).to include("Header Text")
+    end
+
+    it "preserves the body content HTML" do
+      expect(subject).to include("Body <strong>content</strong>")
+    end
+  end
+
+  describe "3-row 2-col labeled shape (type/text labels in col 1)" do
+    let(:original_content) do
+      <<-HTML
+        <table>
+          <tr><td colspan="2">[#{described_class::TAG_NAME}]</td></tr>
+          <tr><td>type</td><td>ATTENDING TO STUDENT IDEAS</td></tr>
+          <tr><td>text</td><td>If there is time, review and celebrate students' learning.</td></tr>
+        </table>
+      HTML
+    end
+
+    it "renders the value column as the type label, not the label column" do
+      expect(subject).to include("ATTENDING TO STUDENT IDEAS")
+      expect(subject).to include("If there is time, review and celebrate students' learning.")
+      expect(subject).to include("o-ld-callout__type")
+    end
+
+    it "renders with inline visual + default + icon" do
+      expect(subject).to include("o-ld-callout--inline")
+      expect(subject).to include("o-ld-callout__icon")
+    end
+  end
+
+  describe "new 1-row 2-col inline shape" do
+    let(:original_content) do
+      <<-HTML
+        <table>
+          <tr>
+            <td><p>[#{described_class::TAG_NAME}: math]</p><p>&#10133;</p><p>Callout Type</p></td>
+            <td><p>Body content goes here</p></td>
+          </tr>
+        </table>
+      HTML
+    end
+
+    it "renders the inline callout template" do
+      expect(subject).to include("o-ld-callout--inline")
+      expect(subject).to include("o-ld-callout__label")
+      expect(subject).to include("o-ld-callout__body")
+    end
+
+    it "strips the [callout: ...] marker from the label cell" do
+      expect(subject).not_to include("[#{described_class::TAG_NAME}: math]")
+    end
+
+    it "preserves the icon and label HTML in the label cell" do
+      expect(subject).to include("Callout Type")
+      expect(subject).to include("&#10133;").or include("➕")
+    end
+
+    it "preserves the body cell HTML" do
+      expect(subject).to include("Body content goes here")
+    end
+  end
+end

--- a/spec/lib/doc_template/tags/material_tag_spec.rb
+++ b/spec/lib/doc_template/tags/material_tag_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DocTemplate::Tags::MaterialTag do
+  let(:tag) { described_class.new }
+  let(:fragment) { Nokogiri::HTML.fragment(html) }
+  let(:node) { fragment.at_xpath(".//p") }
+
+  describe "#parse" do
+    let(:html) { %(<p>provide copies of <span>[material: #{identifier}]</span>.</p>) }
+    let(:identifier) { "10s.10.gg.l7.worksheet01" }
+
+    subject(:parsed) { tag.parse(node, value: identifier) }
+
+    context "when the material exists" do
+      let!(:material) { create(:material, identifier: identifier) }
+
+      it "renders an anchor pointing to the material" do
+        expect(parsed.content).to include(%(href="/materials/#{material.id}"))
+        expect(parsed.content).to include(identifier)
+      end
+
+      it "leaves no errors" do
+        expect(parsed.errors).to be_empty
+      end
+    end
+
+    context "when the material does not exist" do
+      it "renders a red badge with the identifier" do
+        expect(parsed.content).to include("badge text-bg-danger")
+        expect(parsed.content).to include("Unknown material: #{identifier}")
+      end
+
+      it "does not report an error" do
+        expect(parsed.errors).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/lt/lcms/metadata/context_spec.rb
+++ b/spec/lib/lt/lcms/metadata/context_spec.rb
@@ -47,4 +47,57 @@ describe Lt::Lcms::Metadata::Context do
 
     include_examples "reordable", "section"
   end
+
+  describe "lesson-metadata key accessors" do
+    let(:metadata) do
+      {
+        "subject" => "math",
+        "grade" => "10",
+        "unit-id" => "GG",
+        "section-number" => "",
+        "lesson-number" => "7"
+      }
+    end
+    let(:instance) { described_class.new(metadata) }
+
+    it "reads unit from unit-id" do
+      expect(instance.send(:unit)).to eq("gg")
+    end
+
+    it "reads lesson from lesson-number" do
+      expect(instance.send(:lesson)).to eq(7)
+    end
+
+    it "returns blank section when section-number is empty" do
+      expect(instance.send(:section)).to eq("")
+    end
+
+    it "builds directory from new keys" do
+      expect(instance.directory).to eq(["math", "10", "gg", 7])
+    end
+
+    context "with numeric unit-id" do
+      before { metadata["unit-id"] = "2" }
+
+      it "coerces unit to integer" do
+        expect(instance.send(:unit)).to eq(2)
+      end
+    end
+
+    context "with unsupported subject" do
+      before { metadata["subject"] = "history" }
+
+      it "raises a descriptive error" do
+        expect { instance.send(:subject) }.to raise_error(/Unsupported subject "history"/)
+      end
+    end
+
+    context "with blank subject" do
+      before { metadata["subject"] = "" }
+
+      it "returns nil without raising" do
+        expect(instance.send(:subject)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -59,4 +59,115 @@ describe DocumentPresenter do
       expect(header.all? { |row| row.is_a?(Array) }).to be true
     end
   end
+
+  describe "#gdoc_footer" do
+    context "with copyright_text Setting" do
+      before { Setting.set(:documents, "copyright_text" => "© Acme, Spring 2026") }
+
+      it "merges copyright_text into the attribution placeholder" do
+        result = presenter.gdoc_footer
+
+        expect(result).to eq([
+          ["{attribution}"],
+          ["© Acme, Spring 2026"]
+        ])
+      end
+    end
+
+    context "without any copyright info" do
+      it "falls back to the placeholder default" do
+        result = presenter.gdoc_footer
+
+        expect(result).to eq([
+          ["{attribution}"],
+          ["Copyright attribution here"]
+        ])
+      end
+    end
+  end
+
+  describe "#footer_breadcrumb" do
+    it "joins grade label, unit title, and lesson label with bullets" do
+      result = presenter.footer_breadcrumb
+
+      expect(result).to eq("Grade 3/Course • Unit 1 • Lesson 5")
+    end
+
+    context "when all parts are missing" do
+      let(:document) { Document.new(metadata: { "subject" => "math" }) }
+
+      it "returns nil" do
+        expect(presenter.footer_breadcrumb).to be_nil
+      end
+    end
+  end
+
+  describe "#materials_summary" do
+    context "when document has no activity metadata" do
+      it "returns an empty hash" do
+        expect(presenter.materials_summary).to eq({})
+      end
+    end
+
+    context "when document has activity metadata" do
+      let(:document) do
+        create(:document,
+               metadata: {
+                 "lesson_title" => "Sample",
+                 "grade" => "6",
+                 "subject" => "science"
+               },
+               activity_metadata: [
+                 { "activity-materials-student" => "Notebook, [material: worksheet01]",
+                   "activity-materials-class" => "Lesson 7 Slides" },
+                 { "activity-materials-student" => "[material: worksheet02]",
+                   "activity-materials-pair" => "Calculator" }
+               ])
+      end
+
+      it "aggregates and dedupes materials across activities" do
+        summary = presenter.materials_summary
+
+        expect(summary["Individual Student Materials"])
+          .to eq("Notebook, worksheet01, worksheet02")
+        expect(summary["Pair Materials"]).to eq("Calculator")
+        expect(summary["Class Materials"]).to eq("Lesson 7 Slides")
+      end
+
+      it "resolves [material: id] tokens to italic identifier links when the material exists" do
+        create(:material, identifier: "worksheet01")
+
+        summary = presenter.materials_summary
+
+        expect(summary["Individual Student Materials"])
+          .to include('<a class="o-ld-material">worksheet01</a>')
+        expect(summary["Individual Student Materials"])
+          .not_to include("[material:")
+      end
+
+      it "strips brackets for unknown material tokens" do
+        summary = presenter.materials_summary
+
+        expect(summary["Individual Student Materials"]).to include("worksheet01")
+        expect(summary["Individual Student Materials"]).not_to include("[material:")
+      end
+
+      it "renders empty rows as 'None'" do
+        summary = presenter.materials_summary
+
+        expect(summary["Small Group Materials"]).to eq("None")
+        expect(summary["Teacher Materials"]).to eq("None")
+      end
+
+      it "always includes all five canonical rows" do
+        expect(presenter.materials_summary.keys).to eq([
+          "Individual Student Materials",
+          "Pair Materials",
+          "Small Group Materials",
+          "Class Materials",
+          "Teacher Materials"
+        ])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Rebuilds the default GDoc/PDF styling for lessons and materials per the Lesson
specification, and refactors the related rendering path (callouts, presenter,
image handling).

## Changes

**Styles**
- Rebuild default `gdoc`, `pdf`, and `pdf_plain` SCSS
- Embed activity and document styles inline via `asset_helper` in the PDF jobs
- Update GDoc/PDF header & footer partials and activity templates

**Rendering refactor**
- Refactor callout tag and inline callout templates (gdoc/pdf)
- Update `DocumentPresenter` (+ specs)
- Refactor the image rendering wrapper and brandmark image uploader
- Adjust `HtmlSanitizer`, CarrierWave config, and LCMS constants
