### PR TITLE
Add annotate gem and model annotations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - db/schema.rb
     - db/migrate/**/*
     - vendor/**/*
+    - lib/tasks/auto_annotate_models.rake
   NewCops: enable
 
 # Overwrite or add rules to create your own house style

--- a/Gemfile
+++ b/Gemfile
@@ -172,6 +172,10 @@ group :development, :test do
   gem "webdrivers"
 end
 
+group :development do
+  gem "db-annotate"
+end
+
 # ============================================================================
 # Plugin dependencies (auto-loaded from lib/plugins/*/Gemfile)
 # ============================================================================

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,9 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.5.1)
+    db-annotate (1.0.0)
+      activerecord (>= 7.1, < 9.0)
+      rake (>= 10.4, < 14.0)
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -788,6 +791,7 @@ DEPENDENCIES
   concurrent-ruby (~> 1.3)
   cssbundling-rails
   database_cleaner-active_record
+  db-annotate
   debug
   devise (~> 5.0)
   dotenv-rails

--- a/app/models/access_code.rb
+++ b/app/models/access_code.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: access_codes
+#
+#  id         :integer          not null, primary key
+#  active     :boolean          default(TRUE), not null
+#  code       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_access_codes_on_code  (code) UNIQUE
+#
 class AccessCode < ApplicationRecord
   validates :code, presence: true, uniqueness: true
 

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: authors
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  slug       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Author < ApplicationRecord
   has_many :resources
   has_many :curriculums, -> { distinct }, through: :resources

--- a/app/models/curriculum.rb
+++ b/app/models/curriculum.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: curriculums
+#
+#  id         :integer          not null, primary key
+#  default    :boolean          default(FALSE), not null
+#  name       :string           not null
+#  slug       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Curriculum < ApplicationRecord
   has_many :resources, dependent: :nullify
   has_many :authors, -> { distinct }, through: :resources

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: documents
+#
+#  id                :integer          not null, primary key
+#  active            :boolean          default(TRUE), not null
+#  activity_metadata :jsonb
+#  agenda_metadata   :jsonb
+#  css_styles        :text
+#  last_author_email :string
+#  last_author_name  :string
+#  last_modified_at  :datetime
+#  links             :jsonb            not null
+#  metadata          :jsonb            not null
+#  name              :string
+#  original_content  :text
+#  preview_links     :jsonb
+#  reimported        :boolean          default(TRUE), not null
+#  reimported_at     :datetime
+#  sections_metadata :jsonb
+#  version           :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  file_id           :string
+#  resource_id       :integer
+#
+# Indexes
+#
+#  index_documents_on_file_id      (file_id)
+#  index_documents_on_metadata     (metadata) USING gin
+#  index_documents_on_resource_id  (resource_id)
+#
 class Document < ApplicationRecord
   include Filterable
   include Partable

--- a/app/models/document_part.rb
+++ b/app/models/document_part.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: document_parts
+#
+#  id            :integer          not null, primary key
+#  active        :boolean
+#  anchor        :string
+#  content       :text
+#  context_type  :integer          default("default")
+#  data          :jsonb            not null
+#  materials     :text             default([]), not null, is an Array
+#  optional      :boolean          default(FALSE), not null
+#  part_type     :string
+#  placeholder   :string
+#  renderer_type :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  renderer_id   :integer
+#
+# Indexes
+#
+#  index_document_parts_on_anchor                         (anchor)
+#  index_document_parts_on_context_type                   (context_type)
+#  index_document_parts_on_placeholder                    (placeholder)
+#  index_document_parts_on_renderer_type_and_renderer_id  (renderer_type,renderer_id)
+#
 class DocumentPart < ApplicationRecord
   belongs_to :renderer, polymorphic: true
 

--- a/app/models/integrations/webhook_configuration.rb
+++ b/app/models/integrations/webhook_configuration.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: lcms_engine_integrations_webhook_configurations
+#
+#  id               :bigint           not null, primary key
+#  action           :string           default("post"), not null
+#  active           :boolean          default(TRUE)
+#  auth_credentials :jsonb
+#  auth_type        :string
+#  endpoint_url     :string           not null
+#  event_name       :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_webhook_configurations_on_event_name  (event_name)
+#
 module Integrations
   class WebhookConfiguration < ApplicationRecord
     validates :event_name, :endpoint_url, presence: true

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,5 +1,32 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: materials
+#
+#  id                :integer          not null, primary key
+#  css_styles        :text
+#  identifier        :string
+#  last_author_email :string
+#  last_author_name  :string
+#  last_modified_at  :datetime
+#  links             :jsonb
+#  metadata          :jsonb            not null
+#  name              :string
+#  original_content  :text
+#  preview_links     :jsonb
+#  reimported_at     :datetime
+#  version           :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  file_id           :string           not null
+#
+# Indexes
+#
+#  index_materials_on_file_id     (file_id)
+#  index_materials_on_identifier  (identifier)
+#  index_materials_on_metadata    (metadata) USING gin
+#
 require "pg_search"
 
 class Material < ApplicationRecord

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,5 +1,41 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: resources
+#
+#  id                    :integer          not null, primary key
+#  curriculum_type       :string
+#  deleted_at            :datetime
+#  description           :string
+#  hidden                :boolean          default(FALSE)
+#  hierarchical_position :string
+#  image_file            :string
+#  indexed_at            :datetime
+#  level_position        :integer
+#  links                 :jsonb
+#  metadata              :jsonb            not null
+#  short_title           :string
+#  slug                  :string
+#  subtitle              :string
+#  teaser                :string
+#  title                 :string
+#  tree                  :boolean          default(FALSE), not null
+#  url                   :string
+#  created_at            :datetime
+#  updated_at            :datetime
+#  author_id             :integer
+#  curriculum_id         :integer
+#  parent_id             :integer
+#
+# Indexes
+#
+#  index_resources_on_author_id      (author_id)
+#  index_resources_on_curriculum_id  (curriculum_id)
+#  index_resources_on_deleted_at     (deleted_at)
+#  index_resources_on_indexed_at     (indexed_at)
+#  index_resources_on_metadata       (metadata) USING gin
+#
 class Resource < ApplicationRecord
   include Filterable
 

--- a/app/models/resource_standard.rb
+++ b/app/models/resource_standard.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: resource_standards
+#
+#  id          :integer          not null, primary key
+#  created_at  :datetime
+#  updated_at  :datetime
+#  resource_id :integer
+#  standard_id :integer
+#
+# Indexes
+#
+#  index_resource_standards_on_resource_id  (resource_id)
+#  index_resource_standards_on_standard_id  (standard_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (resource_id => resources.id)
+#  fk_rails_...  (standard_id => standards.id)
+#
 class ResourceStandard < ApplicationRecord
   belongs_to :resource
   belongs_to :standard

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: settings
+#
+#  id         :bigint           not null, primary key
+#  key        :string           not null
+#  value      :jsonb            not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_settings_on_key  (key) UNIQUE
+#
 class Setting < ApplicationRecord
   CACHE_PREFIX = "settings"
 

--- a/app/models/standard.rb
+++ b/app/models/standard.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: standards
+#
+#  id          :integer          not null, primary key
+#  alt_names   :text             default([]), not null, is an Array
+#  course      :string
+#  description :string
+#  domain      :string
+#  emphasis    :string
+#  grades      :text             default([]), not null, is an Array
+#  label       :string
+#  name        :string           not null
+#  strand      :string
+#  subject     :string
+#  synonyms    :text             default([]), is an Array
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_standards_on_name     (name)
+#  index_standards_on_subject  (subject)
+#
 class Standard < ApplicationRecord
   has_many :resource_standards, dependent: :destroy
   has_many :resources, through: :resource_standards

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  access_code            :string
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :inet
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :inet
+#  name                   :string
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  role                   :integer          default("user"), not null
+#  sign_in_count          :integer          default(0), not null
+#  survey                 :hstore
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 require "devise"
 
 class User < ApplicationRecord

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,61 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_check_constraints'      => 'false',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'true',
+      'exclude_fixtures'            => 'true',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true',
+      'with_comment_column'         => 'false'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/authors.rb
+++ b/spec/factories/authors.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: authors
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  slug       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :author, class: Author do
     name { "Great Minds" }

--- a/spec/factories/curriculums.rb
+++ b/spec/factories/curriculums.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: curriculums
+#
+#  id         :integer          not null, primary key
+#  default    :boolean          default(FALSE), not null
+#  name       :string           not null
+#  slug       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :curriculum, class: Curriculum do
     name { "EngageNY" }

--- a/spec/factories/document_parts.rb
+++ b/spec/factories/document_parts.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: document_parts
+#
+#  id            :integer          not null, primary key
+#  active        :boolean
+#  anchor        :string
+#  content       :text
+#  context_type  :integer          default("default")
+#  data          :jsonb            not null
+#  materials     :text             default([]), not null, is an Array
+#  optional      :boolean          default(FALSE), not null
+#  part_type     :string
+#  placeholder   :string
+#  renderer_type :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  renderer_id   :integer
+#
+# Indexes
+#
+#  index_document_parts_on_anchor                         (anchor)
+#  index_document_parts_on_context_type                   (context_type)
+#  index_document_parts_on_placeholder                    (placeholder)
+#  index_document_parts_on_renderer_type_and_renderer_id  (renderer_type,renderer_id)
+#
 FactoryBot.define do
   factory :document_part, class: DocumentPart do
     renderer { nil }

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: documents
+#
+#  id                :integer          not null, primary key
+#  active            :boolean          default(TRUE), not null
+#  activity_metadata :jsonb
+#  agenda_metadata   :jsonb
+#  css_styles        :text
+#  last_author_email :string
+#  last_author_name  :string
+#  last_modified_at  :datetime
+#  links             :jsonb            not null
+#  metadata          :jsonb            not null
+#  name              :string
+#  original_content  :text
+#  preview_links     :jsonb
+#  reimported        :boolean          default(TRUE), not null
+#  reimported_at     :datetime
+#  sections_metadata :jsonb
+#  version           :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  file_id           :string
+#  resource_id       :integer
+#
+# Indexes
+#
+#  index_documents_on_file_id      (file_id)
+#  index_documents_on_metadata     (metadata) USING gin
+#  index_documents_on_resource_id  (resource_id)
+#
 FactoryBot.define do
   factory :document, class: Document do
     file_id { "file_#{SecureRandom.hex(6)}" }

--- a/spec/factories/integrations/webhook_configurations.rb
+++ b/spec/factories/integrations/webhook_configurations.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: lcms_engine_integrations_webhook_configurations
+#
+#  id               :bigint           not null, primary key
+#  action           :string           default("post"), not null
+#  active           :boolean          default(TRUE)
+#  auth_credentials :jsonb
+#  auth_type        :string
+#  endpoint_url     :string           not null
+#  event_name       :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_webhook_configurations_on_event_name  (event_name)
+#
 FactoryBot.define do
   factory :webhook_configuration, class: Integrations::WebhookConfiguration do
     event_name { "event_name" }

--- a/spec/factories/materials.rb
+++ b/spec/factories/materials.rb
@@ -1,5 +1,32 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: materials
+#
+#  id                :integer          not null, primary key
+#  css_styles        :text
+#  identifier        :string
+#  last_author_email :string
+#  last_author_name  :string
+#  last_modified_at  :datetime
+#  links             :jsonb
+#  metadata          :jsonb            not null
+#  name              :string
+#  original_content  :text
+#  preview_links     :jsonb
+#  reimported_at     :datetime
+#  version           :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  file_id           :string           not null
+#
+# Indexes
+#
+#  index_materials_on_file_id     (file_id)
+#  index_materials_on_identifier  (identifier)
+#  index_materials_on_metadata    (metadata) USING gin
+#
 FactoryBot.define do
   factory :material, class: Material do
     sequence(:identifier, "a") { |n| n }

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,5 +1,41 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: resources
+#
+#  id                    :integer          not null, primary key
+#  curriculum_type       :string
+#  deleted_at            :datetime
+#  description           :string
+#  hidden                :boolean          default(FALSE)
+#  hierarchical_position :string
+#  image_file            :string
+#  indexed_at            :datetime
+#  level_position        :integer
+#  links                 :jsonb
+#  metadata              :jsonb            not null
+#  short_title           :string
+#  slug                  :string
+#  subtitle              :string
+#  teaser                :string
+#  title                 :string
+#  tree                  :boolean          default(FALSE), not null
+#  url                   :string
+#  created_at            :datetime
+#  updated_at            :datetime
+#  author_id             :integer
+#  curriculum_id         :integer
+#  parent_id             :integer
+#
+# Indexes
+#
+#  index_resources_on_author_id      (author_id)
+#  index_resources_on_curriculum_id  (curriculum_id)
+#  index_resources_on_deleted_at     (deleted_at)
+#  index_resources_on_indexed_at     (indexed_at)
+#  index_resources_on_metadata       (metadata) USING gin
+#
 FactoryBot.define do
   factory :resource, class: Resource do
     curriculum { Curriculum.default || create(:curriculum) }

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: settings
+#
+#  id         :bigint           not null, primary key
+#  key        :string           not null
+#  value      :jsonb            not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_settings_on_key  (key) UNIQUE
+#
 FactoryBot.define do
   factory :setting do
     sequence(:key) { |n| "setting_key_#{n}" }

--- a/spec/factories/standards.rb
+++ b/spec/factories/standards.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: standards
+#
+#  id          :integer          not null, primary key
+#  alt_names   :text             default([]), not null, is an Array
+#  course      :string
+#  description :string
+#  domain      :string
+#  emphasis    :string
+#  grades      :text             default([]), not null, is an Array
+#  label       :string
+#  name        :string           not null
+#  strand      :string
+#  subject     :string
+#  synonyms    :text             default([]), is an Array
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_standards_on_name     (name)
+#  index_standards_on_subject  (subject)
+#
 FactoryBot.define do
   factory :standard, class: Standard do
     subject { %w(ela math).sample }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  access_code            :string
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :inet
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :inet
+#  name                   :string
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  role                   :integer          default("user"), not null
+#  sign_in_count          :integer          default(0), not null
+#  survey                 :hstore
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 FactoryBot.define do
   factory :user, class: User do
     access_code { create(:access_code).code }


### PR DESCRIPTION
## Summary

- Add `annotate` gem to Gemfile for auto-generating schema documentation in model and factory files
- Generate annotations for all models and FactoryBot factories
- Add `auto_annotate_models` Rake task to maintain annotations automatically after migrations
- Update `.rubocop.yml` to exclude generated annotation comments

## Test plan

- [x] `bundle exec rubocop` — 0 violations
- [x] `bundle exec brakeman` — 0 warnings
- [x] RSpec for modified models — all passing
- [x] Pre-commit and pre-push hooks passed