### PR TITLE
Display Google Doc source for Unit/Section resources

### DIFF
--- a/app/presenters/concerns/has_gdoc_source.rb
+++ b/app/presenters/concerns/has_gdoc_source.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Adds accessors for the Google Docs source link stored under
+# +links["source"]["gdoc"]+. Intended to be included in presenters whose
+# underlying record exposes a +links+ JSONB attribute with this structure.
+module HasGdocSource
+  extend ActiveSupport::Concern
+
+  # Returns the display name of the Google Docs source.
+  #
+  # @return [String, nil] the source name, or +nil+ when the link is missing
+  def source_name
+    links.dig("source", "gdoc", "name")
+  end
+
+  # Returns the URL of the Google Docs source.
+  #
+  # @return [String, nil] the source URL, or +nil+ when the link is missing
+  def source_url
+    links.dig("source", "gdoc", "url")
+  end
+end

--- a/app/presenters/section_presenter.rb
+++ b/app/presenters/section_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SectionPresenter < BasePresenter
+  include HasGdocSource
+
   def section_number
     metadata["section_number"].presence || metadata["section"]
   end
@@ -11,10 +13,6 @@ class SectionPresenter < BasePresenter
 
   def section_title_spanish
     metadata["section_title_spanish"]
-  end
-
-  def source_url
-    links.dig("source", "gdoc", "url")
   end
 
   def unit_id

--- a/app/presenters/unit_presenter.rb
+++ b/app/presenters/unit_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UnitPresenter < BasePresenter
+  include HasGdocSource
+
   delegate :acknowledgements, :copyright, :course, :description, :license,
            :unit_id, :unit_title_spanish, :unit_topic, :unit_topic_spanish,
            to: :base_metadata
@@ -17,10 +19,6 @@ class UnitPresenter < BasePresenter
 
   def materials
     unit_bundle_interactor.materials
-  end
-
-  def source_url
-    links.dig("source", "gdoc", "url")
   end
 
   def unit_title

--- a/app/views/admin/sections/index.html.erb
+++ b/app/views/admin/sections/index.html.erb
@@ -57,7 +57,9 @@
           <td><%= section.section_title %></td>
           <td>
             <% if section.source_url.present? %>
-              <%= link_to "Source", section.source_url, target: "_blank", rel: "noreferrer" %>
+              <%= link_to section.source_name, section.source_url, target: "_blank", rel: "noopener noreferrer" %>
+            <% else %>
+              N/A
             <% end %>
           </td>
           <td>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -39,7 +39,9 @@
         <th></th>
         <th>ID</th>
         <th>Curriculum</th>
+        <th>Unit ID</th>
         <th>Title</th>
+        <th>Source</th>
         <th>Preview</th>
         <th>Generate</th>
         <th></th>
@@ -51,7 +53,15 @@
           <td><%= check_box_tag "selected_ids[]", unit.id, selected_id?(unit.id), class: "c-selected-ids" %></td>
           <td><%= unit.id %></td>
           <td><%= Breadcrumbs.new(unit).short_title %></td>
+          <td><%= unit.unit_id %></td>
           <td><%= unit.title %></td>
+          <td>
+            <% if unit.source_url.present? %>
+              <%= link_to unit.source_name, unit.source_url, target: "_blank", rel: "noopener noreferrer" %>
+            <% else %>
+              N/A
+            <% end %>
+          </td>
           <td><%= render partial: "admin/units/preview_links", locals: { unit: unit } %></td>
           <td><%= render partial: "admin/units/generate_links", locals: { unit: unit } %></td>
           <td>

--- a/config/initializers/lcms_constants.rb
+++ b/config/initializers/lcms_constants.rb
@@ -26,10 +26,12 @@ MATERIAL_TYPES = {
 }.freeze
 
 SUBJECTS = {
-  math: "Mathematics"
+  math: "Mathematics",
+  science: "Science"
 }.with_indifferent_access.freeze
 SUBJECTS_SHORT = {
-  math: "MATH"
+  math: "MATH",
+  science: "SCI"
 }.with_indifferent_access.freeze
 SUBJECT_DEFAULT = "math"
 

--- a/spec/presenters/concerns/has_gdoc_source_spec.rb
+++ b/spec/presenters/concerns/has_gdoc_source_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HasGdocSource do
+  let(:klass) do
+    Class.new do
+      include HasGdocSource
+
+      attr_reader :links
+
+      def initialize(links)
+        @links = links
+      end
+    end
+  end
+
+  let(:links) do
+    {
+      "source" => {
+        "gdoc" => {
+          "name" => "Lesson 1 Source",
+          "url" => "https://docs.google.com/document/d/abc123"
+        }
+      }
+    }
+  end
+
+  subject(:presenter) { klass.new(links) }
+
+  describe "#source_name" do
+    it "returns the name from the gdoc source link" do
+      expect(presenter.source_name).to eq("Lesson 1 Source")
+    end
+
+    context "when the gdoc source is missing" do
+      let(:links) { { "source" => {} } }
+
+      it "returns nil" do
+        expect(presenter.source_name).to be_nil
+      end
+    end
+
+    context "when links are empty" do
+      let(:links) { {} }
+
+      it "returns nil" do
+        expect(presenter.source_name).to be_nil
+      end
+    end
+  end
+
+  describe "#source_url" do
+    it "returns the URL from the gdoc source link" do
+      expect(presenter.source_url).to eq("https://docs.google.com/document/d/abc123")
+    end
+
+    context "when the gdoc source is missing" do
+      let(:links) { { "source" => {} } }
+
+      it "returns nil" do
+        expect(presenter.source_url).to be_nil
+      end
+    end
+
+    context "when links are empty" do
+      let(:links) { {} }
+
+      it "returns nil" do
+        expect(presenter.source_url).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extract a shared `HasGdocSource` presenter concern exposing `source_name`/`source_url` helpers and include it in `SectionPresenter` and `UnitPresenter`.
- Surface the Google Doc source as a named link (with safer `rel`) on the admin sections index and add Unit ID + Source columns to the units index.
- Add `Science` to the subject list to align with fresh QA data.

## Test plan
- [x] `rspec spec/presenters/concerns/has_gdoc_source_spec.rb`
- [ ] Open the admin Sections index and verify the Source column renders a named link to the Google Doc
- [ ] Open the admin Units index and verify the new Unit ID and Source columns render correctly