### PR TITLE
(#57) Pluggable PDF renderers with PrinceXML plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"\nimport json, sys, subprocess\ndata = json.load(sys.stdin)\npath = data.get('tool_input', {}).get('file_path', '')\nif not path.endswith('.rb'):\n    sys.exit(0)\nresult = subprocess.run(\n    ['docker', 'compose', 'run', '--rm', 'rails', 'bundle', 'exec', 'rubocop', '--no-color', path],\n    capture_output=True, text=True\n)\nif result.returncode != 0:\n    print(json.dumps({'decision': 'block', 'reason': result.stdout.strip()}))\n\"",
+            "command": "python3 -c \"\nimport json, os, sys, subprocess\ndata = json.load(sys.stdin)\npath = data.get('tool_input', {}).get('file_path', '')\nif not path.endswith('.rb'):\n    sys.exit(0)\nif os.path.isabs(path):\n    path = os.path.relpath(path, os.getcwd())\nresult = subprocess.run(\n    ['docker', 'compose', 'run', '--rm', 'rails', 'bundle', 'exec', 'rubocop', '--no-color', path],\n    capture_output=True, text=True\n)\nif result.returncode != 0:\n    output = (result.stdout + result.stderr).strip()\n    print(json.dumps({'decision': 'block', 'reason': output}))\n\"",
             "timeout": 60
           }
         ]

--- a/.cloud66/deploy_hooks.yml
+++ b/.cloud66/deploy_hooks.yml
@@ -14,3 +14,10 @@ first_thing:
     sudo: true
     apply_during: build_only
     run_on: all_servers
+  - source: /.cloud66/scripts/install-prince-xml.sh
+    destination: /tmp/scripts/install-prince-xml.sh
+    target: rails
+    execute: true
+    sudo: true
+    apply_during: all
+    run_on: all_servers

--- a/.cloud66/scripts/install-prince-xml.sh
+++ b/.cloud66/scripts/install-prince-xml.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -e
+
+if command -v prince >/dev/null 2>&1; then
+  echo "PrinceXML is already installed: $(command -v prince)"
+  echo "PrinceXML version: $(prince --version)"
+  exit 0
+fi
+
+if ! command -v wget >/dev/null 2>&1; then
+  echo "wget is not installed. Installing wget..."
+  apt-get update
+  apt-get install -yy wget
+else
+  echo "wget is installed: $(command -v wget)"
+fi
+
+if ! command -v gdebi >/dev/null 2>&1; then
+  echo "gdebi is not installed. Installing gdebi..."
+  apt-get update
+  apt-get install -yy gdebi
+else
+  echo "gdebi is installed: $(command -v gdebi)"
+fi
+
+PRINCE_VERSION="16.1-1"
+SYSTEM_ARCH="$(dpkg --print-architecture)"
+
+case "$SYSTEM_ARCH" in
+  amd64|arm64)
+    PRINCE_ARCH="$SYSTEM_ARCH"
+    ;;
+  *)
+    echo "Unsupported architecture for PrinceXML package: $SYSTEM_ARCH" >&2
+    exit 1
+    ;;
+esac
+
+if [ -r /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+else
+  echo "Cannot detect operating system: /etc/os-release is missing" >&2
+  exit 1
+fi
+
+if [ "${ID:-}" = "ubuntu" ]; then
+  PRINCE_PLATFORM="ubuntu22.04"
+elif [ "${ID:-}" = "debian" ]; then
+  PRINCE_PLATFORM="debian12"
+elif echo " ${ID_LIKE:-} " | grep -q " ubuntu "; then
+  PRINCE_PLATFORM="ubuntu22.04"
+elif echo " ${ID_LIKE:-} " | grep -q " debian "; then
+  PRINCE_PLATFORM="debian12"
+else
+  echo "Unsupported Linux distribution for PrinceXML package: ${ID:-unknown}" >&2
+  exit 1
+fi
+
+PRINCE_DEB_NAME="prince_${PRINCE_VERSION}_${PRINCE_PLATFORM}_${PRINCE_ARCH}.deb"
+PRINCE_DEB_URL="https://www.princexml.com/download/${PRINCE_DEB_NAME}"
+PRINCE_DEB_FILE="/tmp/${PRINCE_DEB_NAME}"
+
+echo "Downloading PrinceXML package from $PRINCE_DEB_URL"
+wget -O "$PRINCE_DEB_FILE" "$PRINCE_DEB_URL"
+
+echo "Installing PrinceXML..."
+gdebi --non-interactive "$PRINCE_DEB_FILE"
+
+if command -v prince >/dev/null 2>&1; then
+  echo "PrinceXML installed successfully: $(command -v prince)"
+  echo "PrinceXML version: $(prince --version)"
+else
+  echo "Failed to install PrinceXML." >&2
+  exit 1
+fi
+
+# Clean up
+echo "Cleaning up temporary files..."
+rm -f "$PRINCE_DEB_FILE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Asset Pipeline**: esbuild for JavaScript, Sass for CSS
 - **Background Jobs**: Solid Queue
 - **Authentication**: Devise
-- **PDF Generation**: Grover (Puppeteer-based, uses Chromium in Docker)
+- **PDF Generation**: Pluggable renderer architecture ([ADR-0001](docs/adr/0001-pluggable-output-renderers.md)). Default `:grover` (Puppeteer + Chromium) ships in core; `:prince` (PrinceXML, accessible PDF/UA-1) ships as an in-tree plugin at [lib/plugins/prince_pdf/](lib/plugins/prince_pdf/). Selection chain: per-call option → record metadata → registry default. See [docs/pdf-generation.md](docs/pdf-generation.md)
 - **Testing**: RSpec
 - **Containerization**: Docker, Docker Compose
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:3.4.7-slim AS base
+FROM ruby:3.4.7-slim-bookworm AS base
 
 # Install base packages + Chromium for PDF generation
 RUN apt-get update -qq && \
@@ -26,8 +26,34 @@ RUN apt-get update -qq && \
     libxcomposite1 \
     libxdamage1 \
     libxrandr2 \
-    xdg-utils && \
+    xdg-utils \
+    # PrinceXML install deps (prince_pdf plugin)
+    wget \
+    gdebi && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Allow ImageMagick to read PDFs. Debian disables PDF/PS coders by default
+# (CVE-2016-3714 hardening for untrusted-input use cases). We're rendering
+# our own freshly-generated PDFs for thumbnailing, so the restriction is
+# unnecessary here and blocks MaterialPdfJob#perform → Exporters::Thumbnail.
+RUN sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml
+
+# PrinceXML for accessible PDF/UA-1 rendering (prince_pdf plugin).
+# Multi-arch: amd64 + arm64. Pinned to Prince 16.1 / Debian 12.
+# Unlicensed output is watermarked — set PRINCE_LICENSE_PATH at runtime.
+# apt-get update is required here: the previous layer wipes /var/lib/apt/lists
+# and gdebi needs the index to resolve Prince's deps (libaom3, etc.).
+RUN set -e; \
+    SYSTEM_ARCH=$(dpkg --print-architecture); \
+    if [ "$SYSTEM_ARCH" = "amd64" ]; then PRINCE_ARCH="amd64"; \
+    elif [ "$SYSTEM_ARCH" = "arm64" ]; then PRINCE_ARCH="arm64"; \
+    else echo "Unsupported architecture: ${SYSTEM_ARCH}" >&2; exit 1; fi; \
+    PRINCE_DEB="prince_16-1_debian12_${PRINCE_ARCH}.deb"; \
+    apt-get update -qq; \
+    wget -q "https://www.princexml.com/download/${PRINCE_DEB}" -O "/tmp/${PRINCE_DEB}"; \
+    gdebi --non-interactive "/tmp/${PRINCE_DEB}"; \
+    rm "/tmp/${PRINCE_DEB}"; \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 FROM base AS dev

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Type-check baseline scoped to the renderer-plugin contract types only.
+# Expanding this to wider lib/ checking is intentionally deferred — the
+# contract surface is what most benefits from typing today (it's the
+# extension point plugins must satisfy).
+#
+# Plugin signatures are auto-discovered via the lib/plugins/*/sig glob,
+# so plugins can ship their own sig/ trees without Steepfile changes.
+#
+# Run: bundle exec steep check
+#
+D = Steep::Diagnostic
+
+target :lib do
+  signature "sig", "lib/plugins/*/sig"
+
+  check "lib/exporters/pdf/render_options.rb"
+  check "lib/exporters/pdf/renderers/base.rb"
+  check "lib/exporters/pdf/renderers/grover.rb"
+  check "lib/exporters/pdf/renderer_registry.rb"
+  check "lib/plugin_system/registry.rb"
+
+  configure_code_diagnostics do |hash|
+    # Constants supplied by the consumer of PluginSystem::Registry (the
+    # protocol contract is duck-typed by design — see ADR-0001 §3.3).
+    # Steep cannot see these from inside the mixin since they live on the
+    # extending module, not the mixin itself.
+    hash[D::Ruby::UnknownConstant] = :information
+
+    # The `Grover` constant is a third-party gem without RBS signatures.
+    # Could be addressed with a vendor stub if/when wider gem typing is
+    # tackled — out of scope for this baseline.
+
+    # Empty collections used as defaults in `RenderOptions::DEFAULTS` and
+    # `CAPABILITY_FOR_ACCESSIBILITY[:none]`. Their element types are
+    # constrained by the surrounding Hash/Array RBS, not by the literal.
+    hash[D::Ruby::UnannotatedEmptyCollection] = :information
+  end
+end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -5,9 +5,13 @@ module Admin
     def index; end
 
     def update
+      # Image uploads are processed once for ALL groups — `process_image_uploads`
+      # walks every image key across SETTINGS, so calling it per-iteration would
+      # re-upload the same file once per group.
+      processed_params = process_image_uploads(params)
+
       SETTINGS.each do |group, types|
         permitted_keys = types.keys.map(&:to_s)
-        processed_params = process_image_uploads(params)
         new_settings = processed_params.permit(permitted_keys).to_h
         changes = new_settings.select { |key, value| @all_settings[group][key.to_sym] != value }
 

--- a/app/controllers/api/document_jobs_controller.rb
+++ b/app/controllers/api/document_jobs_controller.rb
@@ -17,16 +17,26 @@ module Api
 
     def status
       job_id = params[:job_id]
-      sq_job = SolidQueue::Job.find_by(active_job_id: job_id)
+
+      # Eager-load the same execution associations JobTracker.status_batch uses
+      # so we resolve state in a single round-trip and stay consistent with
+      # how the rest of the app classifies SolidQueue rows.
+      sq_job = SolidQueue::Job
+        .includes(:ready_execution, :claimed_execution, :failed_execution, :scheduled_execution, :blocked_execution)
+        .find_by(active_job_id: job_id)
 
       if (failure = sq_job&.failed_execution)
-        error_msg = failure.error.is_a?(Hash) ? failure.error["message"] : failure.error.to_s
-        return render(json: { status: "failed", error: error_msg.presence || "Job failed" })
+        return render(json: { status: "failed", error: failure.message.presence || "Job failed" })
       end
 
       result = JobResult.find_by(job_id: job_id)
       if result&.result.present?
         render_job_result(result.result)
+      elsif sq_job&.finished?
+        # JobResult row was never written for this jid (legacy job or one
+        # that completed without store_result). Treat the SolidQueue marker
+        # as the source of truth instead of returning :unknown forever.
+        render json: { status: "done" }
       elsif sq_job
         render json: { status: "running" }
       else

--- a/app/controllers/api/document_jobs_controller.rb
+++ b/app/controllers/api/document_jobs_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Api
+  # JSON status endpoint for Document-family async jobs (PDF, GDoc, etc.).
+  #
+  # Decouples job-status polling from the resource type. Any job that writes
+  # its result via JobTracker#store_result becomes pollable here without
+  # per-resource status actions.
+  #
+  # Response shape:
+  #   { status: "running" | "done" | "failed" | "unknown",
+  #     result: <hash from store_result>,   # only when done
+  #     error:  <string>                    # only when failed
+  #   }
+  class DocumentJobsController < ApplicationController
+    respond_to :json
+
+    def status
+      job_id = params[:job_id]
+      sq_job = SolidQueue::Job.find_by(active_job_id: job_id)
+
+      if (failure = sq_job&.failed_execution)
+        error_msg = failure.error.is_a?(Hash) ? failure.error["message"] : failure.error.to_s
+        return render(json: { status: "failed", error: error_msg.presence || "Job failed" })
+      end
+
+      result = JobResult.find_by(job_id: job_id)
+      if result&.result.present?
+        render_job_result(result.result)
+      elsif sq_job
+        render json: { status: "running" }
+      else
+        render json: { status: "unknown" }
+      end
+    end
+
+    private
+
+    # JobTracker convention: failure-on-non-preview writes { ok: false, errors: [...] }.
+    # Anything else with a result is treated as success.
+    def render_job_result(payload)
+      if payload.is_a?(Hash) && payload["ok"] == false
+        error = Array.wrap(payload["errors"]).join(", ").presence || "Job failed"
+        render json: { status: "failed", error: error }
+      else
+        render json: { status: "done", result: payload }
+      end
+    end
+  end
+end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -23,9 +23,10 @@ class DocumentsController < Admin::AdminController
       folder: ENV.fetch("AWS_S3_PREVIEW_FOLDER", "previews"),
       preview: true
     }
-    DocumentPdfJob.perform_now(@document.id, job_options)
-
-    redirect_to @document.reload.preview_links.dig(*link_keys, "url"), allow_other_host: true
+    job = DocumentPdfJob.perform_later(@document.id, job_options)
+    @status_url = status_api_document_job_path(job.job_id)
+    @back_path  = document_path(@document)
+    render template: "shared/preview_generating"
   rescue StandardError => e
     redirect_to document_path(@document), alert: error_message_for(e)
   end

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -17,9 +17,10 @@ class MaterialsController < Admin::AdminController
       folder: ENV.fetch("AWS_S3_PREVIEW_FOLDER", "previews"),
       preview: true
     }
-    MaterialPdfJob.perform_now(@material.id, job_options)
-
-    redirect_to @material.reload.preview_links.dig(*link_keys, "url"), allow_other_host: true
+    job = MaterialPdfJob.perform_later(@material.id, job_options)
+    @status_url = status_api_document_job_path(job.job_id)
+    @back_path  = material_path(@material)
+    render template: "shared/preview_generating"
   rescue StandardError => e
     redirect_to material_path(@material), alert: error_message_for(e)
   end

--- a/app/helpers/admin/settings_helper.rb
+++ b/app/helpers/admin/settings_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Admin
+  # View helpers for the admin Settings UI.
+  module SettingsHelper
+    # Memoized for the lifetime of the current request so partials inside the
+    # `SETTINGS.each` loop don't re-probe backend availability per iteration
+    # (Prince's `available?` shells out to `prince --version`; module-level
+    # memoization handles repeat calls within a process, but a single helper
+    # call per request keeps the contract explicit).
+    def available_pdf_renderers
+      @available_pdf_renderers ||= Exporters::Pdf::RendererRegistry.available
+    end
+  end
+end

--- a/app/jobs/document_pdf_job.rb
+++ b/app/jobs/document_pdf_job.rb
@@ -60,5 +60,10 @@ class DocumentPdfJob < ApplicationJob
         document.update links: document.reload.links.deep_merge(data)
       end
     end
+
+    # Persist a result row so Api::DocumentJobsController#status can read the
+    # outcome without knowing about Document. Failure paths are handled by
+    # DocumentRescuableJob (non-preview) or SolidQueue::FailedExecution (preview).
+    store_result(url: url, pages: pages || -1)
   end
 end

--- a/app/jobs/document_pdf_job.rb
+++ b/app/jobs/document_pdf_job.rb
@@ -27,6 +27,7 @@ class DocumentPdfJob < ApplicationJob
   #
   # @return [void]
   def perform(entry_id, options)
+    options = options.with_indifferent_access
     entry = Document.find(entry_id)
     content_type = options[:content_type].to_sym
     document = DocumentPresenter.new(entry, content_type:)
@@ -53,17 +54,17 @@ class DocumentPdfJob < ApplicationJob
       }
     }
 
+    # Persist link update and JobResult atomically: pollers reading JobResult
+    # after sq_job is `finished` must never see a stale (missing) result row.
+    # Failure paths are handled by DocumentRescuableJob (non-preview) or
+    # SolidQueue::FailedExecution (preview).
     document.with_lock do
       if options[:preview]
         document.update preview_links: document.reload.preview_links.deep_merge(data)
       else
         document.update links: document.reload.links.deep_merge(data)
       end
+      store_result(url: url, pages: pages || -1)
     end
-
-    # Persist a result row so Api::DocumentJobsController#status can read the
-    # outcome without knowing about Document. Failure paths are handled by
-    # DocumentRescuableJob (non-preview) or SolidQueue::FailedExecution (preview).
-    store_result(url: url, pages: pages || -1)
   end
 end

--- a/app/jobs/material_pdf_job.rb
+++ b/app/jobs/material_pdf_job.rb
@@ -65,5 +65,10 @@ class MaterialPdfJob < ApplicationJob
         material.update links: material.reload.links.deep_merge(data)
       end
     end
+
+    # Persist a result row so Api::DocumentJobsController#status can read the
+    # outcome without knowing about Material. See DocumentPdfJob for the
+    # mirror of this contract.
+    store_result(url: pdf_url, pages: pages || -1, thumb_url: thumb_url)
   end
 end

--- a/app/jobs/material_pdf_job.rb
+++ b/app/jobs/material_pdf_job.rb
@@ -58,17 +58,15 @@ class MaterialPdfJob < ApplicationJob
       }
     }
 
+    # Persist link update and JobResult atomically. See DocumentPdfJob for
+    # the mirror of this contract.
     material.with_lock do
       if options[:preview]
         material.update preview_links: material.reload.preview_links.deep_merge(data)
       else
         material.update links: material.reload.links.deep_merge(data)
       end
+      store_result(url: pdf_url, pages: pages || -1, thumb_url: thumb_url)
     end
-
-    # Persist a result row so Api::DocumentJobsController#status can read the
-    # outcome without knowing about Material. See DocumentPdfJob for the
-    # mirror of this contract.
-    store_result(url: pdf_url, pages: pages || -1, thumb_url: thumb_url)
   end
 end

--- a/app/jobs/unit_bundle_pdf_job.rb
+++ b/app/jobs/unit_bundle_pdf_job.rb
@@ -30,6 +30,7 @@ class UnitBundlePdfJob < BaseBundleJob
   CONTENT_TYPE = :unit_bundle
   NESTED_JOBS = %w(DocumentPdfJob MaterialPdfJob UnitBundlePdfJob).freeze
   LINK_KEY = "pdf"
+  PDF_OPTION_KEYS = %i(renderer accessible_pdf accessibility).freeze
 
   queue_as :default
 
@@ -96,21 +97,20 @@ class UnitBundlePdfJob < BaseBundleJob
 
   def generate_lessons
     unit.lessons.each do |lesson|
-      job_options = {
-        content_type: CONTENT_TYPE.to_s,
-        initial_job_id: initial_job_id
-      }
-      DocumentPdfJob.perform_later(lesson.id, job_options)
+      DocumentPdfJob.perform_later(lesson.id, pdf_job_options)
     end
   end
 
   def generate_materials
     unit.materials.each do |material|
-      job_options = {
-        content_type: CONTENT_TYPE.to_s,
-        initial_job_id: initial_job_id
-      }
-      MaterialPdfJob.perform_later(material.id, job_options)
+      MaterialPdfJob.perform_later(material.id, pdf_job_options)
     end
+  end
+
+  def pdf_job_options
+    {
+      content_type: CONTENT_TYPE.to_s,
+      initial_job_id: initial_job_id
+    }.merge(options.slice(*PDF_OPTION_KEYS))
   end
 end

--- a/app/models/concerns/pdf_renderable.rb
+++ b/app/models/concerns/pdf_renderable.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#
+# Per-record PDF renderer + accessibility selection, stored in the
+# existing jsonb `metadata` column. No migration required.
+#
+# Read side: Exporters::Pdf::Base#renderer_name and #accessibility_level
+# call `@document.pdf_renderer` and `@document.accessibility` (delegated
+# from the presenter via SimpleDelegator). Both return nil when unset,
+# and the exporter falls through to the registry default / `:none`.
+#
+# Write side: admin UI / console / migrations set values via the
+# accessors. The accessibility writer validates against a closed set;
+# the renderer writer accepts any symbol/string (registry validates at
+# render time).
+#
+module PdfRenderable
+  extend ActiveSupport::Concern
+
+  ACCESSIBILITY_LEVELS = %w(none tagged pdf_ua).freeze
+
+  def pdf_renderer
+    metadata && metadata["pdf_renderer"].presence
+  end
+
+  def pdf_renderer=(value)
+    write_pdf_metadata("pdf_renderer", value.presence&.to_s)
+  end
+
+  def accessibility
+    metadata && metadata["accessibility"].presence
+  end
+
+  def accessibility=(value)
+    str = value.presence&.to_s
+    if str && !ACCESSIBILITY_LEVELS.include?(str)
+      raise ArgumentError,
+            "accessibility must be one of #{ACCESSIBILITY_LEVELS}, got #{value.inspect}"
+    end
+    write_pdf_metadata("accessibility", str)
+  end
+
+  private
+
+  # Assigns a new hash to `metadata=` so ActiveRecord registers the change.
+  def write_pdf_metadata(key, value)
+    next_meta = (metadata || {}).dup
+    if value.nil?
+      next_meta.delete(key)
+    else
+      next_meta[key] = value
+    end
+    self.metadata = next_meta
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -35,6 +35,7 @@
 class Document < ApplicationRecord
   include Filterable
   include Partable
+  include PdfRenderable
 
   GOOGLE_URL_PREFIX = "https://docs.google.com/document/d"
 

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -33,6 +33,7 @@ class Material < ApplicationRecord
   include Filterable
   include PgSearch::Model
   include Partable
+  include PdfRenderable
 
   validates :file_id, presence: true
   validates :identifier, uniqueness: true

--- a/app/presenters/content_presenter.rb
+++ b/app/presenters/content_presenter.rb
@@ -52,18 +52,45 @@ class ContentPresenter < BasePresenter
   end
 
   def orientation
-    config[:orientation]
+    render_options.orientation
   end
 
   def padding_styles(align_type: "padding")
-    config[:padding].map { |k, v| "#{align_type}-#{k}:#{v};" }.join
+    render_options.padding.map { |k, v| "#{align_type}-#{k}:#{v};" }.join
   end
 
   def pdf_preview_title
     preview_links.dig("preview", "pdf").present? ? I18n.t("admin.common.preview_pdf") : I18n.t("admin.common.generate_pdf")
   end
 
+  #
+  # Single source of truth for rendering-time configuration.
+  # Renderer reads engine-relevant fields; templates read template-relevant
+  # fields (via @render_options assigned by Exporters::Base#render_template).
+  # Subclasses override `effective_orientation` to layer per-record overrides
+  # on top of the per-content-type config.
+  #
+  def render_options
+    @render_options ||= Exporters::Pdf::RenderOptions.build(
+      format: "Letter",
+      orientation: effective_orientation,
+      margin: config[:margin],
+      dpi: config[:dpi],
+      image_dpi: config[:image_dpi],
+      print_background: true,
+      metadata: { title: base_filename, lang: "en" },
+      accessibility: :none,
+      show_header: config.fetch(:header, true),
+      show_name_date: config[:name_date] == true,
+      padding: config[:padding] || {}
+    )
+  end
+
   private
+
+  def effective_orientation
+    config[:orientation] || "portrait"
+  end
 
   def document_parts_index
     @document_parts_index ||= document_parts.pluck(:placeholder, :anchor, :content, :optional)

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -3,7 +3,7 @@
 class DocumentPresenter < ContentPresenter
   include Rails.application.routes.url_helpers
 
-  delegate :cc_attribution, :grade, :subject, :lesson_title, :lesson_number, :section_number, :unit_id,
+  delegate :cc_attribution, :grade, :subject, :lesson_title, :lesson_number, :section_number, :teaser, :unit_id,
            to: :base_metadata
 
   def content_for(context_type, options = {})

--- a/app/presenters/material_presenter.rb
+++ b/app/presenters/material_presenter.rb
@@ -40,11 +40,7 @@ class MaterialPresenter < ContentPresenter
   end
 
   def header?
-    config[:header]
-  end
-
-  def orientation
-    base_metadata.orientation.presence || super
+    render_options.show_header
   end
 
   def pdf_filename
@@ -68,5 +64,9 @@ class MaterialPresenter < ContentPresenter
 
   def base_metadata
     @base_metadata ||= DocTemplate::Objects::Material.build_from(metadata)
+  end
+
+  def effective_orientation
+    base_metadata.orientation.presence || super
   end
 end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -66,7 +66,7 @@
       }
     }
 
-    document.querySelectorAll("input[form='settings-form']")
+    document.querySelectorAll("[form='settings-form']")
       .forEach(input => input.addEventListener("change", handleChange));
 
     document.querySelector('#settings-form').addEventListener("change", handleChange);

--- a/app/views/admin/settings/show/_renderer_select.html.erb
+++ b/app/views/admin/settings/show/_renderer_select.html.erb
@@ -1,0 +1,8 @@
+<select name="<%= setting_key %>" form="<%= form_id %>" class="form-select form-select-sm" style="max-width: 240px;">
+  <option value=""><%= t("admin.settings.renderer_select.use_fallback") %></option>
+  <% Exporters::Pdf::RendererRegistry.available.each do |identifier| %>
+    <option value="<%= identifier %>" <%= "selected" if setting_value.to_s == identifier.to_s %>>
+      <%= identifier %>
+    </option>
+  <% end %>
+</select>

--- a/app/views/admin/settings/show/_renderer_select.html.erb
+++ b/app/views/admin/settings/show/_renderer_select.html.erb
@@ -1,6 +1,6 @@
 <select name="<%= setting_key %>" form="<%= form_id %>" class="form-select form-select-sm" style="max-width: 240px;">
   <option value=""><%= t("admin.settings.renderer_select.use_fallback") %></option>
-  <% Exporters::Pdf::RendererRegistry.available.each do |identifier| %>
+  <% available_pdf_renderers.each do |identifier| %>
     <option value="<%= identifier %>" <%= "selected" if setting_value.to_s == identifier.to_s %>>
       <%= identifier %>
     </option>

--- a/app/views/documents/pdf/_header.html.erb
+++ b/app/views/documents/pdf/_header.html.erb
@@ -1,5 +1,5 @@
 <div class="c-ld__header--pdf o-page--pdf-ld" style="<%= document.padding_styles %>">
-  <h1 class="u-pdf-txt--ld-h1"><%= document.title %></h1>
+  <h1 class="u-pdf-txt--ld-h1"><%= document.lesson_title %></h1>
   <div class="u-txt--teaser">
     <%= raw document.teaser %>
   </div>

--- a/app/views/shared/preview_generating.html.erb
+++ b/app/views/shared/preview_generating.html.erb
@@ -1,0 +1,64 @@
+<%#
+  Shared "generating" view for async PDF preview. Rendered explicitly via
+  `render template: "shared/preview_generating"` by any controller that
+  enqueues a job and wants to show a polling page.
+
+  Instance vars:
+    @status_url - JSON endpoint returning {status, result, error}
+    @back_path  - link target for the Cancel button
+%>
+<div class="container py-5 text-center">
+  <h2>Generating PDF…</h2>
+  <p class="text-muted">This may take 10–30 seconds while the renderer works.</p>
+
+  <div class="spinner-border text-primary my-3" role="status">
+    <span class="visually-hidden">Loading…</span>
+  </div>
+
+  <div id="preview-error" class="alert alert-danger mt-4" style="display:none"></div>
+
+  <p class="mt-4">
+    <%= link_to "Cancel", @back_path, class: "btn btn-link" %>
+  </p>
+</div>
+
+<script>
+  (function() {
+    const statusUrl = <%= raw @status_url.to_json %>;
+    let attempts = 0;
+    const maxAttempts = 80;  // ~2 minutes at 1500ms
+
+    function showError(msg) {
+      const el = document.getElementById("preview-error");
+      el.textContent = msg;
+      el.style.display = "block";
+    }
+
+    async function poll() {
+      attempts += 1;
+      if (attempts > maxAttempts) {
+        showError("Generation is taking longer than expected. Refresh to check status.");
+        return;
+      }
+      try {
+        const res = await fetch(statusUrl, { headers: { "Accept": "application/json" } });
+        if (!res.ok) {
+          showError("Could not check job status (HTTP " + res.status + ")");
+          return;
+        }
+        const data = await res.json();
+        if (data.status === "done" && data.result && data.result.url) {
+          window.location.href = data.result.url;
+        } else if (data.status === "failed") {
+          showError(data.error || "PDF generation failed.");
+        } else {
+          setTimeout(poll, 1500);
+        }
+      } catch (e) {
+        showError("Network error while polling: " + e.message);
+      }
+    }
+
+    poll();
+  })();
+</script>

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -2,3 +2,14 @@
 
 # Indicates whether S3 access is blocked, based on the environment variable `AWS_S3_BLOCK`.
 AWS_S3_BLOCK = ENV.fetch("AWS_S3_BLOCK", "false").in?(%w(true 1))
+
+# Optional S3 endpoint override for local development (minio, localstack).
+# When set, points the AWS SDK's S3 client at the alternate endpoint and
+# enables path-style addressing (required for non-AWS endpoints whose hosts
+# don't support virtual-hosted-style bucket subdomains).
+if (s3_endpoint = ENV["AWS_ENDPOINT_URL_S3"].presence)
+  Aws.config[:s3] = {
+    endpoint: s3_endpoint,
+    force_path_style: true
+  }
+end

--- a/config/initializers/lcms_constants.rb
+++ b/config/initializers/lcms_constants.rb
@@ -42,6 +42,9 @@ SETTINGS = {
     header_dropdown_bg_color: :color,
     header_active_item_color: :color,
     header_logo: :image
+  },
+  pdf: {
+    default_renderer: :renderer_select
   }
 }.freeze
 
@@ -52,5 +55,8 @@ SETTINGS_DEFAULTS = {
     header_dropdown_bg_color: "#ffffff",
     header_active_item_color: "#0d6efd",
     header_logo: nil
+  },
+  pdf: {
+    default_renderer: nil
   }
 }.freeze

--- a/config/initializers/pdf_renderers.rb
+++ b/config/initializers/pdf_renderers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Register PDF renderer backends at boot.
+#
+# Default backends ship in core. Plugin backends register themselves
+# in their own setup! hooks (loaded later via PluginSystem.load_all).
+#
+# Renderer-specific configuration (e.g. Grover's Puppeteer settings)
+# stays in its own initializer (config/initializers/grover.rb).
+#
+# `to_prepare` (not `after_initialize`) so registration survives Zeitwerk
+# code reloads in dev: when lib/exporters/pdf/renderer_registry.rb reloads,
+# the module's @store is wiped, and `to_prepare` re-registers backends on
+# the next request. Runs once in production.
+Rails.application.config.to_prepare do
+  Exporters::Pdf::RendererRegistry.register(Exporters::Pdf::Renderers::Grover)
+end

--- a/config/initializers/plugins.rb
+++ b/config/initializers/plugins.rb
@@ -8,6 +8,10 @@
 
 require_relative "../../lib/plugin_system"
 
-Rails.application.config.after_initialize do
+# `to_prepare` (not `after_initialize`) so plugin setup! hooks re-run after
+# dev-mode code reloads. Plugins use this to re-register renderers and other
+# backends whose stores get wiped when Zeitwerk reloads their registry
+# modules. Runs once in production.
+Rails.application.config.to_prepare do
   PluginSystem.load_all
 end

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -309,8 +309,10 @@ en:
       invalid_group: Invalid settings group.
       groups:
         appearance: Appearance
+        pdf: PDF generation
       descriptions:
         appearance: Customize the appearance of the admin panel interface.
+        pdf: Configure how PDF documents are generated for this project. Only renderers whose runtime dependencies are installed appear here.
       labels:
         appearance:
           header_bg_color: Header Background Color
@@ -318,6 +320,10 @@ en:
           header_dropdown_bg_color: Header Dropdown Background Color
           header_active_item_color: Header Active Item Color
           header_logo: Header Logo
+        pdf:
+          default_renderer: Default PDF renderer
+      renderer_select:
+        use_fallback: "(use system default)"
       index:
         key: Key
         value: Value

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,11 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :resources, only: [:index]
+    resources :document_jobs, only: [], param: :job_id do
+      member do
+        get :status
+      end
+    end
   end
 
   # OAuth callback for Google

--- a/docs/adding-a-pdf-renderer.md
+++ b/docs/adding-a-pdf-renderer.md
@@ -1,0 +1,409 @@
+# Adding a PDF Renderer Plugin
+
+This is a hands-on tutorial. By the end you'll have a working renderer plugin loaded at boot, selectable from the admin Settings UI, with conformance tests in place.
+
+For the *why* behind the design (decoupling, capabilities, two-tier model, etc.) see [ADR-0001](adr/0001-pluggable-output-renderers.md). For an overview of selection precedence and runtime behavior see [pdf-generation.md](pdf-generation.md). This document is the *how*.
+
+Reference implementation: [`lib/plugins/prince_pdf/`](../lib/plugins/prince_pdf/). When in doubt, crib from it.
+
+---
+
+## Step 1 — Scaffold the plugin folder
+
+Pick a short, lowercase, underscored name for your plugin. We'll use `my_pdf` throughout.
+
+```bash
+mkdir -p lib/plugins/my_pdf/{lib/my_pdf,spec/my_pdf,sig/my_pdf}
+touch lib/plugins/my_pdf/{Gemfile,README.md}
+touch lib/plugins/my_pdf/lib/my_pdf.rb
+touch lib/plugins/my_pdf/lib/my_pdf/renderer.rb
+touch lib/plugins/my_pdf/spec/my_pdf/renderer_spec.rb
+```
+
+Minimal layout:
+
+```
+lib/plugins/my_pdf/
+  Gemfile                       # plugin-specific gems (often empty for renderers)
+  README.md                     # what the plugin does, license, install reqs
+  lib/
+    my_pdf.rb                   # entry point: setup! hook
+    my_pdf/
+      renderer.rb               # the PDF renderer
+  spec/
+    my_pdf/
+      renderer_spec.rb
+```
+
+For richer plugins (custom layout, options translator, executable wrapper, accessibility CSS), use [`lib/plugins/prince_pdf/`](../lib/plugins/prince_pdf/) as the template. None of those are required by the protocol.
+
+### Gem dependencies
+
+The host [`Gemfile`](../Gemfile) auto-loads every plugin Gemfile via:
+
+```ruby
+Dir[File.join("lib/plugins/*/Gemfile")].each { |f| eval_gemfile(f) }
+```
+
+So **gems your renderer needs go in `lib/plugins/my_pdf/Gemfile`, not the host Gemfile.** This keeps the plugin self-contained — a fork that doesn't enable your renderer doesn't carry the gem dependency.
+
+```ruby
+# lib/plugins/my_pdf/Gemfile
+# frozen_string_literal: true
+
+gem "my_backend", "~> 1.2"
+```
+
+After editing, run `bundle install` to lock the new dependency. The plugin Gemfile may be empty — Prince's plugin has no Ruby deps because the backend is a system binary invoked via `Open3`.
+
+## Step 2 — Write the entry-point module
+
+`lib/plugins/my_pdf/lib/my_pdf.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module MyPdf
+  class << self
+    def setup!
+      ::Exporters::Pdf::RendererRegistry.register(Renderer)
+      PluginSystem.logger.info \
+        "[MyPdf] :my_pdf renderer registered (available=#{Renderer.available?})"
+    end
+  end
+end
+```
+
+`PluginSystem.load_all` (invoked from [config/initializers/plugins.rb](../config/initializers/plugins.rb) in a `to_prepare` hook) calls `setup!` on every module under `lib/plugins/`. You don't need to register your plugin anywhere — dropping the folder in is sufficient.
+
+### Boot-time configuration belongs in `setup!`
+
+If your backend has a global `.configure` block (Grover, WickedPdf, etc.), put it **inside `setup!`** before the `register` call. **Plugins do not ship `config/initializers/*.rb` files** — the auto-discovery iterates only over plugin Ruby modules, not Rails initializer paths. The `setup!` hook IS the plugin's boot-time initialization point.
+
+```ruby
+module GroverPdf
+  class << self
+    def setup!
+      ::Grover.configure do |config|
+        config.options = {
+          executable_path: ENV.fetch("GROVER_EXECUTABLE_PATH", nil),
+          wait_until: "networkidle0",
+          timeout: ENV.fetch("PUPPETEER_TIMEOUT", 0).to_i
+        }
+      end
+      ::Exporters::Pdf::RendererRegistry.register(Renderer)
+    end
+  end
+end
+```
+
+Because `setup!` runs inside Rails' `to_prepare` hook, it re-runs on every dev-mode code reload — safe for idempotent operations (registration overwrites by identifier; `.configure` overwrites a global). Don't put one-shot side effects (DB writes, network calls, file creation) here.
+
+## Step 3 — Implement the renderer
+
+`lib/plugins/my_pdf/lib/my_pdf/renderer.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module MyPdf
+  class Renderer < ::Exporters::Pdf::Renderers::Base
+    CAPABILITIES = Set[
+      # Declare what this backend supports. See "Capability vocabulary" below.
+    ].freeze
+
+    def self.identifier   = :my_pdf
+    def self.capabilities = CAPABILITIES
+    def self.layout_name  = "pdf"          # ERB layout to render the body in
+    def self.available?   = true           # set to false when runtime deps are missing
+
+    def call(html, options:)
+      # Translate `options` (an Exporters::Pdf::RenderOptions) into your backend's
+      # native option format, then render `html` to PDF bytes and return them.
+      raise NotImplementedError
+    end
+  end
+end
+```
+
+The protocol the registry enforces:
+
+| Method                  | Required? | Type                 | Default (from `Base`) |
+|-------------------------|-----------|----------------------|-----------------------|
+| `.identifier`           | yes       | `Symbol`             | —                     |
+| `#call(html, options:)` | yes       | `String` (PDF bytes) | —                     |
+| `.capabilities`         | no        | `Set[Symbol]`        | empty set             |
+| `.available?`           | no        | `Boolean`            | `true`                |
+| `.layout_name`          | no        | `String`             | `"pdf"`               |
+
+Inheriting `Base` is not required — duck-typed implementations satisfy the registry equally — but it gives you the optional-method defaults for free.
+
+## Step 4 — Declare capabilities
+
+`.capabilities` returns a `Set` of symbols describing what the backend can do. The registry's accessibility gate uses these to reject mismatched (renderer, accessibility) combos at lookup time, before any HTML is rendered.
+
+### Capabilities that gate accessibility
+
+These are checked by `RendererRegistry.fetch_for(identifier:, accessibility:)`:
+
+| Capability    | Required for `accessibility:` |
+|---------------|-------------------------------|
+| `:tagged_pdf` | `:tagged`                     |
+| `:pdf_ua`     | `:pdf_ua`                     |
+
+If you support either tier of accessibility output, declare the corresponding capability. Otherwise leave them out — Grover, for example, declares neither.
+
+### Informational capabilities
+
+Not enforced, but useful for documentation and future feature flags. Common ones used by existing renderers:
+
+- `:landscape` — supports landscape orientation
+- `:web_fonts` — embeds web fonts
+- `:js_execution` — runs JavaScript in the rendered page
+- `:running_headers` — supports CSS `position: running()` for paged headers/footers
+- `:background_print` — honors `print-color-adjust: exact`
+- `:custom_script_hook` — supports a renderer-side script injection point
+
+When in doubt, look at [`PrincePdf::Renderer::CAPABILITIES`](../lib/plugins/prince_pdf/lib/prince_pdf/renderer.rb) for a maximalist example.
+
+## Step 5 — Translate `RenderOptions` to your backend's options
+
+`options` arrives as an [`Exporters::Pdf::RenderOptions`](../lib/exporters/pdf/render_options.rb) — a `Data` object with these fields:
+
+| Field                        | Type         | Notes                                                   |
+|------------------------------|--------------|---------------------------------------------------------|
+| `format`                     | String       | e.g. `"Letter"`, `"A4"`                                 |
+| `orientation`                | String       | `"portrait"` \| `"landscape"`                           |
+| `margin`                     | Hash\|nil    | `{ top:, right:, bottom:, left: }` — CSS length strings |
+| `dpi`, `image_dpi`           | Integer\|nil |                                                         |
+| `print_background`           | Boolean      |                                                         |
+| `header_html`, `footer_html` | String\|nil  | already-rendered HTML fragments                         |
+| `metadata`                   | Hash         | `{ title:, lang: }` — author/title/lang hints           |
+| `accessibility`              | Symbol       | `:none` \| `:tagged` \| `:pdf_ua`                       |
+| `extra`                      | Hash         | escape hatch for renderer-specific options              |
+
+Helper methods: `landscape?`, `portrait?`, `accessible?`.
+
+Renderers extract the subset they care about. Two common patterns:
+
+### Pattern A — direct extraction inside `#call` (smaller renderers)
+
+```ruby
+def call(html, options:)
+  MyBackend.render(html,
+    format: options.format,
+    landscape: options.landscape?,
+    margins: options.margin,
+    pdf_ua: options.accessibility == :pdf_ua
+  )
+end
+```
+
+### Pattern B — `OptionsTranslator` class (larger renderers)
+
+Used by `PrincePdf` — see [`options_translator.rb`](../lib/plugins/prince_pdf/lib/prince_pdf/options_translator.rb). The renderer's `#call` becomes:
+
+```ruby
+def call(html, options:)
+  args = OptionsTranslator.new(options).to_args
+  Backend.run(args, stdin: html)
+end
+```
+
+Pattern B is worth the indirection when the translation is non-trivial (multi-step, conditional flags, asset paths) or when you want to test option mapping in isolation.
+
+## Step 6 — Add a layout (only if your renderer needs custom HTML)
+
+By default, renderers use the shared [`app/views/layouts/pdf.html.erb`](../app/views/layouts/pdf.html.erb) — the body content is wrapped in the standard PDF layout.
+
+If your backend needs a different `<head>` (e.g. embedded metadata for PDF/UA, a different stylesheet link, a custom `<html lang>`), ship your own layout at `lib/plugins/my_pdf/app/views/layouts/pdf_my_pdf.html.erb` and point `.layout_name` at it:
+
+```ruby
+def self.layout_name = "pdf_my_pdf"
+```
+
+Plugin views are auto-discovered via `lib/plugins/*/app/views/` (Rails view path). Reference: [`lib/plugins/prince_pdf/app/views/layouts/pdf_prince.html.erb`](../lib/plugins/prince_pdf/app/views/layouts/pdf_prince.html.erb).
+
+## Step 7 — Write specs
+
+`lib/plugins/my_pdf/spec/my_pdf/renderer_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe MyPdf::Renderer do
+  it_behaves_like "a PDF renderer"
+
+  # Add backend-specific examples here:
+  #   - input/output transformations
+  #   - error handling when the backend fails
+  #   - capability assertions specific to your renderer
+end
+```
+
+`it_behaves_like "a PDF renderer"` is the shared conformance suite ([`spec/support/shared_examples/pdf_renderer.rb`](../spec/support/shared_examples/pdf_renderer.rb)). It checks:
+
+- Protocol surface (identifier, call, capabilities, available?, layout_name) returns the right types
+- The renderer round-trips through `RendererRegistry.register` without raising `ContractViolation`
+- It's fetchable by its identifier when `available?`
+
+It does **not** verify your renderer actually produces a valid PDF — that requires runtime deps and belongs in your plugin's integration tests (typically gated on whether the backend's binary is installed).
+
+Run just your plugin's specs:
+
+```bash
+docker compose run --rm test bundle exec rspec lib/plugins/my_pdf/spec
+```
+
+The `.rspec` `--pattern` already includes `lib/plugins/**/spec/**/*_spec.rb`, so plugin specs run as part of the main suite by default.
+
+## Step 8 — Verify registration at boot
+
+```bash
+docker compose run --rm rails rails runner '
+  reg = Exporters::Pdf::RendererRegistry
+  puts "registered: #{reg.all.inspect}"
+  puts "available:  #{reg.available.inspect}"
+'
+```
+
+Expected output includes `:my_pdf` in both lists. If it's in `registered` but not `available`, your `available?` is returning `false` — usually because a runtime dependency isn't installed (Step 10).
+
+If it doesn't appear at all, check the Rails logs at boot for a `[PluginSystem]` line: each plugin's `setup!` is called once per dev-mode `to_prepare` cycle, with the failure message captured at the `PluginSystem.logger.error` level.
+
+## Step 9 — Test end-to-end
+
+Set your renderer as the default via the admin Settings UI at `/admin/settings` — it should appear in the "Default PDF renderer" dropdown (the dropdown's options come from `RendererRegistry.available`).
+
+Then hit a preview URL with `FORCE_PREVIEW_GENERATION=true` (or clear `preview_links` first):
+
+```
+http://localhost:3000/documents/<id>/preview/pdf?type=<content_type>
+http://localhost:3000/materials/<id>/preview/pdf
+```
+
+Inspect the generated PDF's metadata to confirm your renderer ran:
+
+```bash
+docker compose run --rm rails bash -c '
+  curl -s "<the s3 url>" | strings | grep -E "Producer|Creator" | head -3
+'
+```
+
+You should see your backend's signature (e.g., `Producer: WeasyPrint`, `Producer: wkhtmltopdf`). Compare to Grover's `Producer: Skia/PDF`.
+
+## Step 10 — Install runtime dependencies
+
+Most renderers wrap an external binary or service. You have three places to ensure it's available:
+
+### Local development — Dockerfile.dev
+
+Add an apt/gem/binary install step to [`Dockerfile.dev`](../Dockerfile.dev). Pin versions; document the rationale in a comment. Example pattern from the Prince install:
+
+```dockerfile
+RUN set -e; \
+    ARCH=$(dpkg --print-architecture); \
+    apt-get update -qq; \
+    wget -q "https://example.com/my-backend-${ARCH}.deb" -O "/tmp/my-backend.deb"; \
+    gdebi --non-interactive "/tmp/my-backend.deb"; \
+    rm "/tmp/my-backend.deb"; \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+```
+
+### Production — Cloud66
+
+Ship an idempotent install script under [`.cloud66/scripts/install-my-backend.sh`](../.cloud66/scripts/) and wire it into [`.cloud66/deploy_hooks.yml`](../.cloud66/deploy_hooks.yml) as a `first_thing` hook. Pattern: [`.cloud66/scripts/install-prince-xml.sh`](../.cloud66/scripts/install-prince-xml.sh).
+
+### Documentation — your plugin's README
+
+`lib/plugins/my_pdf/README.md` should list:
+
+- What runtime binary/service is required
+- License terms if commercial (Prince's "non-commercial watermark" trap is a good template)
+- Environment variables your renderer reads (e.g., binary path, license file path)
+- Links to upstream installation docs
+
+**Why install scripts live in the main repo, not the plugin folder:** convention-based plugin self-provisioning was considered and rejected for v1 — see [ADR-0001 §4.4](adr/0001-pluggable-output-renderers.md#44-docker-and-cloud66-integration). The expectation is to revisit once 3+ plugins ship their own provisioning.
+
+## What you don't need to do
+
+- **No route changes** — the renderer is invoked through `Exporters::Pdf::Document#export` and its kin; selection happens via the registry, not via per-renderer URLs.
+- **No controller changes** — `DocumentsController#preview_pdf`, `MaterialsController#preview_pdf`, and the PDF jobs all go through the same registry call.
+- **No view-template changes (usually)** — the existing partials under `app/views/{documents,materials}/pdf/` are renderer-agnostic. Only swap the `.layout_name` if you need a different `<head>`.
+- **No background-job changes** — `DocumentPdfJob` and `MaterialPdfJob` already work for any registered renderer.
+
+## Common pitfalls
+
+1. **Forgot to call `setup!`** — Plugin Ruby code loaded but renderer never registered. Cause: you defined the module but didn't add the `def setup!` method. The system calls `MyPdf.setup!` if it exists; without it, nothing happens. Check the boot logs for `[PluginSystem] Loaded: my_pdf` — if you see only that and not your registration log line, `setup!` is missing.
+
+2. **`available?` returns `false`** — Registered but filtered out. Usually a path or binary check failing inside `available?`. Test from the console: `MyPdf::Renderer.available?` — debug from there.
+
+3. **Capability mismatch raised as `UnsupportedCapability`** — The registry rejects (your renderer, `:pdf_ua`) because you didn't declare `:pdf_ua` in `CAPABILITIES`. Either declare it (and actually support it!) or accept that your renderer is only usable for non-accessible PDFs.
+
+4. **Dev-mode reload wipes the registry** — If you edit `lib/exporters/pdf/renderer_registry.rb` and the dropdown goes empty, that's a `to_prepare` vs `after_initialize` issue. The plugin initializer uses `to_prepare` precisely to survive Zeitwerk reloads; if your registration drops the table, check that you're using `to_prepare`.
+
+## When you ship
+
+- Update [docs/pdf-generation.md](pdf-generation.md) "Available renderers" table with your row
+- Add an integration test that actually invokes your binary (gated on the binary being installed) so CI catches breakage
+- Open a PR — the protocol-conformance suite from `it_behaves_like "a PDF renderer"` already ran in the spec suite, so reviewers can focus on backend-specific behavior
+
+---
+
+## Migrating an existing renderer into a plugin
+
+This guide is structured for greenfield plugins. If you're **extracting** an existing renderer from the host app into a plugin (e.g., turning the in-tree `Exporters::Pdf::Renderers::Grover` into a `lib/plugins/grover_pdf/`), follow Steps 1–9 above, then do this cleanup checklist:
+
+### Files to move
+
+| From (host app)                                   | To (plugin)                                               |
+|---------------------------------------------------|-----------------------------------------------------------|
+| `lib/exporters/pdf/renderers/<name>.rb`           | `lib/plugins/<name>_pdf/lib/<name>_pdf/renderer.rb`       |
+| `config/initializers/<name>.rb` content           | inlined into `<NamePdf>.setup!` (delete the file)         |
+| `spec/lib/exporters/pdf/renderers/<name>_spec.rb` | `lib/plugins/<name>_pdf/spec/<name>_pdf/renderer_spec.rb` |
+| `sig/lib/exporters/pdf/renderers/<name>.rbs`      | `lib/plugins/<name>_pdf/sig/<name>_pdf/renderer.rbs`      |
+| `gem "<backend>"` line from host `Gemfile`        | plugin `Gemfile`                                          |
+
+### Lines to remove from the host app
+
+- The `Exporters::Pdf::RendererRegistry.register(...)` call in [`config/initializers/pdf_renderers.rb`](../config/initializers/pdf_renderers.rb) — registration now happens in the plugin's `setup!`
+- Any host-app references to the renderer class constant (`Exporters::Pdf::Renderers::Grover`) — they should be referenced through the registry (`RendererRegistry.fetch(:grover)`) instead
+- The renderer's row from [`Steepfile`](../Steepfile) if its sig was listed individually — plugin sigs are picked up automatically via `lib/plugins/*/sig`
+
+### Docs to update
+
+- [`docs/pdf-generation.md`](pdf-generation.md) — move the renderer's "(default renderer)"-style section out of the host docs (or update it to reflect plugin location)
+- [`docs/adr/0001-pluggable-output-renderers.md`](adr/0001-pluggable-output-renderers.md) — if the ADR cited the renderer as in-tree, update §4 or note in §5 "What changed"
+
+### Validation
+
+After extraction, the following should still pass without any code changes outside the plugin:
+
+```bash
+docker compose run --rm test bundle exec rspec
+docker compose run --rm rails bundle exec steep check
+docker compose run --rm rails rails runner '
+  puts Exporters::Pdf::RendererRegistry.available.inspect
+  puts Exporters::Pdf::RendererRegistry.default.inspect
+'
+```
+
+If `available` is missing your identifier, the plugin's `setup!` isn't being called — check for a `[PluginSystem] Loaded: <name>` line at boot, and that the module name in `lib/plugins/<name>_pdf/lib/<name>_pdf.rb` matches the folder name (camelized).
+
+### Why extract?
+
+- **Optional dependency.** Forks that don't need your renderer don't pay for the gem/runtime install.
+- **Cleaner ownership.** Renderer-specific code lives next to the registration that activates it; no scattering across `lib/exporters/`, `config/initializers/`, and the host Gemfile.
+- **Parity with future renderers.** Treating every renderer (even the default) as a plugin removes the special case in the architecture.
+
+The trade-off: the "default renderer" loses some discoverability — a new reader of the host app sees zero renderers and has to know to look in `lib/plugins/`. The [pdf-generation.md](pdf-generation.md) "Available renderers" table covers this.
+
+---
+
+## Related docs
+
+- [pdf-generation.md](pdf-generation.md) — renderer selection, options chain, runtime behavior
+- [plugin-system.md](plugin-system.md) — generic plugin authoring (not PDF-specific)
+- [ADR-0001](adr/0001-pluggable-output-renderers.md) — design rationale, protocol spec

--- a/docs/adr/0001-pluggable-output-renderers.md
+++ b/docs/adr/0001-pluggable-output-renderers.md
@@ -1,0 +1,1020 @@
+# ADR-0001: Pluggable Output Renderers via the Plugin System
+
+|                   |                                                                                              |
+|-------------------|----------------------------------------------------------------------------------------------|
+| **Status**        | Proposed                                                                                     |
+| **Date**          | 2026-05-04                                                                                   |
+| **Supersedes**    | —                                                                                            |
+| **Superseded by** | —                                                                                            |
+| **Related**       | [docs/plugin-system.md](../plugin-system.md), [docs/pdf-generation.md](../pdf-generation.md) |
+
+---
+
+## 1. Context
+
+LCMS Core today produces output content in two formats:
+
+- **PDF** — rendered by [`Exporters::Pdf::Base`](../../lib/exporters/pdf/base.rb), which calls `Grover.new(html).to_pdf` directly. Grover drives a headless Chromium via Puppeteer.
+- **Google Doc** — rendered by [`Exporters::Gdoc::Base`](../../lib/exporters/gdoc/base.rb), which uploads HTML to Google Drive and returns a file ID/URL.
+
+Both are invoked by background jobs (`DocumentPdfJob`, `MaterialPdfJob`, `UnitBundlePdfJob`, the corresponding `*GdocJob`s) which hard-instantiate the exporter classes.
+
+Three forces motivate change:
+
+1. **Accessible PDFs.** Some downstream consumers require WCAG/PDF-UA-compliant PDFs. Chromium's `page.pdf` cannot produce tagged PDF; **PrinceXML** can. We need PrinceXML available without removing Grover (Grover stays the default for the bulk of content where accessibility is not required).
+2. **Format extensibility.** Future requirements include Microsoft Word (`.docx`), EPUB, and possibly alternative GDoc-style backends (OneDrive, Notion). Each addition should not require carving up `Exporters::*` again.
+3. **Distribution model.** Operators should be able to opt in to backends without forking the main repo. The existing [plugin system](../plugin-system.md) (`lib/plugins/<name>/`) is the right vehicle, but it needs a stable extension point — the current renderer call is hard-coded.
+
+The current code structure cannot accommodate any of these without invasive change every time:
+
+```ruby
+# lib/exporters/pdf/base.rb
+def export
+  Grover.new(pdf_content, **pdf_params).to_pdf  # hard-coded backend
+end
+```
+
+Adding Prince today would mean editing this file. Adding Word would mean creating a parallel `Exporters::Docx` tree with its own hard-coded backend. Each new backend is a merge-conflict surface for forks.
+
+## 2. Decision
+
+We introduce **per-format backend registries** as the single, generalizable extension point for output generation.
+
+- The **core app** owns the contract for each format: a value object for options, an abstract base class, a registry, and a default backend implementation.
+- **Plugins** in `lib/plugins/<name>/` register additional backends at boot. Each plugin lives in its own namespace and depends *only* on the core contract types.
+- **Jobs and exporter shells stay unchanged in shape**; the seam moves *inside* the exporter so the job layer never sees the swap.
+
+Two contract shapes are recognized — chosen per format, not per backend:
+
+| Contract      | Output                            | Examples                      |
+|---------------|-----------------------------------|-------------------------------|
+| **Renderer**  | `String` (file bytes)             | PDF, DOCX, EPUB, plain HTML   |
+| **Publisher** | external resource handle (id/URL) | Google Docs, OneDrive, Notion |
+
+PDF uses the Renderer contract. GDoc uses the Publisher contract. New formats pick whichever fits.
+
+## 3. Architecture
+
+### 3.1 Layering and dependency direction
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  JOBS LAYER  (app/jobs/)                                           │
+│    DocumentPdfJob   MaterialPdfJob   UnitBundlePdfJob   *GdocJob   │
+│                          │                                         │
+│                          ▼                                         │
+├────────────────────────────────────────────────────────────────────┤
+│  CORE EXPORTER LAYER  (lib/exporters/)                             │
+│                                                                    │
+│    Exporters::Base                                                 │
+│      ├─ Exporters::Pdf::Base ── builds RenderOptions               │
+│      │     └─ RendererRegistry.fetch(name).call(html, options:)    │
+│      └─ Exporters::Gdoc::Base ── builds PublishOptions             │
+│            └─ PublisherRegistry.fetch(name).publish(html, options:)│
+│                                                                    │
+│    PER-FORMAT CONTRACT (each format owns its trio)                 │
+│      Pdf::RenderOptions    Pdf::Renderers::Base    Pdf::Registry   │
+│      Gdoc::PublishOptions  Gdoc::Publishers::Base  Gdoc::Registry  │
+│                                                                    │
+│    DEFAULT BACKENDS (ship in core, registered at boot)             │
+│      Pdf::Renderers::Grover                                        │
+│      Gdoc::Publishers::GoogleDrive                                 │
+│                                                                    │
+│                          ▲ depends on / inherits from              │
+├──────────────────────────┼─────────────────────────────────────────┤
+│  PLUGIN LAYER            │  (lib/plugins/<name>/)                  │
+│                          │                                         │
+│    PrincePdf  ──────────►│  inherits Pdf::Renderers::Base          │
+│    DocxExport ──────────►│  defines Docx::Renderers::*             │
+│    EpubExport ──────────►│  defines Epub::Renderers::*             │
+│    OneDrive   ──────────►│  inherits Gdoc::Publishers::Base        │
+│                                                                    │
+│  Plugins NEVER appear in core code paths.                          │
+│  Discovery happens at runtime via the registries.                  │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+**Single dependency rule:** plugin → core. Core never imports, names, or branches on plugin code. The registry is the only contact surface, and it speaks in core types only.
+
+#### Component dependency graph
+
+The diagram below shows individual classes and how they connect. Edge styles encode the *kind* of dependency:
+
+- **Solid** (`──▶`) — runtime call / instantiation
+- **Dashed** (`╌▶`) — protocol satisfaction (`include`, inherit, *or* duck-typed implementation)
+- **Thick** (`══▶`) — boot-time registration with a registry
+
+```mermaid
+flowchart TB
+    %% =========== JOBS ===========
+    subgraph JOBS["Jobs · app/jobs/"]
+        direction LR
+        J1[DocumentPdfJob]
+        J2[MaterialPdfJob]
+        J3[UnitBundlePdfJob]
+        JG["DocumentGdocJob<br/>MaterialGdocJob"]
+    end
+
+    %% =========== CORE ===========
+    subgraph CORE["Core · lib/exporters/"]
+        direction TB
+        EB["Exporters::Base"]
+        PSReg["PluginSystem::Registry<br/>shared mixin"]
+
+        subgraph PDF["PDF format"]
+            direction TB
+            PB["Pdf::Base"]
+            PDM["Pdf::Document<br/>Pdf::Material"]
+            PRO["Pdf::RenderOptions<br/>value object"]
+            PRBase["Pdf::Renderers::Base<br/>abstract contract"]
+            PReg["Pdf::RendererRegistry"]
+            PGrover["Pdf::Renderers::Grover<br/>default backend"]
+        end
+
+        subgraph GDOC["GDoc format"]
+            direction TB
+            GB["Gdoc::Base"]
+            GDM["Gdoc::Document<br/>Gdoc::Material"]
+            GPO["Gdoc::PublishOptions"]
+            GPBase["Gdoc::Publishers::Base<br/>abstract contract"]
+            GReg["Gdoc::PublisherRegistry"]
+            GGoogle["Gdoc::Publishers::GoogleDrive<br/>default backend"]
+        end
+    end
+
+    %% =========== PLUGINS ===========
+    subgraph PLUGINS["Plugins · lib/plugins/"]
+        direction LR
+        subgraph PP["prince_pdf"]
+            PpR["PrincePdf::Renderer"]
+            PpT["PrincePdf::OptionsTranslator"]
+            PpE["PrincePdf::Executable"]
+        end
+        subgraph WP["weasy_pdf · future"]
+            WpR["WeasyPdf::Renderer"]
+        end
+        subgraph OD["one_drive · future"]
+            OdP["OneDrive::Publisher"]
+        end
+    end
+
+    %% --- Job → Exporter (runtime) ---
+    J1 --> PDM
+    J2 --> PDM
+    J3 --> PDM
+    JG --> GDM
+
+    %% --- Exporter inheritance (core) ---
+    PDM -.-> PB
+    PB  -.-> EB
+    GDM -.-> GB
+    GB  -.-> EB
+
+    %% --- Exporter uses contract types (runtime) ---
+    PB -->|builds| PRO
+    PB -->|fetch backend| PReg
+    GB -->|builds| GPO
+    GB -->|fetch backend| GReg
+
+    %% --- Default backends inherit Base (ergonomic) + register ---
+    PGrover -.inherits.-> PRBase
+    GGoogle -.inherits.-> GPBase
+    PGrover ==>|register at boot| PReg
+    GGoogle ==>|register at boot| GReg
+
+    %% --- Registries share the pattern ---
+    PReg -.includes.-> PSReg
+    GReg -.includes.-> PSReg
+
+    %% --- Plugin backends satisfy the protocol (inherit OR duck-type) ---
+    PpR -.satisfies.-> PRBase
+    WpR -.satisfies.-> PRBase
+    OdP -.satisfies.-> GPBase
+
+    %% --- Plugin internals ---
+    PpR --> PpT
+    PpR --> PpE
+
+    %% --- Plugins register at boot via setup! ---
+    PpR ==>|setup! registers| PReg
+    WpR ==>|setup! registers| PReg
+    OdP ==>|setup! registers| GReg
+
+    %% --- Styling ---
+    classDef jobBox      fill:#f3f4f6,stroke:#6b7280,color:#111827
+    classDef coreBox     fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a
+    classDef contractBox fill:#dcfce7,stroke:#15803d,color:#14532d
+    classDef defaultBox  fill:#fef3c7,stroke:#a16207,color:#713f12
+    classDef pluginBox   fill:#fce7f3,stroke:#be185d,color:#831843
+
+    class J1,J2,J3,JG jobBox
+    class EB,PB,PDM,GB,GDM coreBox
+    class PRO,PRBase,PReg,GPO,GPBase,GReg,PSReg contractBox
+    class PGrover,GGoogle defaultBox
+    class PpR,PpT,PpE,WpR,OdP pluginBox
+```
+
+Three properties are visible at a glance:
+
+1. **Every dashed protocol-satisfaction arrow points into core.** Plugins satisfy core contracts; core never satisfies plugin contracts. Whether a plugin gets there by inheriting `Renderers::Base` or by duck-typing the protocol directly is invisible to the registry.
+2. **Every thick registration arrow points into a registry.** Whether the source is a default backend (Grover, GoogleDrive) shipped in core or a plugin (PrincePdf, OneDrive), the entry path is identical: `Registry.register(...)` at boot, validated against the protocol.
+3. **Both formats share the same shape.** Replace `Pdf::*` with `Gdoc::*` and the topology is unchanged. Adding DOCX or EPUB later means stamping out a new green/amber column on the same template.
+
+### 3.2 Per-format registry, not a global one
+
+We deliberately do **not** introduce a single `Exporters::Registry` keyed by `(format, backend)`. Reasons:
+
+- Each format has its own option vocabulary (`RenderOptions` for PDF is meaningless for GDoc). A unified registry would force a lowest-common-denominator interface.
+- Keeping registries per format keeps each format's contract small and readable.
+- Plugins target one format; one registry to talk to.
+
+What is shared is the *pattern*. We codify it as a small mixin in `lib/plugin_system/registry.rb` (zero-cost, no behavior beyond storing/looking-up). Each format includes it.
+
+```ruby
+# lib/plugin_system/registry.rb (new, ~30 lines)
+module PluginSystem::Registry
+  def register(backend); ...; end
+  def fetch(identifier); ...; end
+  def available; ...; end          # registered AND backend.available?
+  def all; ...; end                # registered (regardless of availability)
+  def default; ...; end            # configurable per registry
+  def unregister(identifier); end  # for tests
+end
+```
+
+### 3.3 PDF Renderer contract (concrete)
+
+The contract is a **protocol**, not a class. The base class exists for ergonomics — plugins may inherit from it for sensible defaults, or implement the protocol directly. The registry verifies the protocol at registration time, so malformed backends fail loudly at boot rather than at first call.
+
+**The protocol**
+
+| Member                            | Kind            | Required                     | Purpose                                                                                                                                                                                           |
+|-----------------------------------|-----------------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `#call(html, options:) -> String` | instance method | **yes**                      | produce PDF bytes from HTML and a `RenderOptions`                                                                                                                                                 |
+| `.identifier -> Symbol`           | class method    | **yes**                      | stable name used for registration and selection                                                                                                                                                   |
+| `.capabilities -> Set<Symbol>`    | class method    | optional (default `Set.new`) | self-described capabilities for filtering / negotiation                                                                                                                                           |
+| `.available? -> Boolean`          | class method    | optional (default `true`)    | boot-time probe — binary present, license loaded, etc.                                                                                                                                            |
+| `.layout_name -> String`          | class method    | optional (default `"pdf"`)   | ERB layout the exporter should render before calling `#call`. The layout itself is responsible for branching on `@options[:accessibility]` to render `*_pdf_ua` partials when appropriate (§3.5). |
+
+Capability vocabulary (extensible): `:landscape`, `:tagged_pdf`, `:pdf_ua`, `:js_execution`, `:web_fonts`, `:running_headers`, `:background_print`, `:custom_script_hook` (renderer accepts a JS hook executed during rendering — Prince via `--script=`, Grover via Puppeteer evaluation).
+
+**`Exporters::Pdf::RenderOptions`** — frozen value object.
+
+```ruby
+RenderOptions = Data.define(
+  :format,            # "Letter" | "A4" | "Legal"
+  :landscape,         # Boolean
+  :margin,            # { top:, right:, bottom:, left: } in CSS units
+  :dpi,               # Integer or nil
+  :print_background,  # Boolean
+  :header_html,       # String or nil — running header
+  :footer_html,       # String or nil — running footer
+  :metadata,          # { title:, author:, lang: }
+  :accessibility,     # :none | :tagged | :pdf_ua
+  :extra              # Hash — backend-specific escape hatch
+)
+```
+
+**`Exporters::Pdf::Renderers::Base`** — ergonomic, opt-in. Provides defaults so plugin authors only override what they care about. Inheriting it is the recommended path; satisfying the protocol without inheriting it is fully supported.
+
+```ruby
+class Exporters::Pdf::Renderers::Base
+  def self.capabilities = Set.new
+  def self.available?   = true
+  def self.layout_name  = "pdf"
+  # No abstract method bodies. The registry enforces the protocol.
+end
+```
+
+**`Exporters::Pdf::RendererRegistry`** — runtime lookup, contract enforcer.
+
+```ruby
+module Exporters::Pdf::RendererRegistry
+  extend PluginSystem::Registry
+
+  REQUIRED_INSTANCE_METHODS = %i[call].freeze
+  REQUIRED_CLASS_METHODS    = %i[identifier].freeze
+
+  class RendererNotFound      < StandardError; end
+  class RendererUnavailable   < StandardError; end
+  class RenderError           < StandardError; end
+  class UnsupportedCapability < StandardError; end
+  class ContractViolation     < ArgumentError;  end
+end
+```
+
+`PluginSystem::Registry#register` calls `verify_contract!` against `REQUIRED_INSTANCE_METHODS` and `REQUIRED_CLASS_METHODS` before storing the backend. `default` reads `ENV["DEFAULT_PDF_RENDERER"]` and falls back to `:grover`.
+
+**`Exporters::Pdf::Renderers::Grover`** — default backend, lives in core.
+
+```ruby
+class Exporters::Pdf::Renderers::Grover < Exporters::Pdf::Renderers::Base
+  def self.identifier   = :grover
+  def self.capabilities = Set[:landscape, :js_execution, :web_fonts,
+                              :running_headers, :background_print]
+
+  def call(html, options:)
+    ::Grover.new(html, **translate(options)).to_pdf
+  end
+
+  private
+
+  def translate(opts)
+    {
+      format: opts.format,
+      landscape: opts.landscape,
+      margin: opts.margin,
+      print_background: opts.print_background,
+      display_header_footer: opts.header_html || opts.footer_html,
+      header_template: opts.header_html,
+      footer_template: opts.footer_html,
+      prefer_css_page_size: false
+    }.compact.merge(opts.extra || {})
+  end
+end
+```
+
+Registered in a new initializer:
+
+```ruby
+# config/initializers/pdf_renderers.rb
+Exporters::Pdf::RendererRegistry.register(Exporters::Pdf::Renderers::Grover)
+```
+
+**`Exporters::Pdf::Base`** — refactored seam.
+
+```ruby
+def export
+  renderer = RendererRegistry.fetch_for(identifier:    renderer_name,
+                                        accessibility: accessibility_level)
+  html     = render_template(template_path("show"), layout: renderer.class.layout_name)
+  renderer.call(html, options: render_options)
+end
+
+private
+
+def renderer_name
+  @options[:renderer]&.to_sym ||
+    (@document.respond_to?(:pdf_renderer) && @document.pdf_renderer&.to_sym) ||
+    RendererRegistry.default
+end
+
+def accessibility_level
+  return :pdf_ua if @options[:accessible_pdf] == true
+  @options[:accessibility]&.to_sym ||
+    (@document.respond_to?(:accessibility) && @document.accessibility&.to_sym) ||
+    :none
+end
+
+def render_options
+  RenderOptions.new(
+    format: "Letter",
+    landscape: @document.orientation == "Landscape",
+    print_background: true,
+    header_html: render_template(base_path("_header"), layout: "pdf_plain"),
+    footer_html: render_template(base_path("_footer"), layout: "pdf_plain"),
+    margin: margin_for(accessibility_level),
+    dpi:    @document.config[:dpi],
+    metadata: { title: @document.base_filename, lang: "en" },
+    accessibility: accessibility_level,
+    extra: {}
+  )
+end
+
+# Distinct margin set for accessible mode (validated pattern from dese-lcms).
+def margin_for(level)
+  level == :none ? @document.config[:margin] : @document.config[:margin_accessible] || @document.config[:margin]
+end
+```
+
+This is the only behavior change in core. Default output (Grover, `accessibility: :none`) is byte-identical to today.
+
+### 3.4 Plugin packaging convention
+
+Every backend plugin follows the same layout:
+
+```
+lib/plugins/<plugin_name>/
+  Gemfile                                # backend-specific gems
+  README.md                              # install, license, env vars
+  lib/
+    <plugin_name>.rb                     # module + setup! (registration)
+    <plugin_name>/
+      renderer.rb                        # or publisher.rb
+      options_translator.rb              # neutral options → backend flags
+      executable.rb                      # binary discovery, version probe
+  app/
+    views/
+      layouts/
+        <plugin_layout>.erb              # if backend needs a custom layout
+  sig/
+    <plugin_name>/                       # RBS signatures (discovered via
+      renderer.rbs                       # Steepfile glob lib/plugins/*/sig)
+      options_translator.rbs
+  spec/
+    services/<plugin_name>/...
+```
+
+Rules a plugin obeys:
+
+1. **Own its namespace.** `PrincePdf::*`, never `Exporters::Pdf::Renderers::Prince`.
+2. **Satisfy the renderer protocol.** Inheriting `Exporters::Pdf::Renderers::Base` is the easy path (sensible defaults, no boilerplate). Plugins may also implement the protocol directly without inheriting — useful for adapter-shaped wrappers around third-party gems, or when the plugin already has its own class hierarchy. The registry verifies either form at registration time.
+3. **Register in `setup!`.** No autoloading side effects; registration is the single boot-time act.
+4. **Probe in `available?`.** A registered-but-unavailable backend (binary missing, license absent) is allowed; the registry filters it out of `.available`.
+
+### 3.5 Accessibility flow
+
+Accessibility is **orthogonal to renderer selection** in the architecture, but they interact at one point: not every renderer can satisfy every accessibility level. The flow keeps the three concerns — caller intent, renderer capability, template variant — explicit and separately resolvable.
+
+**Audience clarification.** "Caller intent" here means the *programmatic caller* — exporter, job, or plugin code — not an end user. Renderer choice and accessibility level are **not** surfaced as core-controller params or core admin forms. They are programmatic seams that case-b plugins (bespoke per-project bundle assembly) use to route different pieces of a bundle to different renderers. The only user-facing renderer-selection surface is the project default, set in settings (§4.3). See §3.0-equivalent framing summarized in §4.3 "Selection surfaces."
+
+**Three orthogonal axes**
+
+| Axis             | Values                                   | Source                                                                                                                |
+|------------------|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| Renderer         | `:grover`, `:prince`, …                  | `options[:renderer]` → `Document#pdf_renderer` (plugin-defined accessor, absent in core) → `RendererRegistry.default` |
+| Accessibility    | `:none`, `:tagged`, `:pdf_ua`            | `options[:accessibility]` → `Document#accessibility` (plugin-defined accessor, absent in core) → `:none`              |
+| Template variant | regular partials, `*_pdf_ua` partials, … | derived from accessibility level inside the layout (not selected by the exporter)                                     |
+
+**Programmatic caller surface**
+
+The forms below are how plugin code or scripted jobs invoke the exporter. They are not how end users or admins request a renderer — that's the project default (§4.3).
+
+```ruby
+# Explicit (plugin code, scripted bulk jobs)
+DocumentPdfJob.perform_later(doc.id, content_type: "lesson",
+                             renderer: :prince,
+                             accessibility: :pdf_ua)
+
+# Shorthand (matches dese-lcms naming, ergonomic for the common case)
+DocumentPdfJob.perform_later(doc.id, content_type: "lesson",
+                             accessible_pdf: true)
+# Internally normalized: accessible_pdf: true → accessibility: :pdf_ua
+
+# Per-record (plugin-set, e.g. at import time by a case-b plugin)
+# Requires a plugin to extend Document with an `accessibility` accessor
+# that reads from metadata; core models do not define this method.
+doc.update!(metadata: doc.metadata.merge("accessibility" => "pdf_ua"))
+```
+
+Resolution order inside `Exporters::Pdf::Base#render_options` (analogous to renderer resolution):
+
+```ruby
+def accessibility_level
+  return :pdf_ua if @options[:accessible_pdf] == true        # shorthand
+  @options[:accessibility]&.to_sym ||
+    (@document.respond_to?(:accessibility) && @document.accessibility&.to_sym) ||
+    :none
+end
+```
+
+**Constraint enforcement at the registry**
+
+The registry fetches by identifier *and* required capabilities. Asking for an accessible PDF from a non-accessible renderer fails fast with a clear error, not a silent compliance bug:
+
+```ruby
+module Exporters::Pdf::RendererRegistry
+  CAPABILITY_FOR_ACCESSIBILITY = {
+    none:   [],
+    tagged: [:tagged_pdf],
+    pdf_ua: [:pdf_ua]
+  }.freeze
+
+  def self.fetch_for(identifier:, accessibility: :none)
+    backend = fetch(identifier)
+    required = CAPABILITY_FOR_ACCESSIBILITY.fetch(accessibility)
+    missing  = required - backend.class.capabilities.to_a
+    return backend if missing.empty?
+    raise UnsupportedCapability,
+          "#{identifier} cannot satisfy accessibility=#{accessibility} " \
+          "(missing capabilities: #{missing.join(', ')})"
+  end
+end
+```
+
+`Exporters::Pdf::Base#export` calls `fetch_for(identifier: renderer_name, accessibility: accessibility_level)` instead of plain `fetch`. The exporter never produces a PDF that silently fails its accessibility contract.
+
+**Template branching at the layout level**
+
+Templates do **not** branch inside the exporter. The layout the renderer declares (`Renderer.layout_name`) is responsible for rendering the right partials based on `@options[:accessibility]`. Concretely:
+
+```erb
+<%# app/views/layouts/pdf_prince.erb (shipped by prince_pdf plugin) %>
+<% if @options[:accessibility] == :pdf_ua %>
+  <%= render "components/overview_pdf_ua" %>
+<% else %>
+  <%= render "components/overview" %>
+<% end %>
+```
+
+Why the layout and not the exporter:
+
+- The exporter has no business knowing which partials map to which accessibility level — that's an authoring concern owned by templates.
+- A renderer's layout *is* the contract for "what HTML this backend expects." If Prince needs PDF/UA partials, that knowledge belongs in `pdf_prince.erb`, not in `Pdf::Document`.
+- Adds no public API surface — an empty `_*_pdf_ua.html.erb` set is a no-op default; the partial fork is purely additive when an operator chooses to author one.
+
+**Auto-renderer-by-capability (rejected for v1)**
+
+A tempting shortcut: if the caller says `accessibility: :pdf_ua` but doesn't specify a renderer, the registry could auto-pick the first registered renderer with `:pdf_ua` capability. **Rejected for v1.** Implicit renderer selection on accessibility-required output is exactly the kind of thing that produces "it worked locally, why is the prod PDF watermarked?" tickets. Operators must opt in to a renderer; if they want `:prince` to be the auto-default for accessible output, they set `DEFAULT_PDF_RENDERER=prince` and we let the explicit chain do its job.
+
+### 3.6 Type signatures (RBS)
+
+The contract is the protocol; the protocol is the surface that benefits most from typing. Sister project `dese-lcms` uses RBS + Steep actively (`Steepfile` + full `sig/` tree mirroring `lib/`). lcms-core has `gem "rbs_rails"` and `gem "steep"` in the development group but no `Steepfile` or `sig/` yet — the tooling is queued, the infrastructure isn't wired up.
+
+This ADR ships RBS signatures for the contract types so they are typed from day one. Activating Steep in lcms-core (Stage A.1 in §9) is a one-time small step — Steepfile + `sig/` discovery — and is forward-compatible with whatever broader RBS rollout the team chooses.
+
+**`sig/lib/exporters/pdf/render_options.rbs`**
+
+```rbs
+module Exporters
+  module Pdf
+    class RenderOptions
+      type accessibility = :none | :tagged | :pdf_ua
+      type margin_box   = { top: String, right: String, bottom: String, left: String }
+
+      attr_reader format: String
+      attr_reader landscape: bool
+      attr_reader margin: margin_box
+      attr_reader dpi: Integer?
+      attr_reader print_background: bool
+      attr_reader header_html: String?
+      attr_reader footer_html: String?
+      attr_reader metadata: Hash[Symbol, untyped]
+      attr_reader accessibility: accessibility
+      attr_reader extra: Hash[Symbol, untyped]
+    end
+  end
+end
+```
+
+**`sig/lib/exporters/pdf/renderers/base.rbs`**
+
+```rbs
+module Exporters
+  module Pdf
+    module Renderers
+      class Base
+        def call: (String html, options: RenderOptions) -> String
+        def self.identifier: () -> Symbol
+        def self.capabilities: () -> Set[Symbol]
+        def self.available?: () -> bool
+        def self.layout_name: () -> String
+      end
+    end
+  end
+end
+```
+
+**`sig/lib/exporters/pdf/renderer_registry.rbs`**
+
+```rbs
+module Exporters
+  module Pdf
+    module RendererRegistry
+      interface _Renderer
+        def call: (String, options: RenderOptions) -> String
+      end
+
+      class RendererNotFound      < StandardError end
+      class RendererUnavailable   < StandardError end
+      class RenderError           < StandardError end
+      class UnsupportedCapability < StandardError end
+      class ContractViolation     < ArgumentError end
+
+      CAPABILITY_FOR_ACCESSIBILITY: Hash[Symbol, Array[Symbol]]
+      REQUIRED_INSTANCE_METHODS:    Array[Symbol]
+      REQUIRED_CLASS_METHODS:       Array[Symbol]
+
+      def self.register: (Class | _Renderer) -> void
+      def self.unregister: (Symbol) -> void
+      def self.fetch: (Symbol identifier) -> _Renderer
+      def self.fetch_for: (identifier: Symbol, ?accessibility: Symbol) -> _Renderer
+      def self.available: () -> Array[Symbol]
+      def self.all:       () -> Array[Symbol]
+      def self.default:   () -> Symbol
+    end
+  end
+end
+```
+
+**Plugin signature** — co-located with the plugin (`lib/plugins/prince_pdf/sig/`), discovered via a Steepfile glob. Lifts the dese-lcms shape almost verbatim:
+
+```rbs
+# lib/plugins/prince_pdf/sig/prince_pdf/renderer.rbs
+module PrincePdf
+  class Renderer < ::Exporters::Pdf::Renderers::Base
+    def self.identifier:   () -> Symbol
+    def self.layout_name:  () -> String
+    def self.capabilities: () -> Set[Symbol]
+    def self.available?:   () -> bool
+    def call: (String html, options: ::Exporters::Pdf::RenderOptions) -> String
+  end
+
+  class OptionsTranslator
+    def initialize: (::Exporters::Pdf::RenderOptions) -> void
+    def to_args:    () -> Array[String]
+  end
+
+  module Executable
+    def self.present?: () -> bool
+    def self.path:     () -> String?
+  end
+end
+```
+
+**Steepfile additions**
+
+```ruby
+# Steepfile (new file)
+target :lib do
+  signature "sig", "lib/plugins/*/sig"   # core sig + plugin sigs
+  check "lib"
+  library "net-http", "set"
+end
+```
+
+This mirrors dese-lcms's `Steepfile` shape, with one extension: a glob over `lib/plugins/*/sig` so plugin signatures are discovered without naming each plugin. Plugin-shipped signatures travel with the plugin directory and are checked alongside core in one Steep run.
+
+## 4. Worked example: PrincePdf plugin
+
+Path: `lib/plugins/prince_pdf/`. Ships in this repo (out-of-the-box), not as a submodule.
+
+### 4.1 Files
+
+```
+lib/plugins/prince_pdf/
+  Gemfile                                # backend-specific gems (none required; system binary)
+  README.md
+  lib/
+    prince_pdf.rb
+    prince_pdf/
+      renderer.rb
+      options_translator.rb
+      executable.rb
+      assets/
+        prince_xml.css                   # PDF/UA tagging stylesheet
+        prince_xml_landscape.css
+        prince_xml_portrait.css
+        prince_xml.js                    # custom JS hook
+  app/
+    views/
+      layouts/
+        pdf_prince.erb                   # @page CSS, lang, accessibility-aware partial selection
+  sig/
+    prince_pdf/
+      renderer.rbs
+      options_translator.rbs
+      executable.rbs
+  spec/
+    services/prince_pdf/renderer_spec.rb        # Open3 stubbed
+    services/prince_pdf/options_translator_spec.rb
+    integration/prince_pdf_spec.rb              # gated on PRINCE_EXECUTABLE_PATH
+```
+
+System-level provisioning (the `prince` .deb install for Docker and Cloud66) lives in the **main repo**, not under the plugin — see §4.4 for the rationale.
+
+### 4.2 Code
+
+```ruby
+# lib/plugins/prince_pdf/lib/prince_pdf.rb
+module PrincePdf
+  def self.setup!
+    Exporters::Pdf::RendererRegistry.register(Renderer)
+    PluginSystem.logger.info \
+      "[PrincePdf] :prince renderer registered (available=#{Renderer.available?})"
+  end
+end
+
+# lib/plugins/prince_pdf/lib/prince_pdf/renderer.rb
+# Path A — recommended: inherit Base for default capabilities/available?/layout_name,
+# override only what differs. Command shape and flags are validated by the
+# production implementation in the dese-lcms project (Prince 16.1, PDF/UA-1).
+module PrincePdf
+  class Renderer < Exporters::Pdf::Renderers::Base
+    def self.identifier   = :prince
+    def self.layout_name  = "pdf_prince"
+    def self.capabilities = Set[:landscape, :tagged_pdf, :pdf_ua,
+                                :running_headers, :web_fonts,
+                                :js_execution, :custom_script_hook]
+
+    def self.available?
+      Executable.present?
+    end
+
+    def call(html, options:)
+      args = OptionsTranslator.new(options).to_args
+      stdout, stderr, status = Open3.capture3(*args, stdin_data: html)
+      raise Exporters::Pdf::RendererRegistry::RenderError, stderr unless status.success?
+      stdout
+    end
+  end
+end
+
+# OptionsTranslator produces a command of the validated shape:
+#
+#   prince - --output=-                                # stdin → stdout
+#   --license-file=<PRINCE_LICENSE_PATH>               # if configured
+#   --style=prince_xml.css                             # tagging stylesheet (PDF/UA)
+#   --style=prince_xml_<orientation>.css               # orientation-specific
+#   --page-margin="<top> <right> <bottom> <left>"
+#   --script=prince_xml.js                             # custom JS hook
+#   --javascript                                       # enable JS execution
+#   --http-timeout=30
+#   --pdf-profile=PDF/UA-1                             # iff RenderOptions#accessibility == :pdf_ua
+```
+
+**`OptionsTranslator` accessibility mapping**
+
+```ruby
+def accessibility_args(options)
+  case options.accessibility
+  when :none   then []
+  when :tagged then ["--tagged-pdf"]                # tagged but not certified PDF/UA
+  when :pdf_ua then ["--pdf-profile=PDF/UA-1"]      # certified profile
+  else raise ArgumentError, "unknown accessibility level: #{options.accessibility}"
+  end
+end
+```
+
+Grover's translator does the same in reverse: any non-`:none` accessibility raises (Grover's capabilities don't include `:tagged_pdf` or `:pdf_ua`), but in practice the registry's `fetch_for` rejects this combination earlier (§3.5), so the renderer never sees it.
+
+A protocol-only equivalent (no inheritance) is equally valid — useful when wrapping a third-party object or when the plugin already has its own class hierarchy:
+
+```ruby
+# Path B — protocol only, no coupling to Renderers::Base.
+module WeasyPdf
+  class Renderer
+    def self.identifier   = :weasy
+    def self.capabilities = Set[:tagged_pdf, :web_fonts]
+    def self.available?   = system("weasyprint --version > /dev/null 2>&1")
+    def self.layout_name  = "pdf_weasy"
+
+    def call(html, options:); ...; end
+  end
+end
+```
+
+The registry's `verify_contract!` accepts either form and rejects anything that misses `#call` or `.identifier`.
+
+### 4.3 Configuration surface
+
+| Variable                 | Purpose                                                                                                                    |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `DEFAULT_PDF_RENDERER`   | Global default. Defaults to `:grover`.                                                                                     |
+| `PRINCE_EXECUTABLE_PATH` | Path to `prince` binary (default: `/usr/bin/prince` after .deb install).                                                   |
+| `PRINCE_LICENSE_PATH`    | Absolute path to `license.dat`; if unset, Prince looks in its install directory. Without a license, output is watermarked. |
+| `PRINCE_HTTP_TIMEOUT`    | Override default `--http-timeout=30` for remote-resource fetches.                                                          |
+
+Plugin exposes a configuration block consumed in an initializer:
+
+```ruby
+# config/initializers/prince_pdf.rb (auto-loaded by plugin Gemfile chain)
+PrincePdf::Renderer.configure do |c|
+  c.license_file = ENV.fetch("PRINCE_LICENSE_PATH", nil)
+end
+```
+
+On Cloud66, the validated convention (from dese-lcms) is to store the license at `$STACK_BASE/shared/princexml/license.dat` and set `PRINCE_LICENSE_PATH` accordingly. The plugin README documents this verbatim.
+
+**Selection surfaces (two-tier model)**
+
+Renderer selection in lcms-core core follows a deliberate two-tier split. Conflating the tiers leads to wasted scope (e.g. building admin UI for a per-record toggle that should live in a plugin).
+
+| Tier                              | Audience         | Where it lives                                                                                                                                                   | How it's set                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|-----------------------------------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Project default**               | Admin / operator | Settings UI (deferred to the `config/pdf.yml → DB` follow-up scope); interim mechanism is the `DEFAULT_PDF_RENDERER` env var read by `RendererRegistry.default`. | Picked from the list of registered renderers. The only renderer-selection surface exposed in core UI.                                                                                                                                                                                                                                                                                                                                                                         |
+| **Per-call / per-record routing** | Plugin code      | `options[:renderer]` / `options[:accessibility]` at the exporter call site, or a plugin-defined `pdf_renderer` / `accessibility` accessor on Document/Material.  | Case-b plugins (per-project bundle assembly) write these to route specific pieces of a bundle to specific renderers — for example, bundling forces a single Prince pass over composed HTML because PDF/UA tags don't survive PDF concatenation, so the plugin sets the renderer explicitly when assembling the bundle. Core models do not define `pdf_renderer` / `accessibility` accessors; a plugin opts in by extending them with methods that read from `metadata` jsonb. |
+
+Resolution order in `Exporters::Pdf::Base` is preserved: option → record → default. The combination is validated by `RendererRegistry.fetch_for` before any HTML is rendered (§3.5). Real columns for `pdf_renderer` / `accessibility` can be promoted later if a plugin needs persistence ergonomics beyond jsonb metadata.
+
+**What this rules out for core:**
+- No `?type=pdf_ua` or similar query-param plumbing in public controllers (that's a dese-lcms case-b artifact).
+- No "PDF / PDF/UA" two-button UX on documents/materials show pages.
+- No admin form fields for per-document renderer/accessibility metadata.
+These belong inside a case-b plugin if a downstream project needs them.
+
+### 4.4 Docker and Cloud66 integration
+
+System-level dependencies for plugins (Prince's .deb being the only current example) are installed by the **main repo**, not by the plugin folder. Two surfaces:
+
+- **Docker** — `Dockerfile.dev` contains a multi-arch RUN block (amd64 + arm64) that detects the build architecture and installs the matching `prince_16-1_debian12_*.deb`. Base image is pinned to `ruby:3.4.7-slim-bookworm` because Prince's bookworm package depends on libs (`libavif15`, etc.) that trixie has replaced. An `apt-get update` is required inside the install layer because the previous layer wipes `/var/lib/apt/lists`.
+- **Cloud66** — `.cloud66/scripts/install-prince-xml.sh` is wired as a `first_thing` deploy hook in `.cloud66/deploy_hooks.yml` with `apply_during: all`. The script is idempotent (skips if `prince` is already on PATH), detects ubuntu22.04 vs debian12 from `/etc/os-release`, picks the matching .deb, and installs `wget`/`gdebi` on demand.
+
+**Why not in the plugin folder?**
+
+A plugin-local installer model was considered and rejected for v1. A central convention (e.g. `lib/plugins/*/provision/docker.sh` iterated from `Dockerfile.dev`, driven by a YAML manifest of enabled plugins) is technically clean, but:
+
+- **Build time and runtime live in different process scopes.** The Ruby plugin registry doesn't exist when `docker build` runs; any iteration has to be shell- or pure-Ruby-without-Rails. That's not insurmountable, but it adds a second discovery layer separate from `PluginSystem.load_all`.
+- **Auditability vs self-containment.** A single Dockerfile.dev block is easier to reason about than a scanner that fans out into per-plugin scripts; cache invalidation behaves more predictably; install order is explicit if plugins ever inter-depend.
+- **Plugin count.** With one plugin today, the central declaration is clearer than a scanning convention. The break-even is somewhere around 3+ plugins shipping their own provisioning.
+
+When that threshold is crossed — or when a fork wants to drop a plugin in without editing main-repo files — this decision should be revisited. The plugin folder layout deliberately leaves room for it (no provisioning files exist now; adding a `provision/` subdir later is non-breaking).
+
+**Availability gating**
+
+If the install steps fail or are skipped on a given host, `Renderer.available?` returns `false`, the registry filters `:prince` out of `.available`, and any record asking for `:prince` fails fast with `RendererUnavailable` — silent fallback to Grover is not allowed.
+
+### 4.5 Implementation patterns validated by dese-lcms
+
+A working PrinceXML integration ships in [`~/Projects/LT/dese-lcms`](../../../dese-lcms/). It validates the renderer mechanics this ADR proposes, while taking a different (lighter) integration path. Concrete patterns to lift:
+
+| Pattern                                     | What it is                                                                                                                                                                  | How it informs the plugin                                                                                                                                                |
+|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **CSS-driven PDF/UA tagging**               | `prince_xml.css` declares `prince-pdf-tag-type: Part \| Sect \| H2 \| H3 \| P \| L \| LI \| Lbl \| LBody \| Artifact` for each semantic role.                               | The plugin must ship a tagging stylesheet, not just a layout. Tagging is a CSS responsibility, not a renderer-flag responsibility.                                       |
+| **Decorative-image affordance**             | `application_helper` adds an `icon-as-artifact` CSS class so decorative images map to PDF Artifact (skipped by screen readers).                                             | Plugin should expose a small helper module that the host app can include into its `ApplicationHelper` to mark decorative content.                                        |
+| **Per-orientation stylesheet**              | `prince_xml_landscape.css` / `prince_xml_portrait.css` loaded conditionally via `--style=`.                                                                                 | `OptionsTranslator` selects orientation CSS based on `RenderOptions#landscape`.                                                                                          |
+| **Custom JS hook**                          | `--script=prince_xml.js` — a Prince-specific JS file that runs inside the rendering context. Used for runtime DOM tweaks Prince needs but the host templates can't bake in. | Plugin ships `prince_xml.js`; tests assert it's loaded via `--script=`.                                                                                                  |
+| **Distinct margin set for accessible mode** | `gutter_margins_for(:margin_accessible, ...)` returns different values from the regular `:margin` key.                                                                      | When `RenderOptions#accessibility != :none`, source the margin set from a separate config branch. Forwards-compatible with the upcoming `config/pdf.yml` → DB migration. |
+| **Template fork at the partial level**      | Every PDF component has a `_*_pdf_ua.html.erb` sibling (12+ partials in dese-lcms across clusters/units).                                                                   | **Scope flag.** Stage B's "ship a Prince layout" understates the work. Plan for one partial fork per PDF component. Migration plan §9 updated.                           |
+| **Eliminates post-processing tooling**      | Switching to Prince let dese-lcms delete the entire `pdf_meta_tool` (PDF metadata injection) and an HTML pre-processor (`convert_ol_to_div` for `<ol>` rendering).          | Concrete positive consequence: a real paged-media engine reduces the surrounding tool surface. Recorded in §7.                                                           |
+| **Open3 + stdin/stdout**                    | `Open3.capture3("prince", "-", "--output=-", *flags, stdin_data: html)`. No temp files.                                                                                     | The plugin's `Executable` wraps exactly this. Tested with Open3 stubbed (see [dese-lcms spec](../../../dese-lcms/spec/lib/lcms/engine/renderer/prince_xml_spec.rb)).     |
+| **Configuration class with env fallback**   | `PrinceXml::Configuration` + `.configure { \|c\| c.license_file = ENV.fetch(...) }`.                                                                                        | Plugin uses the same shape; initializer reads `PRINCE_LICENSE_PATH`.                                                                                                     |
+
+The dese-lcms integration **predates this ADR** and uses a direct branch in `Exporters::Pdf::Base#export` (`if accessible_pdf? then PrinceXml.new.pdf_from_string ...`). It works because there are exactly two renderers and no per-record renderer selection — the option flag `type: "pdf_ua"` doubles as content type and renderer identifier. That approach is recorded in §8 (Alternative G) as the design we deliberately step away from for `lcms-core`. The renderer class itself is fully reusable; the *integration path* is what changes.
+
+## 5. Extension catalog
+
+The same registry pattern accommodates all near- and mid-term needs.
+
+### 5.1 Alternative PDF backends — same registry
+
+Adding **WeasyPrint** or **wkhtmltopdf**: a new plugin under `lib/plugins/`, a new `Renderer < Exporters::Pdf::Renderers::Base`, register in `setup!`. No core change.
+
+### 5.2 New format: DOCX (Microsoft Word)
+
+DOCX is a Renderer-shaped format (HTML in, bytes out). It needs a parallel trio in core:
+
+```
+lib/exporters/docx/
+  base.rb                          # Exporters::Docx::Base < Exporters::Base
+  document.rb
+  material.rb
+  render_options.rb
+  renderer_registry.rb
+  renderers/
+    base.rb
+    pandoc.rb                      # default if we pick one to ship
+```
+
+Plus jobs (`DocumentDocxJob`, `MaterialDocxJob`) modeled on the PDF jobs.
+
+Plugins for DOCX: `lib/plugins/libreoffice_docx/`, `lib/plugins/caracal_docx/`, etc. Each registers an alternative `Docx::Renderers::Base` subclass.
+
+The **format trio (RenderOptions, Renderers::Base, RendererRegistry) is duplicated** for each new format — intentionally. Each format's option vocabulary differs.
+
+### 5.3 New format: EPUB
+
+Identical shape to DOCX. `Exporters::Epub::*`, default backend (e.g. `gepub`), plugins for alternatives.
+
+### 5.4 GDoc — Publisher contract variant
+
+GDoc is **not** a Renderer. It does not return bytes; it creates an external resource and returns a handle.
+
+```ruby
+class Exporters::Gdoc::Publishers::Base
+  def publish(html, options:)
+    # => Exporters::Gdoc::Result.new(id:, url:)
+  end
+  def self.identifier; end
+  def self.available?; true; end
+end
+```
+
+Default backend `Exporters::Gdoc::Publishers::GoogleDrive` (extracted from current `Exporters::Gdoc::Base`). Plugins can add `OneDrivePublisher`, `NotionPublisher`, etc.
+
+The Publisher contract differs from Renderer in:
+- Return type (`Result` value object instead of bytes)
+- Side effects allowed (network, external resource creation)
+- Options shape (`PublishOptions` includes folder ID, file ID for updates, retry policy)
+
+But the **registry mechanics are identical** — `PluginSystem::Registry` mixin, `register/fetch/available/default`, plugin lifecycle, namespace rules.
+
+### 5.5 Comparison table
+
+| Format | Contract  | Default backend (core) | Example plugin backends             |
+|--------|-----------|------------------------|-------------------------------------|
+| PDF    | Renderer  | Grover                 | PrincePdf, WeasyPdf, WkhtmltopdfPdf |
+| DOCX   | Renderer  | Pandoc / Caracal       | LibreOfficeDocx                     |
+| EPUB   | Renderer  | Gepub                  | CalibreEpub                         |
+| GDoc   | Publisher | GoogleDrive            | OneDrivePublisher, NotionPublisher  |
+| HTML   | Renderer  | (trivial passthrough)  | —                                   |
+
+## 6. Plugin lifecycle
+
+| Phase                          | What happens                                                                                                                                                                                           |
+|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Boot — Rails initializers      | Core registers default backends (`Renderers::Grover`, `Publishers::GoogleDrive`).                                                                                                                      |
+| Boot — `PluginSystem.load_all` | Each plugin's main module is constantized; `setup!` runs and calls `Registry.register(Backend)`.                                                                                                       |
+| Boot — log line                | `[PluginSystem] Loaded N plugin(s): ...`                                                                                                                                                               |
+| Per-job runtime                | Exporter resolves backend name (option > record field > registry default) and calls `Registry.fetch(name).call/publish`.                                                                               |
+| Backend unavailable            | `Registry.fetch` raises `BackendUnavailable`. **No silent fallback.** Optional opt-in `fallback_to_default: true` per call for non-critical paths.                                                     |
+| Plugin removal                 | Delete `lib/plugins/<name>/`, remove plugin's gem entries, restart. Registry forgets the backend; records still pointing at it surface `BackendNotFound` on next render — correct behavior, not a bug. |
+
+**Fail-fast on unavailability.** A `:prince` request silently falling back to `:grover` would produce a non-accessible PDF for an accessibility-required record. That is a correctness bug, not a graceful degradation.
+
+## 7. Consequences
+
+### Positive
+
+- **One seam, one rule.** Adding a backend never edits jobs, exporters, or other plugins.
+- **Plugin removability.** Deleting a plugin directory leaves no dangling references in core.
+- **Testable in isolation.** Each backend takes HTML + options and returns bytes (or a Result). Trivial to unit-test with stubbed binaries / network.
+- **Capability negotiation.** Admin UI can filter renderers by capability (e.g., only show `:tagged_pdf`-capable backends for accessibility-required records).
+- **Format symmetry.** PDF, DOCX, EPUB, GDoc, future formats all follow one of two contract shapes.
+- **Fork-friendly.** Forks add private backends without touching core files; merge surface is unchanged.
+- **Decoupled from config source-of-truth.** Renderers consume `RenderOptions`. Whether those values originate from `config/pdf.yml`, jsonb metadata on a record, or a future DB-backed Setting model is transparent to every backend. The upcoming migration of `config/pdf.yml` to the database (next planned task after this ADR) requires zero changes inside any renderer.
+- **Protocol-based, not inheritance-based.** Plugins satisfy a small protocol (`#call`, `.identifier`, optionally `.capabilities`/`.available?`/`.layout_name`); inheriting `Renderers::Base` is a convenience, not a requirement. Plugins keep their own class hierarchy; the registry validates contract compliance at boot, so violations surface immediately and clearly. Coupling between plugin and core is exactly the protocol — no more, no less.
+- **Reduces surrounding tool surface.** A real paged-media renderer (Prince) absorbs work that previously needed standalone post-processing tools. dese-lcms removed `pdf_meta_tool` (PDF metadata injection) and an HTML pre-processor (`convert_ol_to_div` for ordered-list rendering quirks) when it adopted Prince. Adopting it here is expected to do the same.
+
+### Negative
+
+- **Format trio duplication.** Each new format duplicates the `(Options, Backend::Base, Registry)` trio. This is deliberate (each format has its own option vocabulary), but it is real boilerplate. A code generator (`rails g exporter:format <name>`) could mitigate later if the count grows.
+- **Two contract shapes (Renderer vs Publisher), not one.** A single uniform interface would be simpler in some respects but would force GDoc and PDF to share a contract that fits neither well. The duplication is the lesser evil.
+- **Layout-name leak.** The renderer declares its preferred ERB layout (`Renderer.layout_name`). This is a small coupling between rendering backend and view layer. Acceptable; alternatives (template inheritance, view-resolver chains) cost more.
+- **Out-of-the-box plugin ≠ free.** PrincePdf shipping in-tree does not ship the Prince binary or license. The README must communicate this loudly.
+
+## 8. Alternatives considered
+
+### A. Subclass and override the exporter directly
+
+Plugin defines `Exporters::Pdf::Prince::Document` and a job picks it. **Rejected:** jobs become aware of backends; switching renderer per record requires mutating the job; Zeitwerk autoload paths get awkward for cross-tree namespaces.
+
+### B. Single global `Exporters::Registry` keyed by `(format, backend)`
+
+Rejected for the option-vocabulary reason in §3.2. Unified key buys polymorphism we don't actually use; PDF jobs never call DOCX backends.
+
+### C. Strategy injection at the job level
+
+Job receives `renderer_class:` argument and instantiates it. Rejected: pushes backend selection into every caller; doesn't support per-record selection without job-level coupling; loses the runtime registry for capability discovery.
+
+### D. Rack-style middleware chain for rendering
+
+Pipeline of "transformers" that incrementally turn a Document into bytes. **Rejected as premature.** No current need; can be retrofitted inside a single Renderer if a backend ever wants pipelining internally.
+
+### E. Use Action Dispatch's MIME type / responder system
+
+Tempting (Rails-native, well-known). Rejected: MIME types describe what a *controller* responds with for HTTP, not how an export job picks among multiple backends for the same MIME type. We need named backends inside one MIME type.
+
+### F. Make `Renderers::Base` mandatory (inheritance-required contract)
+
+Earlier draft of this ADR required `class PrincePdf::Renderer < Exporters::Pdf::Renderers::Base`. **Rejected** in favor of a protocol checked by the registry. Inheritance-as-requirement creates a hard load-time dependency on a core class, forecloses a plugin's other inheritance choices (single-inheritance Ruby), and silently breaks plugins when `Base` grows new abstract methods. The protocol-with-optional-base design preserves the ergonomic path for the common case while keeping coupling at the protocol level.
+
+### G. Direct branch in `Base#export` (the dese-lcms pattern)
+
+Production reference implementation in `dese-lcms` selects the renderer with a direct conditional:
+
+```ruby
+# dese-lcms: lib/dese/exporters/pdf/base.rb
+if accessible_pdf?
+  ::Lcms::Engine::Renderer::PrinceXml.new.pdf_from_string(content, params)
+else
+  WickedPdf.new.pdf_from_string(content, params)
+end
+```
+
+`accessible_pdf?` is `@options[:type] == "pdf_ua"`. Selection is one boolean; the renderer is hard-coded into both branches.
+
+**Why this works for dese-lcms:** exactly two renderers, no per-record selection beyond the type flag, single tenant of the codebase. Adding a third renderer or per-record renderer choice would require expanding the conditional and propagating it into 5+ exporter subclasses (`cluster_level_material`, `unit_level_material`, `material`, `assessment_lesson`, `master_copies` all carry the same `if accessible_pdf?` branching today).
+
+**Why we reject it for `lcms-core`:** lcms-core is the upstream consumed by multiple forks. Branches in core code force every fork to merge through the same conditional whenever a new renderer is added; a registry localizes the change to one `register` call. The dese-lcms renderer code itself remains useful — only the integration path differs.
+
+## 9. Migration plan
+
+| Stage                                   | Scope                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Behavior change                                           |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| **A** Core refactor                     | Add `RenderOptions`, `Renderers::Base` (ergonomic, opt-in), `RendererRegistry` with protocol verifier, `Renderers::Grover`. Refactor `Exporters::Pdf::Base#export` to use the registry. Register `:grover` in initializer.                                                                                                                                                                                                                                                                                           | None — output is byte-identical.                          |
+| **A.1** Activate Steep                  | Add `Steepfile` (mirrors dese-lcms shape; signature globs include `lib/plugins/*/sig`). Add `sig/lib/exporters/pdf/{render_options,renderer_registry,renderers/base}.rbs` covering Stage A's contract types. Wire `bundle exec steep check` into the pre-push or CI pipeline.                                                                                                                                                                                                                                        | None at runtime; type-checking pipeline gains a baseline. |
+| **B** Plugin: `prince_pdf`              | New plugin under `lib/plugins/`. `setup!` registers `:prince`. Renderer + `OptionsTranslator` + `Executable` (lifted from dese-lcms reference impl). Ships `prince_xml.css` (PDF/UA tagging), `prince_xml_landscape.css`, `prince_xml_portrait.css`, `prince_xml.js` (custom hook), Dockerfile snippet, install script, README, `sig/prince_pdf/*.rbs`. Specs with `Open3` stubbed. **Template authoring is a separate non-trivial scope item**: each PDF component needs a `_*_pdf_ua.html.erb` partial — see §4.5. | None until a record opts in.                              |
+| **C** Selection surface                 | Add `Document#pdf_renderer` reader (jsonb-backed). Document admin instructions.                                                                                                                                                                                                                                                                                                                                                                                                                                      | None until an admin sets it.                              |
+| **D** Generalize: shared registry mixin | Extract `PluginSystem::Registry`. PDF registry uses it.                                                                                                                                                                                                                                                                                                                                                                                                                                                              | None.                                                     |
+| **E** GDoc parity (deferred)            | Apply the same shape to GDoc: `Publishers::Base`, `PublisherRegistry`, extract `GoogleDrive` publisher.                                                                                                                                                                                                                                                                                                                                                                                                              | None.                                                     |
+| **F** DOCX (deferred, separate ADR)     | New format trio + jobs + at least one backend.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | New feature.                                              |
+
+Stages A through D (including A.1) are the scope of this ADR. E and F are referenced for forward-compatibility validation only.
+
+### 9.1 Adjacent work: `config/pdf.yml` → database
+
+Lead engineer has scoped the migration of [config/pdf.yml](../../config/pdf.yml) to the database as the **next task immediately after this ADR ships**. It is intentionally not part of this ADR's scope, but the renderer architecture is forward-compatible with it:
+
+- `Exporters::Pdf::Base#render_options` builds `RenderOptions` from whatever source `ContentPresenter#config` exposes. Swapping the YAML loader for a DB-backed `Setting` lookup (or per-record jsonb metadata) is a change inside the presenter, not inside any renderer.
+- The two concerns currently mixed in `config/pdf.yml` — page layout (`margin`, `dpi`, `orientation`) and template behavior (`header`, `name_date`, `padding`) — should be separated as part of that migration. Page layout flows into `RenderOptions`; template behavior stays in the presenter and is consumed by ERB.
+- Per-record overrides become natural to add at that point, mirroring the per-record `pdf_renderer` resolution chain established in §4.3.
+
+A separate ADR will cover the data model, admin UI, and cache-invalidation strategy.
+
+## 10. References
+
+- [docs/plugin-system.md](../plugin-system.md) — plugin discovery, autoload, menu registry
+- [docs/pdf-generation.md](../pdf-generation.md) — current Grover/Puppeteer setup
+- [lib/exporters/pdf/base.rb](../../lib/exporters/pdf/base.rb) — current PDF exporter
+- [lib/exporters/gdoc/base.rb](../../lib/exporters/gdoc/base.rb) — current GDoc exporter
+- [lib/plugin_system.rb](../../lib/plugin_system.rb) — plugin system core
+- `~/Projects/LT/dese-lcms/lib/lcms/engine/renderer/prince_xml.rb` — production-validated PrinceXML renderer (reference for plugin implementation)
+- `~/Projects/LT/dese-lcms/spec/lib/lcms/engine/renderer/prince_xml_spec.rb` — Open3-stubbed spec pattern
+- `~/Projects/LT/dese-lcms/lib/lcms/engine/renderer/prince_xml.css` — PDF/UA tagging stylesheet
+- `~/Projects/LT/dese-lcms/.cloud66/install_prince_xml.sh` — runtime install script reference
+- `~/Projects/LT/dese-lcms/docs/princexml-license.md` — license-on-server convention
+- PrinceXML documentation — https://www.princexml.com/doc/
+- PrinceXML PDF tagging guide — https://www.princexml.com/doc/tagged-pdf/
+- Grover gem — https://github.com/Studiosity/grover
+- Michael Nygard, *Documenting Architecture Decisions* — https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions

--- a/docs/adr/0002-role-based-access-control.md
+++ b/docs/adr/0002-role-based-access-control.md
@@ -1,0 +1,96 @@
+# ADR-0002: Role-Based Access Control for Sensitive Operations
+
+|                   |                                                                                              |
+|-------------------|----------------------------------------------------------------------------------------------|
+| **Status**        | Draft                                                                                        |
+| **Date**          | 2026-06-09                                                                                   |
+| **Supersedes**    | —                                                                                            |
+| **Superseded by** | —                                                                                            |
+| **Related**       | [ADR-0001](./0001-pluggable-output-renderers.md)                                             |
+
+---
+
+## 1. Context
+
+LCMS Core currently has a binary authentication model:
+
+- **Anonymous** — public document/material viewing.
+- **Authenticated** — anyone signed in via Devise (`authenticate_user!`).
+- **Admin** — controllers under `Admin::` namespace use `authenticate_admin!`.
+
+There is no per-resource ownership check, no team/organization scoping, and no
+fine-grained capability model. Several operations that *should* be restricted
+to the resource owner (or an admin) are currently reachable by any authenticated
+user who can guess or enumerate the resource identifier (IDOR).
+
+This ADR is a placeholder to track the operations that need role-based or
+ownership-based access control before a proper RBAC layer is introduced.
+
+## 2. Decision
+
+To be defined. Candidate approaches:
+
+- **Pundit** policies per resource class (`DocumentPolicy`, `JobResultPolicy`).
+- **CanCanCan** ability rules centralized in `Ability`.
+- Hand-rolled `before_action` ownership checks (short-term mitigation).
+
+The chosen approach will:
+
+1. Introduce a `Role` (or capability) model attached to `User`.
+2. Replace blanket `authenticate_user!` with policy checks where applicable.
+3. Provide an audit trail of which controllers/actions were migrated.
+
+## 3. Inventory of Operations Requiring RBAC
+
+The list below tracks endpoints and operations that today rely on
+`authenticate_user!` alone but expose resource-scoped data and should be
+re-evaluated under the future RBAC model.
+
+### 3.1 Job-status polling
+
+| Operation                                | Controller / Action                                      | Risk                                                                                                  |
+|------------------------------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| Read async job status and S3 result URL  | `Api::DocumentJobsController#status`                     | IDOR — any authenticated user can poll any `job_id` (UUIDv4) and read another user's PDF link.        |
+
+**Refactor candidate.** `Api::DocumentJobsController` currently inherits from
+`ApplicationController` and exposes `/api/document_jobs/:job_id/status` to any
+signed-in session. There is no link between `job_id` and the user who enqueued
+the job. Once RBAC lands, this controller should either:
+
+- Inherit from `Admin::AdminController` (if status polling is admin-only), **or**
+- Persist `user_id` on `JobResult` (and/or check via the wrapped `Document`/
+  `Material` ownership) and authorize via policy.
+
+A short-term mitigation is documented in ADR-0001's related PR (#69) and
+should be revisited as part of this RBAC effort.
+
+### 3.2 Document and material reads
+
+*To be inventoried.* Public `DocumentsController` and `MaterialsController`
+actions need to be classified into:
+
+- Truly public (no auth) — current behavior is correct.
+- Authenticated but currently leaking cross-user data — needs scoping.
+
+### 3.3 Admin actions
+
+*To be inventoried.* Today the `Admin::` namespace gates everything behind
+`authenticate_admin!`. With RBAC we may split:
+
+- Super-admin (settings, user management).
+- Content editor (documents, materials, standards).
+- Read-only auditor (reports, dashboards).
+
+## 4. Consequences
+
+- Until RBAC ships, new endpoints exposing per-resource data must add
+  ownership checks inline and reference this ADR.
+- This document is the canonical place to add new entries to the inventory.
+  When a feature PR introduces a new sensitive endpoint, append a row to the
+  appropriate section in §3.
+
+## 5. Open Questions
+
+- Library choice (Pundit vs. CanCanCan vs. hand-rolled).
+- Multi-tenancy story — does each `User` belong to an `Organization`?
+- Migration path for existing data — backfilling `user_id` on legacy records.

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -69,12 +69,27 @@ The project uses several Google products, including analytics, OAuth for allowin
 Obs: if you're setting a local dev machine on OSX and getting small fonts when generating pdfs, try downgrading wkhtmltopdf to `0.12.3`
 
 ### PDF related config
+
+PDF rendering goes through a pluggable renderer abstraction. See [docs/pdf-generation.md](pdf-generation.md) and [ADR-0001](adr/0001-pluggable-output-renderers.md).
+
+#### Renderer selection
+| Name                   | Description                                                                                                                                             |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DEFAULT_PDF_RENDERER   | Identifier of the renderer used when no per-call/per-record selection applies. Default: `grover`. Set to `prince` to make accessible PDFs the default.  |
+
+#### Grover (default renderer)
 | Name                   | Description                                                                                                                                             |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GROVER_EXECUTABLE_PATH | Path to the Google Chrome or Chromium executable (e.g., `/usr/bin/google-chrome-stable`)                                                                |
 | GROVER_NO_SANDBOX      | Disable Chrome sandbox (`true`/`false`). Required for server environments where Chrome runs under a system user (e.g., `nginx` on Cloud66)              |
 | PUPPETEER_TIMEOUT      | Puppeteer timeout in milliseconds (default: `3000`)                                                                                                     |
 | ENABLE_BASE64_CACHING  | Turns on/off caching of assets used for PDF generation (`true` by default, recommended as `false` for local env)                                        |
+
+#### PrinceXML (optional plugin renderer for accessible PDFs)
+| Name                   | Description                                                                                                                                             |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PRINCE_EXECUTABLE_PATH | Path to the `prince` binary. Defaults to whatever's on `$PATH`. Set when prince is installed in a non-standard location.                                |
+| PRINCE_LICENSE_PATH    | Absolute path to `license.dat`. Without it, output PDFs are watermarked. Cloud66 convention: `$STACK_BASE/shared/princexml/license.dat`.                |
 
 ### Postgres config
 | Name                |

--- a/docs/pdf-generation.md
+++ b/docs/pdf-generation.md
@@ -1,37 +1,95 @@
 # PDF Generation
 
-We're using [puppeteer](https://pptr.dev/) with headless chrome for PDF generation.
+PDF rendering goes through a pluggable renderer abstraction. The default renderer is **Grover** (headless Chromium via Puppeteer); additional renderers can be registered via plugins. Architecture rationale: [ADR-0001](adr/0001-pluggable-output-renderers.md).
 
-## PDF security policy
-After fresh server installation ImageMagick security policies have to be updated. Complete the following steps:
+## How it works
 
-1. Locate the file `/etc/ImageMagick-6/policy.xml`
-2. Find the policy for PDF format. It looks like this
-```xml
-<policy domain="coder" rights="none" pattern="PDF" />
+Every PDF job ([`DocumentPdfJob`](../app/jobs/document_pdf_job.rb), [`MaterialPdfJob`](../app/jobs/material_pdf_job.rb), [`UnitBundlePdfJob`](../app/jobs/unit_bundle_pdf_job.rb)) constructs an `Exporters::Pdf::Document`/`Pdf::Material` exporter, which:
+
+1. Resolves which renderer to use (chain: per-call option → per-record metadata → registry default)
+2. Resolves accessibility level (chain: per-call option → per-record metadata → `:none`)
+3. Asks `Exporters::Pdf::RendererRegistry` for the renderer matching that combination — fails fast if the renderer can't satisfy the requested accessibility level
+4. Renders the HTML through the renderer's preferred layout
+5. Calls the renderer with renderer-neutral [`RenderOptions`](../lib/exporters/pdf/render_options.rb)
+6. Returns PDF bytes for upload
+
+No job code changes when a new renderer plugin is added — the seam is inside the exporter.
+
+## Available renderers
+
+| Identifier | Source                                                  | Strengths                                             | Limits                                                                 |
+|------------|---------------------------------------------------------|-------------------------------------------------------|------------------------------------------------------------------------|
+| `:grover`  | core, default                                           | Modern CSS, JS execution, web fonts, fast             | Cannot produce PDF/UA-1 (tagged accessible PDFs)                       |
+| `:prince`  | [`lib/plugins/prince_pdf/`](../lib/plugins/prince_pdf/) | PDF/UA-1, true paged-media typography, embedded fonts | Commercial license, controlled JS environment, separate binary install |
+
+Run `Exporters::Pdf::RendererRegistry.available` from the console to see what's currently usable on the host.
+
+## Selecting a renderer
+
+| Form                        | Example                                                                              | Resolution priority              |
+|-----------------------------|--------------------------------------------------------------------------------------|----------------------------------|
+| Per-call option             | `DocumentPdfJob.perform_later(id, renderer: :prince)`                                | highest                          |
+| Shorthand for accessibility | `DocumentPdfJob.perform_later(id, accessible_pdf: true)`                             | maps to `accessibility: :pdf_ua` |
+| Per-record metadata         | `doc.update!(metadata: { "pdf_renderer" => "prince", "accessibility" => "pdf_ua" })` | middle                           |
+| Global default              | `DEFAULT_PDF_RENDERER=prince` env var                                                | lowest                           |
+
+`Document#pdf_renderer` and `Document#accessibility` accessors are provided by the [`PdfRenderable`](../app/models/concerns/pdf_renderable.rb) concern (included in both Document and Material). `accessibility=` validates against `[none, tagged, pdf_ua]`.
+
+## Adding a new renderer
+
+**See the step-by-step tutorial: [adding-a-pdf-renderer.md](adding-a-pdf-renderer.md).** It walks through scaffolding the plugin folder, satisfying the protocol, declaring capabilities, translating options, writing conformance tests, and installing runtime deps.
+
+In short: a plugin under `lib/plugins/<name>/` registers a renderer in its `setup!`:
+
+```ruby
+module MyPdf
+  def self.setup!
+    Exporters::Pdf::RendererRegistry.register(MyPdf::Renderer)
+  end
+end
 ```
-3. Change it to this
+
+The renderer satisfies a small protocol (2 required methods, 3 optional). Inheriting `Exporters::Pdf::Renderers::Base` is the easy path; duck-typed implementations work too. The registry validates the protocol at registration time. Protocol-level conformance is covered by `it_behaves_like "a PDF renderer"` (in [spec/support/shared_examples/pdf_renderer.rb](../spec/support/shared_examples/pdf_renderer.rb)).
+
+## Grover (default renderer)
+
+Backed by [`Grover`](https://github.com/Studiosity/grover) — Ruby gem driving headless Chromium via Puppeteer. Configuration in [`config/initializers/grover.rb`](../config/initializers/grover.rb).
+
+### Local development
+1. Install Puppeteer (and any missing Chrome libraries — see [troubleshooting](https://pptr.dev/troubleshooting)): `nvm use && yarn install`
+2. Set `ENABLE_BASE64_CACHING=false` (or remember to clear cache when PDF-related CSS/images change)
+3. Use your own S3 bucket to avoid overwrite conflicts (`AWS_S3_BUCKET_NAME`)
+
+### Cloud66 deployment
+Puppeteer downloads browsers into `~/.cache/puppeteer`. Cloud66 deploys as a different user, so set the cache location via `.puppeteerrc.cjs`:
+
+```js
+const { join } = require("path");
+
+module.exports = {
+  cacheDirectory: process.env["STACK_BASE"] ? join(__dirname, ".cache", "puppeteer") : null,
+};
+```
+
+### PDF security policy
+After fresh server installation, ImageMagick's policy may block PDF coder. Edit `/etc/ImageMagick-6/policy.xml`:
+
 ```xml
+<!-- before -->
+<policy domain="coder" rights="none" pattern="PDF" />
+<!-- after -->
 <policy domain="coder" rights="read|write" pattern="PDF" />
 ```
 
-## Local development
-1. install Puppeteer + maybe some missed libraries for Chrome (see details on #puppeteer), install `puppeteer`: `nvm use && yarn install`
-2. set `ENABLE_BASE64_CACHING` as `false` or don't forger to clean cache on pdf related css/images changes (see below)
-3. set up own s3 bucket to avoid overwriting conflicts (`AWS_S3_BUCKET_NAME`)
+## PrinceXML (accessible PDFs, optional plugin)
 
-## Puppeteer
-Chrome version will come with Puppeteer, but there maybe some missed libraries or other issues, please check [troubleshooting](https://pptr.dev/troubleshooting).
+Ships in-tree at `lib/plugins/prince_pdf/`. Used when an accessible PDF (PDF/UA-1) is required — Grover cannot produce tagged PDFs.
 
-Starting from Puppeteer version `19.0` Puppeteer will download browsers into `~/.cache/puppeteer` using `os.homedir` for better caching between Puppeteer upgrades. As c66 deployment is done by different user the recommended `.puppeteerrc.cjs` config is
-```
-const {join} = require('path');
+PrinceXML is a separate commercial binary. Without a license, output is watermarked. Installation, license setup, Docker integration, env vars, and operator notes live in the plugin's own [`README.md`](../lib/plugins/prince_pdf/README.md).
 
-/**
- * @type {import("puppeteer").Configuration}
- */
-module.exports = {
-  // Changes the cache location for Puppeteer.
-  cacheDirectory: process.env['STACK_BASE'] ? join(__dirname, '.cache', 'puppeteer') : null,
-};
-```
+When the binary isn't installed on a host, `:prince` is registered but filtered out of `RendererRegistry.available` — explicit fetches raise `RendererUnavailable` rather than silently falling back to Grover (preserves the accessibility contract).
+
+## Related docs
+- [ADR-0001: Pluggable Output Renderers](adr/0001-pluggable-output-renderers.md) — full architecture context, future-format extensibility
+- [PrincePdf plugin README](../lib/plugins/prince_pdf/README.md) — PrinceXML install, license, operator concerns
+- [Plugin system](plugin-system.md) — how plugins are discovered and loaded

--- a/lib/exporters/base.rb
+++ b/lib/exporters/base.rb
@@ -19,11 +19,9 @@ module Exporters
 
     def render_template(path, layout:)
       field = path.starts_with?("/") ? :file : :template
-      ApplicationController.render(
-        field => path,
-        layout:,
-        assigns: { document: @document, options: @options }
-      )
+      assigns = { document: @document, options: @options }
+      assigns[:render_options] = @render_options unless @render_options.nil?
+      ApplicationController.render(field => path, layout:, assigns: assigns)
     end
 
     def template_path(name)

--- a/lib/exporters/pdf/base.rb
+++ b/lib/exporters/pdf/base.rb
@@ -2,32 +2,78 @@
 
 module Exporters
   module Pdf
+    #
+    # Base PDF exporter. Subclasses (Pdf::Document, Pdf::Material) supply
+    # only `base_path` for template resolution.
+    #
+    # Renderer selection follows a two-tier model:
+    #
+    #   Tier 1 — admin-facing (the only user-visible surface):
+    #     The project's default renderer, chosen by an operator in
+    #     settings. Currently held in the DEFAULT_PDF_RENDERER env var
+    #     and read by RendererRegistry.default; will move to a DB-backed
+    #     setting in the pdf.yml→DB follow-up scope.
+    #
+    #   Tier 2 — programmatic (extension points for plugins):
+    #     Bespoke per-project plugins that own complex bundle assembly
+    #     (e.g. mixing renderers across pieces of a bundle, where PDF/UA
+    #     tags don't survive concatenation so bundles must be rendered
+    #     in one Prince pass over composed HTML) route specific records
+    #     or pieces to specific renderers. Two seams exist for plugin
+    #     code, neither surfaced as core-controller params or admin UI:
+    #       (a) per-call:   options[:renderer], options[:accessibility]
+    #       (b) per-record: @document.pdf_renderer / @document.accessibility
+    #                       — core models do not define these methods;
+    #                       a plugin opts in by extending Document/Material
+    #                       with accessors that read from metadata jsonb.
+    #
+    # Resolution chain (preserved in #renderer_name / #accessibility_level):
+    #   per-call option -> per-record method -> project default
+    #
+    # The registry rejects unsupported (renderer, accessibility) combinations
+    # before any HTML is rendered (e.g. :grover + :pdf_ua raises
+    # UnsupportedCapability).
+    #
     class Base < Exporters::Base
       def export
-        Grover.new(pdf_content, **pdf_params).to_pdf
+        @render_options = build_render_options
+        renderer = RendererRegistry.fetch_for(
+          identifier: renderer_name,
+          accessibility: @render_options.accessibility
+        )
+        layout = layout_name_for(renderer)
+        html = render_template(template_path("show"), layout: layout)
+        renderer.call(html, options: @render_options)
       end
-
-      def pdf_content
-        render_template template_path("show"), layout: "pdf"
-      end
-
-      protected
 
       private
 
-      def pdf_custom_params
-        @document.config.slice(:margin, :dpi)
+      def renderer_name
+        @options[:renderer]&.to_sym ||
+          (@document.respond_to?(:pdf_renderer) && @document.pdf_renderer&.to_sym) ||
+          RendererRegistry.default
       end
 
-      def pdf_params
-        {
-          format: "Letter",
-          landscape: (@document.orientation == "Landscape"),
-          print_background: true,
-          prefer_css_page_size: false,
-          display_header_footer: true,
-          footer_template: render_template(base_path("_footer"), layout: "pdf_plain")
-        }.merge(pdf_custom_params)
+      def accessibility_level
+        return :pdf_ua if @options[:accessible_pdf] == true
+
+        @options[:accessibility]&.to_sym ||
+          (@document.respond_to?(:accessibility) && @document.accessibility&.to_sym) ||
+          :none
+      end
+
+      def build_render_options
+        @document.render_options.with(
+          accessibility: accessibility_level,
+          footer_html: render_template(base_path("_footer"), layout: "pdf_plain")
+        )
+      end
+
+      def layout_name_for(renderer)
+        renderer_class = renderer.is_a?(Class) ? renderer : renderer.class
+        return renderer_class.layout_name if renderer_class.respond_to?(:layout_name)
+
+        Renderers::Base::DEFAULT_LAYOUT
       end
     end
   end

--- a/lib/exporters/pdf/render_options.rb
+++ b/lib/exporters/pdf/render_options.rb
@@ -33,11 +33,11 @@ module Exporters
 
     class RenderOptions
       ALLOWED_ACCESSIBILITY = %i(none tagged pdf_ua).freeze
-      ALLOWED_ORIENTATION  = %w(portrait landscape).freeze
+      ALLOWED_ORIENTATION  = %i(portrait landscape).freeze
 
       DEFAULTS = {
         format: "Letter",
-        orientation: "portrait",
+        orientation: :portrait,
         margin: nil,
         dpi: nil,
         image_dpi: nil,
@@ -54,7 +54,7 @@ module Exporters
 
       def self.build(**overrides)
         attrs = DEFAULTS.merge(overrides)
-        attrs[:orientation] = attrs[:orientation].to_s.downcase if attrs[:orientation]
+        attrs[:orientation] = attrs[:orientation].to_s.downcase.to_sym if attrs[:orientation]
         validate!(attrs)
         new(**attrs)
       end
@@ -64,13 +64,13 @@ module Exporters
           raise ArgumentError,
                 "accessibility must be one of #{ALLOWED_ACCESSIBILITY}, got #{attrs[:accessibility].inspect}"
         end
-        unless ALLOWED_ORIENTATION.include?(attrs[:orientation].to_s)
+        unless ALLOWED_ORIENTATION.include?(attrs[:orientation])
           raise ArgumentError,
                 "orientation must be one of #{ALLOWED_ORIENTATION}, got #{attrs[:orientation].inspect}"
         end
       end
 
-      def landscape? = orientation.to_s == "landscape"
+      def landscape? = orientation == :landscape
       def portrait?  = !landscape?
       def accessible? = accessibility != :none
     end

--- a/lib/exporters/pdf/render_options.rb
+++ b/lib/exporters/pdf/render_options.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Exporters
+  module Pdf
+    #
+    # Renderer-neutral configuration for one PDF rendering operation.
+    #
+    # Single source of truth for both the rendering engine (margins, format,
+    # accessibility profile, ...) and the templates (header visibility,
+    # name/date fields, padding, ...). Renderers consume the engine-relevant
+    # subset; ERB templates consume the template-relevant subset; both read
+    # from the same instance.
+    #
+    # Construct via `RenderOptions.build(...)` to pick up defaults.
+    # Direct `RenderOptions.new(...)` is supported but requires every field.
+    #
+    RenderOptions = Data.define(
+      :format,
+      :orientation,
+      :margin,
+      :dpi,
+      :image_dpi,
+      :print_background,
+      :header_html,
+      :footer_html,
+      :metadata,
+      :accessibility,
+      :show_header,
+      :show_name_date,
+      :padding,
+      :extra
+    )
+
+    class RenderOptions
+      ALLOWED_ACCESSIBILITY = %i(none tagged pdf_ua).freeze
+      ALLOWED_ORIENTATION  = %w(portrait landscape).freeze
+
+      DEFAULTS = {
+        format: "Letter",
+        orientation: "portrait",
+        margin: nil,
+        dpi: nil,
+        image_dpi: nil,
+        print_background: true,
+        header_html: nil,
+        footer_html: nil,
+        metadata: {}.freeze,
+        accessibility: :none,
+        show_header: true,
+        show_name_date: false,
+        padding: nil,
+        extra: {}.freeze
+      }.freeze
+
+      def self.build(**overrides)
+        attrs = DEFAULTS.merge(overrides)
+        attrs[:orientation] = attrs[:orientation].to_s.downcase if attrs[:orientation]
+        validate!(attrs)
+        new(**attrs)
+      end
+
+      def self.validate!(attrs)
+        unless ALLOWED_ACCESSIBILITY.include?(attrs[:accessibility])
+          raise ArgumentError,
+                "accessibility must be one of #{ALLOWED_ACCESSIBILITY}, got #{attrs[:accessibility].inspect}"
+        end
+        unless ALLOWED_ORIENTATION.include?(attrs[:orientation].to_s)
+          raise ArgumentError,
+                "orientation must be one of #{ALLOWED_ORIENTATION}, got #{attrs[:orientation].inspect}"
+        end
+      end
+
+      def landscape? = orientation.to_s == "landscape"
+      def portrait?  = !landscape?
+      def accessible? = accessibility != :none
+    end
+  end
+end

--- a/lib/exporters/pdf/renderer_registry.rb
+++ b/lib/exporters/pdf/renderer_registry.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Exporters
+  module Pdf
+    #
+    # Runtime registry of PDF renderer backends.
+    #
+    # Backends register themselves at boot (default backends in core
+    # initializers, plugin backends in their setup! hooks). The registry
+    # validates the renderer protocol at registration time so malformed
+    # backends fail loudly when they are loaded, not at first render.
+    #
+    # Resolution: callers fetch by identifier and required accessibility
+    # level. The registry rejects combinations the requested backend
+    # cannot satisfy (e.g. :grover + :pdf_ua) before any HTML is rendered.
+    #
+    # The generic register/fetch/available/all/reset mechanics live in
+    # PluginSystem::Registry. PDF-specific extensions (capability gating,
+    # default identifier from env) live here.
+    #
+    module RendererRegistry
+      extend PluginSystem::Registry
+
+      REQUIRED_INSTANCE_METHODS = %i(call).freeze
+      REQUIRED_CLASS_METHODS    = %i(identifier).freeze
+
+      CAPABILITY_FOR_ACCESSIBILITY = {
+        none: [].freeze,
+        tagged: %i(tagged_pdf).freeze,
+        pdf_ua: %i(pdf_ua).freeze
+      }.freeze
+
+      DEFAULT_RENDERER_ENV = "DEFAULT_PDF_RENDERER"
+      FALLBACK_DEFAULT     = :grover
+
+      # Backward-compatible aliases for the generic errors raised by the
+      # mixin. Existing consumers can rescue using the PDF-flavored names.
+      RendererNotFound    = PluginSystem::Registry::NotFound
+      RendererUnavailable = PluginSystem::Registry::Unavailable
+      ContractViolation   = PluginSystem::Registry::ContractViolation
+
+      # PDF-specific errors.
+      class RenderError           < StandardError; end
+      class UnsupportedCapability < StandardError; end
+
+      class << self
+        #
+        # Look up a renderer that can satisfy a given accessibility level.
+        # Raises UnsupportedCapability if the backend lacks required
+        # capabilities (e.g. :grover asked for :pdf_ua).
+        #
+        def fetch_for(identifier:, accessibility: :none)
+          backend  = fetch(identifier)
+          required = CAPABILITY_FOR_ACCESSIBILITY.fetch(accessibility) do
+            raise ArgumentError, "unknown accessibility level: #{accessibility.inspect}"
+          end
+          missing = required - capabilities_of(backend)
+          return backend if missing.empty?
+
+          raise UnsupportedCapability,
+                "#{identifier} cannot satisfy accessibility=#{accessibility} " \
+                "(missing capabilities: #{missing.join(', ')})"
+        end
+
+        # Resolution order: Setting (admin UI) → env var → FALLBACK_DEFAULT.
+        # Setting is the admin-facing surface from the two-tier model;
+        # env stays as an interim/CI override; FALLBACK_DEFAULT (:grover)
+        # ensures the system always boots even with no config at all.
+        def default
+          from_setting = Setting.get(:pdf)&.dig("default_renderer").to_s.presence
+          return from_setting.to_sym if from_setting
+
+          ENV.fetch(DEFAULT_RENDERER_ENV, FALLBACK_DEFAULT.to_s).to_sym
+        end
+
+        private
+
+        def capabilities_of(backend)
+          klass = backend.is_a?(Class) ? backend : backend.class
+          # @type var klass: untyped
+          klass.respond_to?(:capabilities) ? klass.capabilities.to_a : []
+        end
+      end
+    end
+  end
+end

--- a/lib/exporters/pdf/renderers/base.rb
+++ b/lib/exporters/pdf/renderers/base.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Exporters
+  module Pdf
+    module Renderers
+      #
+      # Optional ergonomic base class for PDF renderers.
+      #
+      # Provides defaults for the optional parts of the renderer protocol
+      # so plugin authors only override what differs. Inheriting Base is
+      # not required — any object that satisfies the protocol can be
+      # registered. The protocol is enforced by RendererRegistry at
+      # registration time, not by this class.
+      #
+      # The protocol:
+      #   #call(html, options:) -> String   (required, PDF bytes)
+      #   .identifier           -> Symbol   (required, stable name)
+      #   .capabilities         -> Set[Symbol]  (optional, default: empty)
+      #   .available?           -> Boolean      (optional, default: true)
+      #   .layout_name          -> String       (optional, default: "pdf")
+      #
+      # `#call` and `.identifier` are deliberately NOT defined here.
+      # Defining them with raise NotImplementedError would defeat the
+      # protocol verifier — the inherited methods would satisfy the
+      # method-defined check while still failing at runtime.
+      #
+      class Base
+        EMPTY_CAPABILITIES = Set.new.freeze
+        DEFAULT_LAYOUT     = "pdf"
+
+        def self.capabilities = EMPTY_CAPABILITIES
+        def self.available?   = true
+        def self.layout_name  = DEFAULT_LAYOUT
+      end
+    end
+  end
+end

--- a/lib/exporters/pdf/renderers/grover.rb
+++ b/lib/exporters/pdf/renderers/grover.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Exporters
+  module Pdf
+    module Renderers
+      #
+      # Default PDF renderer. Wraps the Grover gem (headless Chromium via
+      # Puppeteer) and translates RenderOptions into Grover's option hash.
+      #
+      # Grover-specific configuration (executable path, sandbox flags,
+      # timeout) lives in config/initializers/grover.rb and is read from
+      # the Grover global by ::Grover.new.
+      #
+      class Grover < Base
+        CAPABILITIES = Set[
+          :landscape,
+          :background_print,
+          :running_headers,
+          :web_fonts,
+          :js_execution
+        ].freeze
+
+        def self.identifier   = :grover
+        def self.capabilities = CAPABILITIES
+
+        def call(html, options:)
+          ::Grover.new(html, **translate(options)).to_pdf
+        end
+
+        private
+
+        def translate(opts)
+          {
+            format: opts.format,
+            landscape: opts.landscape?,
+            margin: opts.margin,
+            dpi: opts.dpi,
+            print_background: opts.print_background,
+            prefer_css_page_size: false,
+            display_header_footer: !(opts.header_html.nil? && opts.footer_html.nil?),
+            header_template: opts.header_html,
+            footer_template: opts.footer_html
+          }.compact.merge(opts.extra || {})
+        end
+      end
+    end
+  end
+end

--- a/lib/plugin_system/registry.rb
+++ b/lib/plugin_system/registry.rb
@@ -27,12 +27,19 @@ module PluginSystem
     Error             = Class.new(StandardError)
     NotFound          = Class.new(Error)
     Unavailable       = Class.new(Error)
+    AlreadyRegistered = Class.new(Error)
     ContractViolation = Class.new(ArgumentError)
 
     def register(backend)
       klass = klass_of(backend)
       verify_contract!(klass)
-      store[klass.identifier.to_sym] = backend
+      identifier = klass.identifier.to_sym
+      if store.key?(identifier)
+        raise AlreadyRegistered,
+              "backend #{identifier.inspect} is already registered " \
+              "(existing: #{klass_of(store[identifier])}, attempted: #{klass})"
+      end
+      store[identifier] = backend
     end
 
     def unregister(identifier)
@@ -40,8 +47,13 @@ module PluginSystem
     end
 
     def fetch(identifier)
-      backend = store[identifier.to_sym]
-      raise NotFound, "no backend registered for: #{identifier.inspect}" unless backend
+      key = identifier.to_sym
+      backend = store[key]
+      unless backend
+        raise NotFound,
+              "no backend registered for: #{identifier.inspect} " \
+              "(registered: #{store.keys.inspect})"
+      end
 
       klass = klass_of(backend)
       unless available_class?(klass)
@@ -61,8 +73,12 @@ module PluginSystem
       store.keys
     end
 
-    # Reset the registry. Test-only.
+    # Reset the registry. Test-only — raises in any non-test environment to
+    # prevent accidental wipe of registered backends in dev/staging/prod.
     def reset!
+      unless defined?(Rails) && Rails.env.test?
+        raise Error, "Registry#reset! is only allowed in the test environment"
+      end
       @store = {}
     end
 

--- a/lib/plugin_system/registry.rb
+++ b/lib/plugin_system/registry.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module PluginSystem
+  #
+  # Generic registry-of-backends pattern. Extracted from Pdf::RendererRegistry
+  # so other format registries (Gdoc::PublisherRegistry, Docx::RendererRegistry,
+  # ...) can reuse the same mechanics: protocol-verified registration, fetch
+  # with availability gating, list of available/all identifiers, test reset.
+  #
+  # Consumers `extend` this module and declare two protocol constants:
+  #
+  #   module Exporters::Pdf::RendererRegistry
+  #     extend PluginSystem::Registry
+  #
+  #     REQUIRED_INSTANCE_METHODS = %i(call).freeze
+  #     REQUIRED_CLASS_METHODS    = %i(identifier).freeze
+  #   end
+  #
+  # Format-specific extensions (capability gating, default identifier,
+  # error subclasses) stay on the format's registry.
+  #
+  # Beyond the required protocol methods, registries may also use optional
+  # backend class methods such as `.available?`. When omitted, the mixin
+  # falls back to sensible defaults (for availability, `true`).
+  #
+  module Registry
+    Error             = Class.new(StandardError)
+    NotFound          = Class.new(Error)
+    Unavailable       = Class.new(Error)
+    ContractViolation = Class.new(ArgumentError)
+
+    def register(backend)
+      klass = klass_of(backend)
+      verify_contract!(klass)
+      store[klass.identifier.to_sym] = backend
+    end
+
+    def unregister(identifier)
+      store.delete(identifier.to_sym)
+    end
+
+    def fetch(identifier)
+      backend = store[identifier.to_sym]
+      raise NotFound, "no backend registered for: #{identifier.inspect}" unless backend
+
+      klass = klass_of(backend)
+      unless available_class?(klass)
+        raise Unavailable, "#{identifier.inspect} is registered but not available on this host"
+      end
+
+      backend.is_a?(Class) ? backend.new : backend
+    end
+
+    # Identifiers of registered backends whose `available?` returns true.
+    def available
+      store.select { |_, b| available_class?(klass_of(b)) }.keys
+    end
+
+    # Identifiers of all registered backends, regardless of availability.
+    def all
+      store.keys
+    end
+
+    # Reset the registry. Test-only.
+    def reset!
+      @store = {}
+    end
+
+    private
+
+    def store
+      @store ||= {}
+    end
+
+    # Resolves the registrable class from a Class or instance backend.
+    # Untyped boundary by design — the contract is duck-typed, so callers
+    # treat the return as opaque and rely on verify_contract! for safety.
+    def klass_of(backend)
+      backend.is_a?(Class) ? backend : backend.class
+    end
+
+    def verify_contract!(klass)
+      missing_class    = self::REQUIRED_CLASS_METHODS.reject    { |m| klass.respond_to?(m) }
+      missing_instance = self::REQUIRED_INSTANCE_METHODS.reject { |m| klass.public_method_defined?(m) }
+      return if missing_class.empty? && missing_instance.empty?
+
+      raise ContractViolation,
+            "#{klass} missing required methods " \
+            "(class: #{missing_class}, instance: #{missing_instance})"
+    end
+
+    def available_class?(klass)
+      klass.respond_to?(:available?) ? klass.available? : true
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/Gemfile
+++ b/lib/plugins/prince_pdf/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# PrincePdf plugin dependencies.
+# Auto-loaded by the main Gemfile via eval_gemfile.
+#
+# PrinceXML itself is a system binary, not a Ruby gem. There are no
+# Ruby dependencies for this plugin — the renderer shells out to the
+# `prince` command via Open3.
+#
+# See README.md for installation instructions.

--- a/lib/plugins/prince_pdf/README.md
+++ b/lib/plugins/prince_pdf/README.md
@@ -1,0 +1,102 @@
+# PrincePdf
+
+Accessible PDF rendering for LCMS Core via [PrinceXML](https://www.princexml.com/). Plugs into `Exporters::Pdf::RendererRegistry` as `:prince`. Activated when a job or document opts into accessibility output (PDF/UA-1), which the default Grover/Chromium renderer cannot produce.
+
+This plugin ships in-tree under `lib/plugins/prince_pdf/`. PrinceXML itself is a separate system binary, not a Ruby gem — see installation below.
+
+## When to use it
+
+Use the `:prince` renderer when:
+
+- **PDF/UA-1 compliance** is required (tagged PDFs validating against pac3 / veraPDF for assistive technology)
+- **High-fidelity print typography** is needed (running headers/footers, complex page boxes, hyphenation, font embedding)
+- **PDF metadata** (title, lang, author) needs to land in the output PDF
+
+Stick with the default `:grover` renderer when:
+
+- Output goes to screen viewing only (no accessibility requirement)
+- Templates rely on JavaScript rendered DOM that Prince's controlled JS environment doesn't support
+
+## Installation
+
+PrinceXML is a commercial product. Free non-commercial / evaluation use produces watermarked output; production use requires a license.
+
+### Docker (recommended)
+
+PrinceXML is installed by the main [`Dockerfile.dev`](../../../Dockerfile.dev) — multi-arch (amd64 + arm64), pinned to Prince 16.1 / Debian 12. Rebuilding the dev image is enough; no extra steps are required.
+
+Forks that don't need accessible PDF output can drop the `wget`/`gdebi` packages and the `RUN` block that installs Prince from `Dockerfile.dev`.
+
+### Cloud66
+
+Cloud66 deploys run [`.cloud66/scripts/install-prince-xml.sh`](../../../.cloud66/scripts/install-prince-xml.sh) automatically via the `first_thing` deploy hook (see [`.cloud66/deploy_hooks.yml`](../../../.cloud66/deploy_hooks.yml)). The script is idempotent — it skips if `prince` is already on PATH, otherwise installs `wget`/`gdebi` if missing, downloads the official Ubuntu 22.04 amd64 .deb, and verifies post-install.
+
+For other bare-metal hosts, run the same script manually with `sudo`.
+
+### Verifying
+
+```bash
+prince --version
+# Prince 16.1
+```
+
+## License
+
+PrinceXML is commercial software by YesLogic. Without a license file, output PDFs include a watermark — usable for development, not for production.
+
+To install a license on a Cloud66 server:
+
+```bash
+sudo -i -u cloud66-user
+mkdir -p "$STACK_BASE/shared/princexml"
+cp license.dat "$STACK_BASE/shared/princexml/"
+chown -R cloud66-user:cloud66-user "$STACK_BASE/shared/princexml/"
+```
+
+Then set `PRINCE_LICENSE_PATH` in the deployment environment:
+
+```bash
+PRINCE_LICENSE_PATH="$STACK_BASE/shared/princexml/license.dat"
+```
+
+If `PRINCE_LICENSE_PATH` is unset, Prince looks in its default install directory.
+
+Verify license is picked up:
+
+```bash
+prince --version --license-file=$PRINCE_LICENSE_PATH
+# Prince 16.1
+# Server License (Academic)
+```
+
+## Environment variables
+
+| Variable                  | Purpose                                                                  |
+|---------------------------|--------------------------------------------------------------------------|
+| `PRINCE_EXECUTABLE_PATH`  | Path to `prince` binary. Defaults to whatever's on `$PATH`.              |
+| `PRINCE_LICENSE_PATH`     | Absolute path to `license.dat`. Unset = default install dir = watermarked. |
+| `DEFAULT_PDF_RENDERER`    | Set to `prince` to make accessible the global default for all PDFs.       |
+
+## How selection works
+
+Once installed and registered, the renderer is selected by:
+
+1. **Per-call option** — `DocumentPdfJob.perform_later(doc_id, renderer: :prince)` or `accessible_pdf: true` (shorthand)
+2. **Per-record metadata** — `document.metadata['pdf_renderer'] = "prince"` or `metadata['accessibility'] = "pdf_ua"`
+3. **Global default** — `DEFAULT_PDF_RENDERER=prince`
+
+Resolution order: per-call → per-record → global default.
+
+If the renderer is registered but the binary isn't on the host (e.g. a fork that stripped the Prince install from `Dockerfile.dev`, or a bare-metal host where the install script wasn't run), `Renderer.available?` returns `false` and the registry filters `:prince` out. Any record asking for `:prince` then fails fast with `RendererUnavailable` — never silently downgraded to Grover, since the accessibility contract would be lost.
+
+## Templates and accessibility
+
+PDF/UA-1 compliance requires both Prince *and* tagged HTML. The plugin ships a tagging stylesheet (`prince_xml.css`, added in a later commit) that maps standard HTML elements to PDF semantic tags via `prince-pdf-tag-type:` rules. Most lessons render acceptably tagged out of the box.
+
+For strict pac3 / veraPDF certification, operators should also author accessibility-grade template variants per PDF component (semantic markup, ARIA where applicable, decorative-image artifact marking via the `icon-as-artifact` helper). See ADR-0001 §4.5 for the full pattern.
+
+## See also
+
+- [ADR-0001: Pluggable Output Renderers](../../docs/adr/0001-pluggable-output-renderers.md) — architecture context
+- [PrinceXML documentation](https://www.princexml.com/doc/) — full CLI reference
+- [Prince tagged-PDF guide](https://www.princexml.com/doc/tagged-pdf/) — PDF/UA semantics

--- a/lib/plugins/prince_pdf/app/views/layouts/pdf_prince.erb
+++ b/lib/plugins/prince_pdf/app/views/layouts/pdf_prince.erb
@@ -1,0 +1,46 @@
+<!doctype html>
+<%#
+  PrinceXML-specific layout. Selected by PrincePdf::Renderer.layout_name.
+
+  Differs from the default `pdf` layout in three small ways needed for
+  PDF/UA compliance:
+
+    1. <html lang="..."> set from RenderOptions.metadata[:lang] (Prince
+       embeds this as the PDF /Lang entry, required for PDF/UA-1).
+
+    2. dc:title and dc:language <meta> tags so Prince populates the PDF
+       document metadata (visible in PDF viewers, required for PDF/UA-1).
+
+    3. Body content is otherwise identical to the default `pdf` layout
+       — accessibility-grade per-component partials (e.g. _*_pdf_ua.html.erb)
+       are an authoring concern that operators ship in their own forks
+       (see ADR-0001 §4.5). The Prince tagging stylesheet
+       (`prince_xml.css`, loaded via the renderer's --style flag) maps
+       standard HTML elements emitted by the default partials to PDF
+       semantic tags out of the box.
+
+  The Prince-specific tagging stylesheet, JS hook, and orientation CSS
+  are loaded by the renderer via CLI flags (`--style=`, `--script=`),
+  not from this layout. That keeps this file focused on document-level
+  metadata and shared with the default partial set.
+%>
+<html lang="<%= (@render_options&.metadata.is_a?(Hash) ? @render_options.metadata[:lang] : nil) || "en" %>">
+  <head>
+    <meta charset="utf-8">
+    <%
+      meta = @render_options&.metadata.is_a?(Hash) ? @render_options.metadata : {}
+      title = meta[:title]
+      lang  = meta[:lang] || "en"
+    %>
+    <% if title.present? %>
+      <title><%= title %></title>
+      <meta name="dc:title" content="<%= title %>">
+    <% end %>
+    <meta name="dc:language" content="<%= lang %>">
+
+    <%= params.key?("debug") ? stylesheet_link_tag("pdf", media: "all") : stylesheet_link_tag(base64_encoded_asset("pdf.css")) %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/lib/plugins/prince_pdf/lib/prince_pdf.rb
+++ b/lib/plugins/prince_pdf/lib/prince_pdf.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# PrincePdf — accessible PDF rendering via the PrinceXML command-line tool.
+#
+# Plugs into Exporters::Pdf::RendererRegistry as `:prince`. Used when a
+# document or job opts into accessibility (PDF/UA-1) output, which the
+# default Grover/Chromium renderer cannot produce. See ADR-0001 §4.
+#
+# Runtime requirements:
+#   - PrinceXML binary on PATH (or PRINCE_EXECUTABLE_PATH set)
+#   - Optional: PRINCE_LICENSE_PATH for unwatermarked output
+#
+# See README.md for installation, licensing, and Docker integration.
+#
+module PrincePdf
+  class << self
+    def setup!
+      ::Exporters::Pdf::RendererRegistry.register(Renderer)
+      PluginSystem.logger.info \
+        "[PrincePdf] :prince renderer registered (available=#{Renderer.available?})"
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml.css
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml.css
@@ -1,0 +1,76 @@
+/*
+ * PrinceXML PDF/UA tagging baseline for LCMS Core.
+ *
+ * Prince's `--pdf-profile=PDF/UA-1` automatically tags standard HTML
+ * elements (h1-h6, p, ul, ol, li, table, tr, th, td, etc.). This file
+ * supplies the *deviations* from those defaults — primarily marking
+ * decorative content as Artifact so screen readers skip it.
+ *
+ * Forks needing template-specific tagging (e.g. dese-lcms) ship their
+ * own additional stylesheet and load it via the renderer's JS hook or
+ * an extended layout. This baseline stays generic.
+ *
+ * Reference: https://www.princexml.com/doc/tagged-pdf/
+ */
+
+/* -------------------------------------------------------------------------
+ * Decorative content marked as Artifact (skipped by AT)
+ * -----------------------------------------------------------------------*/
+
+/* Convention: any element with .icon-as-artifact is decorative.
+ * Templates use this class on icons that exist purely for visual layout
+ * and carry no semantic meaning. */
+.icon-as-artifact,
+img.icon-as-artifact,
+svg.icon-as-artifact {
+  prince-pdf-tag-type: Artifact;
+}
+
+/* Images with empty or "decorative"/"is-artifact" alt are decorative. */
+img[alt=""],
+img[alt="decorative"],
+img[alt="is-artifact"] {
+  -prince-pdf-tag-type: Artifact;
+}
+
+/* Paragraphs that the JS hook marks as effectively empty (whitespace-only).
+ * The JS adds .pdf-artifact to such elements at preprocessing time. */
+.pdf-artifact,
+p.pdf-artifact,
+p:empty {
+  prince-pdf-tag-type: Artifact;
+}
+
+/* Form inputs in printed output are visual placeholders, not interactive. */
+input.form-check-input,
+.form-check-input {
+  -prince-pdf-tag-type: Artifact;
+}
+
+/* -------------------------------------------------------------------------
+ * Escape-hatch classes operators can use in templates
+ * -----------------------------------------------------------------------*/
+
+/* Force a wrapper to render as a Section. */
+.pdf-section { prince-pdf-tag-type: Sect; }
+
+/* Force a heading level when the surrounding HTML can't be changed. */
+.pdf-heading-1 { prince-pdf-tag-type: H1; }
+.pdf-heading-2 { prince-pdf-tag-type: H2; }
+.pdf-heading-3 { prince-pdf-tag-type: H3; }
+.pdf-heading-4 { prince-pdf-tag-type: H4; }
+
+/* Force a note tag. */
+.pdf-note { prince-pdf-tag-type: Note; }
+
+/* Force a paragraph tag (useful for divs that should read as P). */
+.pdf-paragraph { prince-pdf-tag-type: P; }
+
+/* -------------------------------------------------------------------------
+ * Figures
+ * -----------------------------------------------------------------------*/
+
+/* Let Prince infer figure tagging from <figure>/<figcaption>. */
+figure {
+  -prince-pdf-tag-type: none;
+}

--- a/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml.js
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml.js
@@ -1,0 +1,37 @@
+/**
+ * PrinceXML DOM preprocessing for LCMS Core.
+ *
+ * Runs inside Prince's controlled JS environment via the --script flag.
+ * This file is intentionally minimal — handles the universally useful
+ * cleanups, leaves template-specific behaviors to forks.
+ *
+ * Problem solved here: CSS :empty does not match elements containing
+ * only whitespace text or empty inline children. Such paragraphs leak
+ * into the tagged PDF as P elements, producing accessibility noise
+ * (screen readers announce them).
+ *
+ * Solution: tag whitespace-only paragraphs with a class that
+ * prince_xml.css then maps to Artifact.
+ *
+ * Reference: https://www.princexml.com/doc/javascript/
+ */
+document.addEventListener('DOMContentLoaded', function() {
+  markEffectivelyEmptyParagraphs();
+});
+
+/**
+ * Adds .pdf-artifact to <p> elements containing no non-whitespace content.
+ * Matches <p></p>, <p>   </p>, <p><span></span></p>, etc.
+ */
+function markEffectivelyEmptyParagraphs() {
+  var paragraphs = document.getElementsByTagName('p');
+
+  for (var i = 0; i < paragraphs.length; i++) {
+    var p = paragraphs[i];
+    var text = (p.textContent || '').trim();
+
+    if (text === '') {
+      p.classList.add('pdf-artifact');
+    }
+  }
+}

--- a/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml_landscape.css
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml_landscape.css
@@ -1,0 +1,3 @@
+@page {
+  size: letter landscape;
+}

--- a/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml_portrait.css
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/assets/prince_xml_portrait.css
@@ -1,0 +1,3 @@
+@page {
+  size: letter portrait;
+}

--- a/lib/plugins/prince_pdf/lib/prince_pdf/executable.rb
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/executable.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module PrincePdf
+  #
+  # PrinceXML binary discovery and invocation.
+  #
+  # Uses Open3 to shell out to the `prince` command. Path is configurable
+  # via PRINCE_EXECUTABLE_PATH; otherwise the default `prince` resolves
+  # against $PATH.
+  #
+  # `present?` is cached after the first probe so the registry's repeated
+  # `available?` calls don't fork a subprocess every time. Tests use
+  # `reset!` to clear the cache between scenarios.
+  #
+  module Executable
+    DEFAULT_BINARY = "prince"
+
+    class NonZeroExit < StandardError; end
+
+    class << self
+      def path
+        ENV.fetch("PRINCE_EXECUTABLE_PATH", DEFAULT_BINARY)
+      end
+
+      def present?
+        return @present if defined?(@present)
+
+        @present = probe
+      end
+
+      def version
+        stdout, _stderr, status = Open3.capture3(path, "--version")
+        status.success? ? stdout.lines.first&.strip : nil
+      rescue Errno::ENOENT
+        nil
+      end
+
+      #
+      # Run prince with the given arg list. HTML on stdin, PDF bytes on stdout.
+      # Raises NonZeroExit with stderr if prince exits non-zero.
+      #
+      def run(args, stdin:)
+        stdout, stderr, status = Open3.capture3(path, *args, stdin_data: stdin)
+        raise NonZeroExit, stderr unless status.success?
+
+        stdout
+      end
+
+      def reset!
+        remove_instance_variable(:@present) if defined?(@present)
+      end
+
+      private
+
+      def probe
+        _stdout, _stderr, status = Open3.capture3(path, "--version")
+        status.success?
+      rescue Errno::ENOENT
+        false
+      end
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/lib/prince_pdf/options_translator.rb
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/options_translator.rb
@@ -51,7 +51,15 @@ module PrincePdf
     end
 
     def stylesheet_args
-      orientation_css = File.join(ASSETS_DIR, "prince_xml_#{options.orientation}.css")
+      # Defense-in-depth: RenderOptions.build validates orientation, but a
+      # caller may bypass it via RenderOptions.new(...). Re-check here so the
+      # value can never reach a File.join interpolation as an arbitrary path.
+      orientation = options.orientation
+      unless Exporters::Pdf::RenderOptions::ALLOWED_ORIENTATION.include?(orientation)
+        raise ArgumentError, "invalid orientation: #{orientation.inspect}"
+      end
+
+      orientation_css = File.join(ASSETS_DIR, "prince_xml_#{orientation}.css")
       ["--style=#{BASE_STYLESHEET}", "--style=#{orientation_css}"]
     end
 

--- a/lib/plugins/prince_pdf/lib/prince_pdf/options_translator.rb
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/options_translator.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module PrincePdf
+  #
+  # Translates a renderer-neutral RenderOptions into the array of PrinceXML
+  # CLI arguments. Output shape is validated by the production reference
+  # implementation in dese-lcms (see ADR-0001 §4.5).
+  #
+  # Example output:
+  #   ["-", "--output=-",
+  #    "--license-file=/etc/prince/license.dat",
+  #    "--style=/.../prince_xml.css",
+  #    "--style=/.../prince_xml_portrait.css",
+  #    "--page-margin=\"0.5in 1in 0.5in 0.5in\"",
+  #    "--script=/.../prince_xml.js",
+  #    "--javascript",
+  #    "--http-timeout=30",
+  #    "--pdf-profile=PDF/UA-1"]
+  #
+  class OptionsTranslator
+    ASSETS_DIR      = File.expand_path("assets", __dir__)
+    BASE_STYLESHEET = File.join(ASSETS_DIR, "prince_xml.css")
+    SCRIPT          = File.join(ASSETS_DIR, "prince_xml.js")
+    HTTP_TIMEOUT    = "30"
+    PDF_UA_PROFILE  = "PDF/UA-1"
+
+    def initialize(options)
+      @options = options
+    end
+
+    def to_args
+      [
+        "-", "--output=-",
+        *license_args,
+        *stylesheet_args,
+        *margin_args,
+        *script_args,
+        "--javascript",
+        "--http-timeout=#{HTTP_TIMEOUT}",
+        *accessibility_args
+      ]
+    end
+
+    private
+
+    attr_reader :options
+
+    def license_args
+      license = ENV.fetch("PRINCE_LICENSE_PATH", nil)
+      license ? ["--license-file=#{license}"] : []
+    end
+
+    def stylesheet_args
+      orientation_css = File.join(ASSETS_DIR, "prince_xml_#{options.orientation}.css")
+      ["--style=#{BASE_STYLESHEET}", "--style=#{orientation_css}"]
+    end
+
+    def margin_args
+      m = options.margin
+      return [] unless m
+
+      [%(--page-margin="#{m[:top]} #{m[:right]} #{m[:bottom]} #{m[:left]}")]
+    end
+
+    def script_args
+      ["--script=#{SCRIPT}"]
+    end
+
+    def accessibility_args
+      case options.accessibility
+      when :none   then []
+      when :tagged then ["--tagged-pdf"]
+      when :pdf_ua then ["--pdf-profile=#{PDF_UA_PROFILE}"]
+      else
+        raise ArgumentError, "unknown accessibility level: #{options.accessibility.inspect}"
+      end
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/lib/prince_pdf/renderer.rb
+++ b/lib/plugins/prince_pdf/lib/prince_pdf/renderer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module PrincePdf
+  #
+  # PDF renderer backed by the PrinceXML command-line tool.
+  #
+  # Implements Exporters::Pdf::Renderers::Base. Inherits the optional-method
+  # defaults from Base; overrides identifier, capabilities, layout_name,
+  # available?, and provides the required #call.
+  #
+  # Capabilities advertise PDF/UA-1 and tagged-PDF support so the registry's
+  # accessibility-capability gate accepts :tagged and :pdf_ua requests
+  # against this renderer.
+  #
+  # Available? returns false when the prince binary cannot be invoked,
+  # which causes the registry to filter :prince out of `.available`.
+  # Records requesting :prince in that state fail fast with
+  # RendererUnavailable rather than silently downgrading to Grover.
+  #
+  class Renderer < ::Exporters::Pdf::Renderers::Base
+    CAPABILITIES = Set[
+      :landscape,
+      :tagged_pdf,
+      :pdf_ua,
+      :running_headers,
+      :web_fonts,
+      :js_execution,
+      :custom_script_hook,
+      :background_print
+    ].freeze
+
+    def self.identifier   = :prince
+    def self.capabilities = CAPABILITIES
+    def self.layout_name  = "pdf_prince"
+
+    def self.available?
+      Executable.present?
+    end
+
+    def call(html, options:)
+      args = OptionsTranslator.new(options).to_args
+      Executable.run(args, stdin: html)
+    rescue Executable::NonZeroExit => e
+      raise ::Exporters::Pdf::RendererRegistry::RenderError,
+            "PrinceXML failed: #{e.message}"
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/sig/prince_pdf.rbs
+++ b/lib/plugins/prince_pdf/sig/prince_pdf.rbs
@@ -1,0 +1,3 @@
+module PrincePdf
+  def self.setup!: () -> void
+end

--- a/lib/plugins/prince_pdf/sig/prince_pdf/executable.rbs
+++ b/lib/plugins/prince_pdf/sig/prince_pdf/executable.rbs
@@ -1,0 +1,18 @@
+module PrincePdf
+  module Executable
+    DEFAULT_BINARY: String
+
+    class NonZeroExit < StandardError
+    end
+
+    def self.path: () -> String
+    def self.present?: () -> bool
+    def self.version: () -> String?
+    def self.run: (Array[String] args, stdin: String) -> String
+    def self.reset!: () -> void
+
+    private
+
+    def self.probe: () -> bool
+  end
+end

--- a/lib/plugins/prince_pdf/sig/prince_pdf/options_translator.rbs
+++ b/lib/plugins/prince_pdf/sig/prince_pdf/options_translator.rbs
@@ -1,0 +1,22 @@
+module PrincePdf
+  class OptionsTranslator
+    ASSETS_DIR: String
+    BASE_STYLESHEET: String
+    SCRIPT: String
+    HTTP_TIMEOUT: String
+    PDF_UA_PROFILE: String
+
+    def initialize: (::Exporters::Pdf::RenderOptions options) -> void
+    def to_args: () -> Array[String]
+
+    private
+
+    attr_reader options: ::Exporters::Pdf::RenderOptions
+
+    def license_args: () -> Array[String]
+    def stylesheet_args: () -> Array[String]
+    def margin_args: () -> Array[String]
+    def script_args: () -> Array[String]
+    def accessibility_args: () -> Array[String]
+  end
+end

--- a/lib/plugins/prince_pdf/sig/prince_pdf/renderer.rbs
+++ b/lib/plugins/prince_pdf/sig/prince_pdf/renderer.rbs
@@ -1,0 +1,12 @@
+module PrincePdf
+  class Renderer < ::Exporters::Pdf::Renderers::Base
+    CAPABILITIES: Set[Symbol]
+
+    def self.identifier: () -> Symbol
+    def self.capabilities: () -> Set[Symbol]
+    def self.layout_name: () -> String
+    def self.available?: () -> bool
+
+    def call: (String html, options: ::Exporters::Pdf::RenderOptions) -> String
+  end
+end

--- a/lib/plugins/prince_pdf/spec/prince_pdf/executable_spec.rb
+++ b/lib/plugins/prince_pdf/spec/prince_pdf/executable_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PrincePdf::Executable do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
+  let(:success_status) { instance_double(Process::Status, success?: true) }
+  let(:failure_status) { instance_double(Process::Status, success?: false) }
+
+  describe ".path" do
+    it "defaults to 'prince' when env unset" do
+      original = ENV["PRINCE_EXECUTABLE_PATH"]
+      ENV.delete("PRINCE_EXECUTABLE_PATH")
+      expect(described_class.path).to eq("prince")
+    ensure
+      ENV["PRINCE_EXECUTABLE_PATH"] = original
+    end
+
+    it "honors PRINCE_EXECUTABLE_PATH env" do
+      original = ENV["PRINCE_EXECUTABLE_PATH"]
+      ENV["PRINCE_EXECUTABLE_PATH"] = "/opt/prince/bin/prince"
+      expect(described_class.path).to eq("/opt/prince/bin/prince")
+    ensure
+      ENV["PRINCE_EXECUTABLE_PATH"] = original
+    end
+  end
+
+  describe ".present?" do
+    it "returns true when prince --version exits 0" do
+      allow(Open3).to receive(:capture3).with(described_class.path, "--version")
+                                        .and_return(["Prince 16.1\n", "", success_status])
+      expect(described_class.present?).to be true
+    end
+
+    it "returns false when prince --version exits non-zero" do
+      allow(Open3).to receive(:capture3).with(described_class.path, "--version")
+                                        .and_return(["", "boom", failure_status])
+      expect(described_class.present?).to be false
+    end
+
+    it "returns false when binary is missing (Errno::ENOENT)" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+      expect(described_class.present?).to be false
+    end
+
+    it "caches the result across calls" do
+      allow(Open3).to receive(:capture3).and_return(["Prince 16.1\n", "", success_status])
+      described_class.present?
+      described_class.present?
+      expect(Open3).to have_received(:capture3).once
+    end
+  end
+
+  describe ".run" do
+    it "invokes prince with stdin and returns stdout on success" do
+      allow(Open3).to receive(:capture3).with(described_class.path, "-", "--output=-",
+                                              stdin_data: "<html/>")
+                                        .and_return(["%PDF-1.4 fake", "", success_status])
+      result = described_class.run(["-", "--output=-"], stdin: "<html/>")
+      expect(result).to eq("%PDF-1.4 fake")
+    end
+
+    it "raises NonZeroExit with stderr on failure" do
+      allow(Open3).to receive(:capture3).and_return(["", "prince: error: boom", failure_status])
+      expect { described_class.run([], stdin: "") }
+        .to raise_error(described_class::NonZeroExit, /boom/)
+    end
+  end
+
+  describe ".version" do
+    it "returns the first line of stdout when prince exits 0" do
+      allow(Open3).to receive(:capture3).with(described_class.path, "--version")
+                                        .and_return(["Prince 16.1\nbuild info", "", success_status])
+      expect(described_class.version).to eq("Prince 16.1")
+    end
+
+    it "returns nil on failure" do
+      allow(Open3).to receive(:capture3).and_return(["", "boom", failure_status])
+      expect(described_class.version).to be_nil
+    end
+
+    it "returns nil when binary missing" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+      expect(described_class.version).to be_nil
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/spec/prince_pdf/options_translator_spec.rb
+++ b/lib/plugins/prince_pdf/spec/prince_pdf/options_translator_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PrincePdf::OptionsTranslator do
+  subject(:args) { described_class.new(options).to_args }
+
+  let(:options) do
+    Exporters::Pdf::RenderOptions.build(
+      orientation: "portrait",
+      margin: { top: "0.5in", right: "1in", bottom: "0.5in", left: "0.5in" },
+      accessibility: :pdf_ua
+    )
+  end
+
+  describe "command shape" do
+    it "starts with stdin/stdout flags" do
+      expect(args[0]).to eq("-")
+      expect(args[1]).to eq("--output=-")
+    end
+
+    it "always enables JavaScript" do
+      expect(args).to include("--javascript")
+    end
+
+    it "always sets http-timeout" do
+      expect(args).to include("--http-timeout=30")
+    end
+
+    it "loads the base tagging stylesheet" do
+      base = args.find { |a| a.end_with?("prince_xml.css") && a.start_with?("--style=") }
+      expect(base).not_to be_nil
+    end
+
+    it "loads the orientation-specific stylesheet" do
+      orient = args.find { |a| a.end_with?("prince_xml_portrait.css") && a.start_with?("--style=") }
+      expect(orient).not_to be_nil
+    end
+
+    it "loads the JS hook via --script=" do
+      script = args.find { |a| a.start_with?("--script=") && a.end_with?("prince_xml.js") }
+      expect(script).not_to be_nil
+    end
+  end
+
+  describe "license" do
+    it "omits --license-file when env unset" do
+      original = ENV["PRINCE_LICENSE_PATH"]
+      ENV.delete("PRINCE_LICENSE_PATH")
+      expect(args.any? { |a| a.start_with?("--license-file=") }).to be false
+    ensure
+      ENV["PRINCE_LICENSE_PATH"] = original
+    end
+
+    it "includes --license-file when env set" do
+      original = ENV["PRINCE_LICENSE_PATH"]
+      ENV["PRINCE_LICENSE_PATH"] = "/etc/prince/license.dat"
+      expect(args).to include("--license-file=/etc/prince/license.dat")
+    ensure
+      ENV["PRINCE_LICENSE_PATH"] = original
+    end
+  end
+
+  describe "margin" do
+    it "joins top/right/bottom/left into a single quoted arg" do
+      margin_arg = args.find { |a| a.start_with?("--page-margin=") }
+      expect(margin_arg).to eq('--page-margin="0.5in 1in 0.5in 0.5in"')
+    end
+
+    it "omits --page-margin when margin is nil" do
+      no_margin = Exporters::Pdf::RenderOptions.build(orientation: "portrait", margin: nil)
+      out = described_class.new(no_margin).to_args
+      expect(out.any? { |a| a.start_with?("--page-margin=") }).to be false
+    end
+  end
+
+  describe "accessibility" do
+    it "adds --pdf-profile=PDF/UA-1 for :pdf_ua" do
+      pdf_ua = Exporters::Pdf::RenderOptions.build(accessibility: :pdf_ua, orientation: "portrait")
+      expect(described_class.new(pdf_ua).to_args).to include("--pdf-profile=PDF/UA-1")
+    end
+
+    it "adds --tagged-pdf for :tagged" do
+      tagged = Exporters::Pdf::RenderOptions.build(accessibility: :tagged, orientation: "portrait")
+      expect(described_class.new(tagged).to_args).to include("--tagged-pdf")
+    end
+
+    it "omits accessibility flags for :none" do
+      none = Exporters::Pdf::RenderOptions.build(accessibility: :none, orientation: "portrait")
+      out = described_class.new(none).to_args
+      expect(out.any? { |a| a.include?("--pdf-profile=") || a == "--tagged-pdf" }).to be false
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/spec/prince_pdf/options_translator_spec.rb
+++ b/lib/plugins/prince_pdf/spec/prince_pdf/options_translator_spec.rb
@@ -91,4 +91,31 @@ describe PrincePdf::OptionsTranslator do
       expect(out.any? { |a| a.include?("--pdf-profile=") || a == "--tagged-pdf" }).to be false
     end
   end
+
+  describe "orientation guard" do
+    # RenderOptions.build validates orientation, but RenderOptions.new bypasses
+    # that path. The translator must defend itself so a poisoned value cannot
+    # be interpolated into a stylesheet path that lands on the prince CLI.
+    it "raises ArgumentError when orientation is not in ALLOWED_ORIENTATION" do
+      poisoned = Exporters::Pdf::RenderOptions.new(
+        format: "Letter",
+        orientation: "../../../etc/passwd",
+        margin: nil,
+        dpi: nil,
+        image_dpi: nil,
+        print_background: true,
+        header_html: nil,
+        footer_html: nil,
+        metadata: {},
+        accessibility: :none,
+        show_header: true,
+        show_name_date: false,
+        padding: nil,
+        extra: {}
+      )
+
+      expect { described_class.new(poisoned).to_args }
+        .to raise_error(ArgumentError, /invalid orientation/)
+    end
+  end
 end

--- a/lib/plugins/prince_pdf/spec/prince_pdf/renderer_spec.rb
+++ b/lib/plugins/prince_pdf/spec/prince_pdf/renderer_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PrincePdf::Renderer do
+  it_behaves_like "a PDF renderer"
+
+  subject(:renderer) { described_class.new }
+
+  let(:html) { "<html><body><h1>Hi</h1></body></html>" }
+  let(:options) do
+    Exporters::Pdf::RenderOptions.build(
+      orientation: "portrait",
+      margin: { top: "0.5in", right: "1in", bottom: "0.5in", left: "0.5in" },
+      accessibility: :pdf_ua
+    )
+  end
+  let(:fake_pdf) { "%PDF-1.4 fake bytes" }
+
+  describe "protocol" do
+    it "has identifier :prince" do
+      expect(described_class.identifier).to eq(:prince)
+    end
+
+    it "advertises :pdf_ua and :tagged_pdf capabilities" do
+      expect(described_class.capabilities).to include(:pdf_ua, :tagged_pdf)
+    end
+
+    it "uses the pdf_prince layout" do
+      expect(described_class.layout_name).to eq("pdf_prince")
+    end
+
+    it "delegates available? to Executable.present?" do
+      allow(PrincePdf::Executable).to receive(:present?).and_return(true)
+      expect(described_class.available?).to be true
+
+      allow(PrincePdf::Executable).to receive(:present?).and_return(false)
+      expect(described_class.available?).to be false
+    end
+
+    it "satisfies RendererRegistry's protocol verifier" do
+      expect { Exporters::Pdf::RendererRegistry.register(described_class) }.not_to raise_error
+    ensure
+      Exporters::Pdf::RendererRegistry.unregister(:prince)
+      # Re-register the host's default to keep state stable for other specs
+      Exporters::Pdf::RendererRegistry.register(Exporters::Pdf::Renderers::Grover) \
+        unless Exporters::Pdf::RendererRegistry.all.include?(:grover)
+    end
+
+    it "is registered with :pdf_ua capability so the registry's gate accepts it" do
+      Exporters::Pdf::RendererRegistry.register(described_class)
+      allow(PrincePdf::Executable).to receive(:present?).and_return(true)
+
+      expect { Exporters::Pdf::RendererRegistry.fetch_for(identifier: :prince, accessibility: :pdf_ua) }
+        .not_to raise_error
+    ensure
+      Exporters::Pdf::RendererRegistry.unregister(:prince)
+    end
+  end
+
+  describe "#call" do
+    before do
+      allow(PrincePdf::Executable).to receive(:run).and_return(fake_pdf)
+    end
+
+    it "returns the bytes from Executable.run" do
+      expect(renderer.call(html, options: options)).to eq(fake_pdf)
+    end
+
+    it "passes the HTML on stdin and translated args to Executable.run" do
+      renderer.call(html, options: options)
+      expect(PrincePdf::Executable).to have_received(:run) do |args, stdin:|
+        expect(args).to be_an(Array)
+        expect(args).to include("--javascript", "--http-timeout=30", "--pdf-profile=PDF/UA-1")
+        expect(stdin).to eq(html)
+      end
+    end
+
+    it "wraps NonZeroExit as RendererRegistry::RenderError" do
+      allow(PrincePdf::Executable).to receive(:run)
+        .and_raise(PrincePdf::Executable::NonZeroExit, "prince: error: boom")
+
+      expect { renderer.call(html, options: options) }
+        .to raise_error(Exporters::Pdf::RendererRegistry::RenderError, /PrinceXML failed.*boom/)
+    end
+  end
+end

--- a/lib/plugins/prince_pdf/spec/prince_pdf/renderer_spec.rb
+++ b/lib/plugins/prince_pdf/spec/prince_pdf/renderer_spec.rb
@@ -39,22 +39,16 @@ describe PrincePdf::Renderer do
     end
 
     it "satisfies RendererRegistry's protocol verifier" do
-      expect { Exporters::Pdf::RendererRegistry.register(described_class) }.not_to raise_error
-    ensure
       Exporters::Pdf::RendererRegistry.unregister(:prince)
-      # Re-register the host's default to keep state stable for other specs
-      Exporters::Pdf::RendererRegistry.register(Exporters::Pdf::Renderers::Grover) \
-        unless Exporters::Pdf::RendererRegistry.all.include?(:grover)
+      expect { Exporters::Pdf::RendererRegistry.register(described_class) }.not_to raise_error
     end
 
     it "is registered with :pdf_ua capability so the registry's gate accepts it" do
-      Exporters::Pdf::RendererRegistry.register(described_class)
+      # :prince is registered at boot via PrincePdf.setup!; fetch_for uses it as-is.
       allow(PrincePdf::Executable).to receive(:present?).and_return(true)
 
       expect { Exporters::Pdf::RendererRegistry.fetch_for(identifier: :prince, accessibility: :pdf_ua) }
         .not_to raise_error
-    ensure
-      Exporters::Pdf::RendererRegistry.unregister(:prince)
     end
   end
 

--- a/sig/lib/exporters/pdf/render_options.rbs
+++ b/sig/lib/exporters/pdf/render_options.rbs
@@ -1,0 +1,37 @@
+module Exporters
+  module Pdf
+    class RenderOptions
+      type accessibility_level = :none | :tagged | :pdf_ua
+      type orientation = "portrait" | "landscape"
+      type margin_box = { top: String, right: String, bottom: String, left: String }
+
+      ALLOWED_ACCESSIBILITY: Array[Symbol]
+      ALLOWED_ORIENTATION: Array[String]
+      DEFAULTS: Hash[Symbol, untyped]
+
+      attr_reader format: String
+      attr_reader orientation: String
+      attr_reader margin: margin_box?
+      attr_reader dpi: Integer?
+      attr_reader image_dpi: Integer?
+      attr_reader print_background: bool
+      attr_reader header_html: String?
+      attr_reader footer_html: String?
+      attr_reader metadata: Hash[Symbol, untyped]
+      attr_reader accessibility: accessibility_level
+      attr_reader show_header: bool
+      attr_reader show_name_date: bool
+      attr_reader padding: Hash[Symbol, untyped]
+      attr_reader extra: Hash[Symbol, untyped]
+
+      def self.build: (**untyped overrides) -> RenderOptions
+      def self.validate!: (Hash[Symbol, untyped] attrs) -> void
+
+      def landscape?: () -> bool
+      def portrait?: () -> bool
+      def accessible?: () -> bool
+
+      def with: (**untyped overrides) -> RenderOptions
+    end
+  end
+end

--- a/sig/lib/exporters/pdf/renderer_registry.rbs
+++ b/sig/lib/exporters/pdf/renderer_registry.rbs
@@ -1,0 +1,39 @@
+module Exporters
+  module Pdf
+    module RendererRegistry
+      type accessibility_level = :none | :tagged | :pdf_ua
+
+      REQUIRED_INSTANCE_METHODS: Array[Symbol]
+      REQUIRED_CLASS_METHODS: Array[Symbol]
+      CAPABILITY_FOR_ACCESSIBILITY: Hash[Symbol, Array[Symbol]]
+      DEFAULT_RENDERER_ENV: String
+      FALLBACK_DEFAULT: Symbol
+
+      RendererNotFound: Class
+      RendererUnavailable: Class
+      ContractViolation: Class
+
+      class RenderError < StandardError
+      end
+
+      class UnsupportedCapability < StandardError
+      end
+
+      def self.fetch_for: (identifier: Symbol, ?accessibility: Symbol) -> untyped
+      def self.default: () -> Symbol
+
+      # Private. `untyped backend` because the protocol is duck-typed —
+      # `klass.capabilities` is guarded by `respond_to?` at runtime,
+      # which Steep cannot narrow on.
+      def self.capabilities_of: (untyped backend) -> Array[Symbol]
+
+      # Methods provided by extending PluginSystem::Registry.
+      def self.register: (untyped backend) -> untyped
+      def self.unregister: (Symbol | String identifier) -> untyped
+      def self.fetch: (Symbol | String identifier) -> untyped
+      def self.available: () -> Array[Symbol]
+      def self.all: () -> Array[Symbol]
+      def self.reset!: () -> Hash[Symbol, untyped]
+    end
+  end
+end

--- a/sig/lib/exporters/pdf/renderers/base.rbs
+++ b/sig/lib/exporters/pdf/renderers/base.rbs
@@ -1,0 +1,14 @@
+module Exporters
+  module Pdf
+    module Renderers
+      class Base
+        EMPTY_CAPABILITIES: Set[Symbol]
+        DEFAULT_LAYOUT: String
+
+        def self.capabilities: () -> Set[Symbol]
+        def self.available?: () -> bool
+        def self.layout_name: () -> String
+      end
+    end
+  end
+end

--- a/sig/lib/exporters/pdf/renderers/grover.rbs
+++ b/sig/lib/exporters/pdf/renderers/grover.rbs
@@ -1,0 +1,18 @@
+module Exporters
+  module Pdf
+    module Renderers
+      class Grover < Base
+        CAPABILITIES: Set[Symbol]
+
+        def self.identifier: () -> Symbol
+        def self.capabilities: () -> Set[Symbol]
+
+        def call: (String html, options: Exporters::Pdf::RenderOptions) -> String
+
+        private
+
+        def translate: (Exporters::Pdf::RenderOptions opts) -> Hash[Symbol, untyped]
+      end
+    end
+  end
+end

--- a/sig/lib/plugin_system/registry.rbs
+++ b/sig/lib/plugin_system/registry.rbs
@@ -9,6 +9,9 @@ module PluginSystem
     class Unavailable < Error
     end
 
+    class AlreadyRegistered < Error
+    end
+
     class ContractViolation < ArgumentError
     end
 

--- a/sig/lib/plugin_system/registry.rbs
+++ b/sig/lib/plugin_system/registry.rbs
@@ -1,0 +1,29 @@
+module PluginSystem
+  module Registry
+    class Error < StandardError
+    end
+
+    class NotFound < Error
+    end
+
+    class Unavailable < Error
+    end
+
+    class ContractViolation < ArgumentError
+    end
+
+    def register: (untyped backend) -> untyped
+    def unregister: (Symbol | String identifier) -> untyped
+    def fetch: (Symbol | String identifier) -> untyped
+    def available: () -> Array[Symbol]
+    def all: () -> Array[Symbol]
+    def reset!: () -> Hash[Symbol, untyped]
+
+    private
+
+    def store: () -> Hash[Symbol, untyped]
+    def klass_of: (untyped backend) -> untyped
+    def verify_contract!: (untyped klass) -> void
+    def available_class?: (untyped klass) -> bool
+  end
+end

--- a/spec/controllers/api/document_jobs_controller_spec.rb
+++ b/spec/controllers/api/document_jobs_controller_spec.rb
@@ -11,11 +11,23 @@ describe Api::DocumentJobsController do
   describe "#status" do
     subject(:do_request) { get :status, params: { job_id: job_id } }
 
+    # The controller eager-loads execution associations to stay consistent
+    # with JobTracker.status_batch. Stub the relation so .find_by is reached.
+    let(:relation) { class_double(SolidQueue::Job) }
+
+    before do
+      allow(SolidQueue::Job).to receive(:includes)
+        .with(:ready_execution, :claimed_execution, :failed_execution, :scheduled_execution, :blocked_execution)
+        .and_return(relation)
+    end
+
     context "when the job has failed via Solid Queue" do
-      let(:failed_execution) { instance_double(SolidQueue::FailedExecution, error: { "message" => "boom" }) }
+      # The real FailedExecution.message reads error["message"] from the
+      # serialized JSON column. We mock the delegated method directly.
+      let(:failed_execution) { instance_double(SolidQueue::FailedExecution, message: "boom") }
       let(:sq_job)           { instance_double(SolidQueue::Job, failed_execution: failed_execution) }
 
-      before { allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(sq_job) }
+      before { allow(relation).to receive(:find_by).with(active_job_id: job_id).and_return(sq_job) }
 
       it "returns a failed status with the underlying error message" do
         do_request
@@ -27,7 +39,7 @@ describe Api::DocumentJobsController do
 
     context "when the job completed successfully" do
       before do
-        allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(nil)
+        allow(relation).to receive(:find_by).with(active_job_id: job_id).and_return(nil)
         JobResult.create!(job_id: job_id, job_class: "DocumentPdfJob",
                           result: { "url" => "http://example.com/x.pdf", "pages" => 12 })
       end
@@ -42,7 +54,7 @@ describe Api::DocumentJobsController do
 
     context "when JobResult stores an `ok: false` failure record (non-preview failure path)" do
       before do
-        allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(nil)
+        allow(relation).to receive(:find_by).with(active_job_id: job_id).and_return(nil)
         JobResult.create!(job_id: job_id, job_class: "DocumentPdfJob",
                           result: { "ok" => false, "errors" => ["doc name", "PrinceXML failed"] })
       end
@@ -56,10 +68,10 @@ describe Api::DocumentJobsController do
     end
 
     context "when the job is still in the queue (no result, sq_job present)" do
-      let(:sq_job) { instance_double(SolidQueue::Job, failed_execution: nil) }
+      let(:sq_job) { instance_double(SolidQueue::Job, failed_execution: nil, finished?: false) }
 
       before do
-        allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(sq_job)
+        allow(relation).to receive(:find_by).with(active_job_id: job_id).and_return(sq_job)
       end
 
       it "returns a running status" do
@@ -68,8 +80,21 @@ describe Api::DocumentJobsController do
       end
     end
 
+    context "when sq_job is finished but no JobResult was written (legacy job)" do
+      let(:sq_job) { instance_double(SolidQueue::Job, failed_execution: nil, finished?: true) }
+
+      before do
+        allow(relation).to receive(:find_by).with(active_job_id: job_id).and_return(sq_job)
+      end
+
+      it "treats the SolidQueue finished marker as success" do
+        do_request
+        expect(response.parsed_body).to eq("status" => "done")
+      end
+    end
+
     context "when neither sq_job nor JobResult exists (unknown job_id)" do
-      before { allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(nil) }
+      before { allow(relation).to receive(:find_by).with(active_job_id: job_id).and_return(nil) }
 
       it "returns an unknown status" do
         do_request

--- a/spec/controllers/api/document_jobs_controller_spec.rb
+++ b/spec/controllers/api/document_jobs_controller_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Api::DocumentJobsController do
+  let(:user)   { create :admin }
+  let(:job_id) { "job_abc_123" }
+
+  before { sign_in user }
+
+  describe "#status" do
+    subject(:do_request) { get :status, params: { job_id: job_id } }
+
+    context "when the job has failed via Solid Queue" do
+      let(:failed_execution) { instance_double(SolidQueue::FailedExecution, error: { "message" => "boom" }) }
+      let(:sq_job)           { instance_double(SolidQueue::Job, failed_execution: failed_execution) }
+
+      before { allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(sq_job) }
+
+      it "returns a failed status with the underlying error message" do
+        do_request
+        body = response.parsed_body
+        expect(body["status"]).to eq("failed")
+        expect(body["error"]).to eq("boom")
+      end
+    end
+
+    context "when the job completed successfully" do
+      before do
+        allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(nil)
+        JobResult.create!(job_id: job_id, job_class: "DocumentPdfJob",
+                          result: { "url" => "http://example.com/x.pdf", "pages" => 12 })
+      end
+
+      it "returns a done status with the stored result payload" do
+        do_request
+        body = response.parsed_body
+        expect(body["status"]).to eq("done")
+        expect(body["result"]).to eq("url" => "http://example.com/x.pdf", "pages" => 12)
+      end
+    end
+
+    context "when JobResult stores an `ok: false` failure record (non-preview failure path)" do
+      before do
+        allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(nil)
+        JobResult.create!(job_id: job_id, job_class: "DocumentPdfJob",
+                          result: { "ok" => false, "errors" => ["doc name", "PrinceXML failed"] })
+      end
+
+      it "returns a failed status with the joined error message" do
+        do_request
+        body = response.parsed_body
+        expect(body["status"]).to eq("failed")
+        expect(body["error"]).to include("PrinceXML failed")
+      end
+    end
+
+    context "when the job is still in the queue (no result, sq_job present)" do
+      let(:sq_job) { instance_double(SolidQueue::Job, failed_execution: nil) }
+
+      before do
+        allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(sq_job)
+      end
+
+      it "returns a running status" do
+        do_request
+        expect(response.parsed_body).to eq("status" => "running")
+      end
+    end
+
+    context "when neither sq_job nor JobResult exists (unknown job_id)" do
+      before { allow(SolidQueue::Job).to receive(:find_by).with(active_job_id: job_id).and_return(nil) }
+
+      it "returns an unknown status" do
+        do_request
+        expect(response.parsed_body).to eq("status" => "unknown")
+      end
+    end
+
+    context "when the request is unauthenticated" do
+      before { sign_out user }
+
+      it "redirects to login (Devise authenticate_user!)" do
+        do_request
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -3,5 +3,45 @@
 require "rails_helper"
 
 describe DocumentsController do
-  it "Add tests here"
+  let(:user)     { create :admin }
+  let(:document) { create :document }
+  let(:job_id)   { "job_abc_123" }
+
+  before { sign_in user }
+
+  describe "#preview_pdf" do
+    render_views
+
+    let(:enqueued_job) { instance_double(DocumentPdfJob, job_id: job_id) }
+
+    before { allow(DocumentPdfJob).to receive(:perform_later).and_return(enqueued_job) }
+
+    around do |example|
+      original = ENV["FORCE_PREVIEW_GENERATION"]
+      ENV["FORCE_PREVIEW_GENERATION"] = "true"
+      example.run
+    ensure
+      ENV["FORCE_PREVIEW_GENERATION"] = original
+    end
+
+    it "enqueues a DocumentPdfJob via perform_later (not perform_now)" do
+      expect(DocumentPdfJob)
+        .to receive(:perform_later)
+        .with(document.id, hash_including(content_type: :preview, preview: true))
+        .and_return(enqueued_job)
+      expect(DocumentPdfJob).not_to receive(:perform_now)
+
+      get :preview_pdf, params: { id: document.id }
+    end
+
+    it "responds with a 200 instead of redirecting (async flow)" do
+      get :preview_pdf, params: { id: document.id }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "embeds the generic job-status URL so the page can poll" do
+      get :preview_pdf, params: { id: document.id }
+      expect(response.body).to include(status_api_document_job_path(job_id))
+    end
+  end
 end

--- a/spec/controllers/materials_controller_spec.rb
+++ b/spec/controllers/materials_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe MaterialsController do
+  let(:user)     { create :admin }
+  let(:material) { create :material }
+  let(:job_id)   { "job_xyz_456" }
+
+  before { sign_in user }
+
+  describe "#preview_pdf" do
+    render_views
+
+    let(:enqueued_job) { instance_double(MaterialPdfJob, job_id: job_id) }
+
+    before { allow(MaterialPdfJob).to receive(:perform_later).and_return(enqueued_job) }
+
+    around do |example|
+      original = ENV["FORCE_PREVIEW_GENERATION"]
+      ENV["FORCE_PREVIEW_GENERATION"] = "true"
+      example.run
+    ensure
+      ENV["FORCE_PREVIEW_GENERATION"] = original
+    end
+
+    it "enqueues a MaterialPdfJob via perform_later (not perform_now)" do
+      expect(MaterialPdfJob)
+        .to receive(:perform_later)
+        .with(material.id, hash_including(content_type: :preview, preview: true))
+        .and_return(enqueued_job)
+      expect(MaterialPdfJob).not_to receive(:perform_now)
+
+      get :preview_pdf, params: { id: material.id }
+    end
+
+    it "responds with a 200 instead of redirecting (async flow)" do
+      get :preview_pdf, params: { id: material.id }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "embeds the generic job-status URL so the page can poll" do
+      get :preview_pdf, params: { id: material.id }
+      expect(response.body).to include(status_api_document_job_path(job_id))
+    end
+  end
+end

--- a/spec/jobs/unit_bundle_pdf_job_spec.rb
+++ b/spec/jobs/unit_bundle_pdf_job_spec.rb
@@ -62,7 +62,12 @@ describe UnitBundlePdfJob do
 
     before do
       job.instance_variable_set(:@unit, unit_presenter)
-      job.instance_variable_set(:@options, { initial_job_id: "job_123" })
+      job.instance_variable_set(:@options, {
+        initial_job_id: "job_123",
+        renderer: :prince,
+        accessible_pdf: true,
+        accessibility: :pdf_ua
+      })
       allow(unit_presenter).to receive(:with_lock).and_yield
       allow(unit_presenter).to receive(:reload).and_return(unit_presenter)
       allow(unit_presenter).to receive(:update)
@@ -71,9 +76,27 @@ describe UnitBundlePdfJob do
     describe "#generate_lessons" do
       it "enqueues DocumentPdfJob for each lesson" do
         expect(DocumentPdfJob).to receive(:perform_later)
-          .with(lesson1.id, hash_including(content_type: "unit_bundle", initial_job_id: "job_123"))
+          .with(
+            lesson1.id,
+            hash_including(
+              content_type: "unit_bundle",
+              initial_job_id: "job_123",
+              renderer: :prince,
+              accessible_pdf: true,
+              accessibility: :pdf_ua
+            )
+          )
         expect(DocumentPdfJob).to receive(:perform_later)
-          .with(lesson2.id, hash_including(content_type: "unit_bundle", initial_job_id: "job_123"))
+          .with(
+            lesson2.id,
+            hash_including(
+              content_type: "unit_bundle",
+              initial_job_id: "job_123",
+              renderer: :prince,
+              accessible_pdf: true,
+              accessibility: :pdf_ua
+            )
+          )
 
         job.send(:generate_lessons)
       end
@@ -82,9 +105,27 @@ describe UnitBundlePdfJob do
     describe "#generate_materials" do
       it "enqueues MaterialPdfJob for each material" do
         expect(MaterialPdfJob).to receive(:perform_later)
-          .with(material1.id, hash_including(content_type: "unit_bundle", initial_job_id: "job_123"))
+          .with(
+            material1.id,
+            hash_including(
+              content_type: "unit_bundle",
+              initial_job_id: "job_123",
+              renderer: :prince,
+              accessible_pdf: true,
+              accessibility: :pdf_ua
+            )
+          )
         expect(MaterialPdfJob).to receive(:perform_later)
-          .with(material2.id, hash_including(content_type: "unit_bundle", initial_job_id: "job_123"))
+          .with(
+            material2.id,
+            hash_including(
+              content_type: "unit_bundle",
+              initial_job_id: "job_123",
+              renderer: :prince,
+              accessible_pdf: true,
+              accessibility: :pdf_ua
+            )
+          )
 
         job.send(:generate_materials)
       end

--- a/spec/lib/exporters/pdf/base_spec.rb
+++ b/spec/lib/exporters/pdf/base_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Exporters::Pdf::Base do
+  let(:exporter_class) do
+    Class.new(described_class) do
+      private
+
+      def base_path(name)
+        File.join("dummy", name)
+      end
+    end
+  end
+
+  let(:render_options) { Exporters::Pdf::RenderOptions.build }
+  let(:document) do
+    double(
+      "DocumentLike",
+      render_options: render_options,
+      pdf_renderer: nil,
+      accessibility: nil
+    )
+  end
+  let(:exporter) { exporter_class.new(document, {}) }
+
+  describe "#export" do
+    it "falls back to the default pdf layout when the renderer omits .layout_name" do
+      renderer = Class.new do
+        def call(html, options:)
+          "%PDF-1.4\n#{html}"
+        end
+      end.new
+
+      allow(Exporters::Pdf::RendererRegistry).to receive(:fetch_for).and_return(renderer)
+      allow(exporter).to receive(:render_template)
+        .with(File.join("dummy", "_footer"), layout: "pdf_plain")
+        .and_return("<footer/>")
+      expect(exporter).to receive(:render_template)
+        .with(File.join("dummy", "show"), layout: "pdf")
+        .and_return("<html/>")
+
+      expect(exporter.export).to start_with("%PDF-1.4")
+    end
+  end
+end

--- a/spec/lib/exporters/pdf/render_options_spec.rb
+++ b/spec/lib/exporters/pdf/render_options_spec.rb
@@ -8,7 +8,7 @@ describe Exporters::Pdf::RenderOptions do
       opts = described_class.build
 
       expect(opts.format).to eq("Letter")
-      expect(opts.orientation).to eq("portrait")
+      expect(opts.orientation).to eq(:portrait)
       expect(opts.print_background).to be true
       expect(opts.accessibility).to eq(:none)
       expect(opts.show_header).to be true
@@ -28,7 +28,7 @@ describe Exporters::Pdf::RenderOptions do
       )
 
       expect(opts.format).to eq("A4")
-      expect(opts.orientation).to eq("landscape")
+      expect(opts.orientation).to eq(:landscape)
       expect(opts.margin[:top]).to eq("1in")
       expect(opts.accessibility).to eq(:pdf_ua)
       expect(opts.show_header).to be false
@@ -45,9 +45,13 @@ describe Exporters::Pdf::RenderOptions do
         .to raise_error(ArgumentError, /orientation must be one of/)
     end
 
-    it "normalizes mixed-case orientation to lowercase" do
-      expect(described_class.build(orientation: "Landscape").orientation).to eq("landscape")
-      expect(described_class.build(orientation: "PORTRAIT").orientation).to eq("portrait")
+    it "normalizes mixed-case orientation to a lowercase symbol" do
+      expect(described_class.build(orientation: "Landscape").orientation).to eq(:landscape)
+      expect(described_class.build(orientation: "PORTRAIT").orientation).to eq(:portrait)
+    end
+
+    it "accepts symbol orientation" do
+      expect(described_class.build(orientation: :landscape).orientation).to eq(:landscape)
     end
   end
 

--- a/spec/lib/exporters/pdf/render_options_spec.rb
+++ b/spec/lib/exporters/pdf/render_options_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Exporters::Pdf::RenderOptions do
+  describe ".build" do
+    it "applies defaults for unspecified fields" do
+      opts = described_class.build
+
+      expect(opts.format).to eq("Letter")
+      expect(opts.orientation).to eq("portrait")
+      expect(opts.print_background).to be true
+      expect(opts.accessibility).to eq(:none)
+      expect(opts.show_header).to be true
+      expect(opts.show_name_date).to be false
+      expect(opts.metadata).to eq({})
+      expect(opts.extra).to eq({})
+    end
+
+    it "accepts overrides" do
+      opts = described_class.build(
+        format: "A4",
+        orientation: "landscape",
+        margin: { top: "1in", right: "0.5in", bottom: "1in", left: "0.5in" },
+        accessibility: :pdf_ua,
+        show_header: false,
+        show_name_date: true
+      )
+
+      expect(opts.format).to eq("A4")
+      expect(opts.orientation).to eq("landscape")
+      expect(opts.margin[:top]).to eq("1in")
+      expect(opts.accessibility).to eq(:pdf_ua)
+      expect(opts.show_header).to be false
+      expect(opts.show_name_date).to be true
+    end
+
+    it "rejects unknown accessibility levels" do
+      expect { described_class.build(accessibility: :pdf_x) }
+        .to raise_error(ArgumentError, /accessibility must be one of/)
+    end
+
+    it "rejects unknown orientations" do
+      expect { described_class.build(orientation: "diagonal") }
+        .to raise_error(ArgumentError, /orientation must be one of/)
+    end
+
+    it "normalizes mixed-case orientation to lowercase" do
+      expect(described_class.build(orientation: "Landscape").orientation).to eq("landscape")
+      expect(described_class.build(orientation: "PORTRAIT").orientation).to eq("portrait")
+    end
+  end
+
+  describe "#landscape? / #portrait?" do
+    it "is portrait by default" do
+      opts = described_class.build
+      expect(opts.portrait?).to be true
+      expect(opts.landscape?).to be false
+    end
+
+    it "reflects landscape orientation" do
+      opts = described_class.build(orientation: "landscape")
+      expect(opts.landscape?).to be true
+      expect(opts.portrait?).to be false
+    end
+  end
+
+  describe "#accessible?" do
+    it "is false when accessibility is :none" do
+      expect(described_class.build(accessibility: :none).accessible?).to be false
+    end
+
+    it "is true for :tagged" do
+      expect(described_class.build(accessibility: :tagged).accessible?).to be true
+    end
+
+    it "is true for :pdf_ua" do
+      expect(described_class.build(accessibility: :pdf_ua).accessible?).to be true
+    end
+  end
+
+  describe "value semantics" do
+    it "treats two builds with the same args as equal" do
+      a = described_class.build(format: "A4")
+      b = described_class.build(format: "A4")
+      expect(a).to eq(b)
+    end
+
+    it "is frozen by Data semantics" do
+      opts = described_class.build
+      expect { opts.instance_variable_set(:@format, "A4") }.to raise_error(FrozenError)
+    end
+  end
+end

--- a/spec/lib/exporters/pdf/renderer_registry_spec.rb
+++ b/spec/lib/exporters/pdf/renderer_registry_spec.rb
@@ -52,12 +52,12 @@ describe Exporters::Pdf::RendererRegistry do
         .to raise_error(described_class::ContractViolation, /class.*identifier/)
     end
 
-    it "replaces a prior registration with the same identifier" do
-      first  = build_renderer(identifier: :gamma)
+    it "raises AlreadyRegistered when an identifier is registered twice" do
+      first = build_renderer(identifier: :gamma)
       second = build_renderer(identifier: :gamma)
       described_class.register(first)
-      described_class.register(second)
-      expect(described_class.fetch(:gamma)).to be_a(second)
+      expect { described_class.register(second) }
+        .to raise_error(PluginSystem::Registry::AlreadyRegistered, /:gamma/)
     end
   end
 

--- a/spec/lib/exporters/pdf/renderer_registry_spec.rb
+++ b/spec/lib/exporters/pdf/renderer_registry_spec.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Exporters::Pdf::RendererRegistry do
+  # Save and restore the registry around each example so test-only registrations
+  # do not leak into other specs (which rely on the boot-time :grover registration).
+  around do |example|
+    saved = described_class.instance_variable_get(:@store)&.dup
+    described_class.reset!
+    example.run
+  ensure
+    described_class.instance_variable_set(:@store, saved || {})
+  end
+
+  # Helper: build a renderer class on the fly with the given protocol shape.
+  def build_renderer(identifier:, capabilities: [], available: true)
+    Class.new do
+      define_singleton_method(:identifier)   { identifier }
+      define_singleton_method(:capabilities) { Set.new(capabilities) }
+      define_singleton_method(:available?)   { available }
+      define_method(:call) { |_html, options:| "%PDF-1.4\n" }
+    end
+  end
+
+  describe ".register" do
+    it "stores a class that satisfies the protocol" do
+      klass = build_renderer(identifier: :alpha)
+      described_class.register(klass)
+      expect(described_class.all).to eq([:alpha])
+    end
+
+    it "stores an instance that satisfies the protocol" do
+      klass = build_renderer(identifier: :beta)
+      described_class.register(klass.new)
+      expect(described_class.all).to eq([:beta])
+    end
+
+    it "rejects a class missing the #call instance method" do
+      bad = Class.new do
+        define_singleton_method(:identifier) { :no_call }
+      end
+      expect { described_class.register(bad) }
+        .to raise_error(described_class::ContractViolation, /instance.*call/)
+    end
+
+    it "rejects a class missing the .identifier class method" do
+      bad = Class.new do
+        define_method(:call) { |_html, options:| "" }
+      end
+      expect { described_class.register(bad) }
+        .to raise_error(described_class::ContractViolation, /class.*identifier/)
+    end
+
+    it "replaces a prior registration with the same identifier" do
+      first  = build_renderer(identifier: :gamma)
+      second = build_renderer(identifier: :gamma)
+      described_class.register(first)
+      described_class.register(second)
+      expect(described_class.fetch(:gamma)).to be_a(second)
+    end
+  end
+
+  describe ".fetch" do
+    it "returns an instance for a class registration" do
+      klass = build_renderer(identifier: :alpha)
+      described_class.register(klass)
+      expect(described_class.fetch(:alpha)).to be_a(klass)
+    end
+
+    it "returns the same instance for an instance registration" do
+      klass    = build_renderer(identifier: :beta)
+      instance = klass.new
+      described_class.register(instance)
+      expect(described_class.fetch(:beta)).to be(instance)
+    end
+
+    it "raises RendererNotFound for an unknown identifier" do
+      expect { described_class.fetch(:missing) }
+        .to raise_error(described_class::RendererNotFound)
+    end
+
+    it "raises RendererUnavailable for a registered-but-unavailable backend" do
+      klass = build_renderer(identifier: :delta, available: false)
+      described_class.register(klass)
+      expect { described_class.fetch(:delta) }
+        .to raise_error(described_class::RendererUnavailable)
+    end
+
+    it "treats a registered backend without .available? as available" do
+      klass = Class.new do
+        define_singleton_method(:identifier) { :implicit }
+        define_singleton_method(:capabilities) { Set.new }
+        define_method(:call) { |_html, options:| "%PDF-1.4\n" }
+      end
+
+      described_class.register(klass)
+      expect(described_class.fetch(:implicit)).to be_a(klass)
+    end
+  end
+
+  describe ".fetch_for" do
+    it "returns the backend when no accessibility is required" do
+      klass = build_renderer(identifier: :alpha)
+      described_class.register(klass)
+      expect(described_class.fetch_for(identifier: :alpha)).to be_a(klass)
+    end
+
+    it "returns the backend when capability requirement is met" do
+      klass = build_renderer(identifier: :prince_like, capabilities: %i(pdf_ua tagged_pdf))
+      described_class.register(klass)
+      expect(described_class.fetch_for(identifier: :prince_like, accessibility: :pdf_ua))
+        .to be_a(klass)
+    end
+
+    it "treats a backend without .capabilities as supporting only accessibility=:none" do
+      klass = Class.new do
+        define_singleton_method(:identifier) { :minimal }
+        define_singleton_method(:available?) { true }
+        define_method(:call) { |_html, options:| "%PDF-1.4\n" }
+      end
+
+      described_class.register(klass)
+      expect(described_class.fetch_for(identifier: :minimal)).to be_a(klass)
+      expect { described_class.fetch_for(identifier: :minimal, accessibility: :pdf_ua) }
+        .to raise_error(described_class::UnsupportedCapability)
+    end
+
+    it "raises UnsupportedCapability when the backend lacks required capability" do
+      klass = build_renderer(identifier: :grover_like)
+      described_class.register(klass)
+      expect { described_class.fetch_for(identifier: :grover_like, accessibility: :pdf_ua) }
+        .to raise_error(described_class::UnsupportedCapability, /missing capabilities: pdf_ua/)
+    end
+
+    it "raises ArgumentError for unknown accessibility level" do
+      klass = build_renderer(identifier: :alpha)
+      described_class.register(klass)
+      expect { described_class.fetch_for(identifier: :alpha, accessibility: :pdf_x) }
+        .to raise_error(ArgumentError, /unknown accessibility level/)
+    end
+  end
+
+  describe ".available / .all" do
+    before do
+      described_class.register(build_renderer(identifier: :one))
+      described_class.register(build_renderer(identifier: :two, available: false))
+    end
+
+    it "returns only available identifiers from .available" do
+      expect(described_class.available).to eq([:one])
+    end
+
+    it "returns all registered identifiers from .all" do
+      expect(described_class.all).to contain_exactly(:one, :two)
+    end
+
+    it "includes backends that omit .available? in .available" do
+      klass = Class.new do
+        define_singleton_method(:identifier) { :implicit }
+        define_singleton_method(:capabilities) { Set.new }
+        define_method(:call) { |_html, options:| "%PDF-1.4\n" }
+      end
+
+      described_class.register(klass)
+      expect(described_class.available).to include(:implicit)
+    end
+  end
+
+  describe ".default" do
+    around do |example|
+      original = ENV[described_class::DEFAULT_RENDERER_ENV]
+      Setting.unset(:pdf)
+      example.run
+    ensure
+      ENV[described_class::DEFAULT_RENDERER_ENV] = original
+      Setting.unset(:pdf)
+    end
+
+    it "falls back to :grover when neither Setting nor env is set" do
+      ENV.delete(described_class::DEFAULT_RENDERER_ENV)
+      expect(described_class.default).to eq(:grover)
+    end
+
+    it "reads from DEFAULT_PDF_RENDERER env when Setting is unset" do
+      ENV[described_class::DEFAULT_RENDERER_ENV] = "prince"
+      expect(described_class.default).to eq(:prince)
+    end
+
+    it "prefers Setting over env" do
+      ENV[described_class::DEFAULT_RENDERER_ENV] = "grover"
+      Setting.set(:pdf, "default_renderer" => "prince")
+      expect(described_class.default).to eq(:prince)
+    end
+
+    it "ignores Setting when its default_renderer is blank, falling through to env" do
+      ENV[described_class::DEFAULT_RENDERER_ENV] = "prince"
+      Setting.set(:pdf, "default_renderer" => "")
+      expect(described_class.default).to eq(:prince)
+    end
+  end
+
+  describe ".unregister" do
+    it "removes a previously registered backend" do
+      described_class.register(build_renderer(identifier: :temp))
+      described_class.unregister(:temp)
+      expect(described_class.all).to be_empty
+    end
+  end
+end

--- a/spec/lib/exporters/pdf/renderers/grover_spec.rb
+++ b/spec/lib/exporters/pdf/renderers/grover_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Exporters::Pdf::Renderers::Grover do
+  it_behaves_like "a PDF renderer"
+
+  subject(:renderer) { described_class.new }
+
+  let(:grover_double) { instance_double(::Grover, to_pdf: pdf_bytes) }
+  let(:pdf_bytes) { "%PDF-1.4\n…fake bytes…" }
+  let(:html) { "<html><body>hi</body></html>" }
+
+  before do
+    allow(::Grover).to receive(:new).and_return(grover_double)
+  end
+
+  describe "protocol" do
+    it "has identifier :grover" do
+      expect(described_class.identifier).to eq(:grover)
+    end
+
+    it "advertises capabilities including :js_execution" do
+      expect(described_class.capabilities).to include(:js_execution, :background_print, :landscape)
+    end
+
+    it "is available by default" do
+      expect(described_class.available?).to be true
+    end
+
+    it "satisfies RendererRegistry's protocol verifier" do
+      expect { Exporters::Pdf::RendererRegistry.register(described_class) }.not_to raise_error
+      Exporters::Pdf::RendererRegistry.unregister(:grover)
+    end
+  end
+
+  describe "#call" do
+    let(:options) do
+      Exporters::Pdf::RenderOptions.build(
+        format: "Letter",
+        orientation: "portrait",
+        margin: { top: "0.5in", right: "1in", bottom: "0.5in", left: "0.5in" },
+        dpi: 72,
+        print_background: true,
+        footer_html: "<footer>page</footer>"
+      )
+    end
+
+    it "returns Grover's PDF bytes" do
+      expect(renderer.call(html, options: options)).to eq(pdf_bytes)
+    end
+
+    it "passes the HTML to Grover" do
+      renderer.call(html, options: options)
+      expect(::Grover).to have_received(:new).with(html, anything)
+    end
+
+    it "translates portrait orientation to landscape: false" do
+      renderer.call(html, options: options)
+      expect(::Grover).to have_received(:new).with(html, hash_including(landscape: false))
+    end
+
+    it "translates landscape orientation to landscape: true" do
+      landscape_opts = Exporters::Pdf::RenderOptions.build(orientation: "landscape", footer_html: "<f/>")
+      renderer.call(html, options: landscape_opts)
+      expect(::Grover).to have_received(:new).with(html, hash_including(landscape: true))
+    end
+
+    it "passes through format, margin, dpi, print_background" do
+      renderer.call(html, options: options)
+      expect(::Grover).to have_received(:new).with(
+        html,
+        hash_including(
+          format: "Letter",
+          margin: options.margin,
+          dpi: 72,
+          print_background: true
+        )
+      )
+    end
+
+    it "always sets prefer_css_page_size: false" do
+      renderer.call(html, options: options)
+      expect(::Grover).to have_received(:new).with(html, hash_including(prefer_css_page_size: false))
+    end
+
+    it "enables display_header_footer when footer_html is present" do
+      renderer.call(html, options: options)
+      expect(::Grover).to have_received(:new).with(html, hash_including(
+        display_header_footer: true,
+        footer_template: "<footer>page</footer>"
+      ))
+    end
+
+    it "disables display_header_footer when both header_html and footer_html are nil" do
+      bare = Exporters::Pdf::RenderOptions.build(header_html: nil, footer_html: nil)
+      renderer.call(html, options: bare)
+      expect(::Grover).to have_received(:new).with(html, hash_including(display_header_footer: false))
+    end
+
+    it "omits nil-valued translated keys" do
+      no_margin = Exporters::Pdf::RenderOptions.build(margin: nil, dpi: nil, footer_html: "<f/>")
+      renderer.call(html, options: no_margin)
+
+      expect(::Grover).to have_received(:new) do |_html, args|
+        expect(args).not_to have_key(:margin)
+        expect(args).not_to have_key(:dpi)
+      end
+    end
+
+    it "merges RenderOptions#extra over the translated hash" do
+      extra_opts = Exporters::Pdf::RenderOptions.build(
+        footer_html: "<f/>",
+        extra: { wait_until: "networkidle2", scale: 1.5 }
+      )
+      renderer.call(html, options: extra_opts)
+      expect(::Grover).to have_received(:new).with(html, hash_including(
+        wait_until: "networkidle2",
+        scale: 1.5
+      ))
+    end
+  end
+end

--- a/spec/lib/exporters/pdf/renderers/grover_spec.rb
+++ b/spec/lib/exporters/pdf/renderers/grover_spec.rb
@@ -29,8 +29,8 @@ describe Exporters::Pdf::Renderers::Grover do
     end
 
     it "satisfies RendererRegistry's protocol verifier" do
-      expect { Exporters::Pdf::RendererRegistry.register(described_class) }.not_to raise_error
       Exporters::Pdf::RendererRegistry.unregister(:grover)
+      expect { Exporters::Pdf::RendererRegistry.register(described_class) }.not_to raise_error
     end
   end
 

--- a/spec/lib/plugin_system/registry_spec.rb
+++ b/spec/lib/plugin_system/registry_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PluginSystem::Registry do
+  # A minimal host that extends the mixin and declares the protocol.
+  let(:host) do
+    Module.new do
+      extend PluginSystem::Registry
+
+      const_set(:REQUIRED_INSTANCE_METHODS, %i(perform).freeze)
+      const_set(:REQUIRED_CLASS_METHODS,    %i(identifier).freeze)
+    end
+  end
+
+  def build_backend(identifier:, available: true)
+    Class.new do
+      define_singleton_method(:identifier) { identifier }
+      define_singleton_method(:available?) { available }
+      define_method(:perform) { |*| "result" }
+    end
+  end
+
+  describe "#register" do
+    it "stores a class that satisfies the protocol" do
+      host.register(build_backend(identifier: :alpha))
+      expect(host.all).to eq([:alpha])
+    end
+
+    it "stores an instance that satisfies the protocol" do
+      host.register(build_backend(identifier: :beta).new)
+      expect(host.all).to eq([:beta])
+    end
+
+    it "rejects a backend missing a required instance method" do
+      bad = Class.new do
+        define_singleton_method(:identifier) { :no_perform }
+      end
+      expect { host.register(bad) }
+        .to raise_error(PluginSystem::Registry::ContractViolation, /instance.*perform/)
+    end
+
+    it "rejects a backend missing a required class method" do
+      bad = Class.new do
+        define_method(:perform) { |*| "" }
+      end
+      expect { host.register(bad) }
+        .to raise_error(PluginSystem::Registry::ContractViolation, /class.*identifier/)
+    end
+  end
+
+  describe "#fetch" do
+    it "returns an instance for a class registration" do
+      klass = build_backend(identifier: :alpha)
+      host.register(klass)
+      expect(host.fetch(:alpha)).to be_a(klass)
+    end
+
+    it "returns the same instance for an instance registration" do
+      instance = build_backend(identifier: :beta).new
+      host.register(instance)
+      expect(host.fetch(:beta)).to be(instance)
+    end
+
+    it "raises NotFound for an unknown identifier" do
+      expect { host.fetch(:missing) }
+        .to raise_error(PluginSystem::Registry::NotFound)
+    end
+
+    it "raises Unavailable when the backend reports available? false" do
+      host.register(build_backend(identifier: :gamma, available: false))
+      expect { host.fetch(:gamma) }
+        .to raise_error(PluginSystem::Registry::Unavailable)
+    end
+
+    it "treats a backend without .available? as available" do
+      klass = Class.new do
+        define_singleton_method(:identifier) { :no_probe }
+        define_method(:perform) { |*| "result" }
+      end
+
+      host.register(klass)
+      expect(host.fetch(:no_probe)).to be_a(klass)
+    end
+  end
+
+  describe "#available / #all" do
+    before do
+      host.register(build_backend(identifier: :one))
+      host.register(build_backend(identifier: :two, available: false))
+    end
+
+    it "returns only available identifiers from #available" do
+      expect(host.available).to eq([:one])
+    end
+
+    it "returns all registered identifiers from #all" do
+      expect(host.all).to contain_exactly(:one, :two)
+    end
+
+    it "includes backends that omit .available? in #available" do
+      klass = Class.new do
+        define_singleton_method(:identifier) { :implicit }
+        define_method(:perform) { |*| "result" }
+      end
+
+      host.register(klass)
+      expect(host.available).to include(:implicit)
+    end
+  end
+
+  describe "#unregister and #reset!" do
+    before { host.register(build_backend(identifier: :temp)) }
+
+    it "removes a previously registered backend" do
+      host.unregister(:temp)
+      expect(host.all).to be_empty
+    end
+
+    it "clears all registrations" do
+      host.reset!
+      expect(host.all).to be_empty
+    end
+  end
+end

--- a/spec/lib/plugin_system/registry_spec.rb
+++ b/spec/lib/plugin_system/registry_spec.rb
@@ -47,6 +47,12 @@ describe PluginSystem::Registry do
       expect { host.register(bad) }
         .to raise_error(PluginSystem::Registry::ContractViolation, /class.*identifier/)
     end
+
+    it "raises AlreadyRegistered when the identifier is already taken" do
+      host.register(build_backend(identifier: :dup))
+      expect { host.register(build_backend(identifier: :dup)) }
+        .to raise_error(PluginSystem::Registry::AlreadyRegistered, /:dup/)
+    end
   end
 
   describe "#fetch" do
@@ -62,9 +68,10 @@ describe PluginSystem::Registry do
       expect(host.fetch(:beta)).to be(instance)
     end
 
-    it "raises NotFound for an unknown identifier" do
+    it "raises NotFound for an unknown identifier and lists registered ones" do
+      host.register(build_backend(identifier: :present))
       expect { host.fetch(:missing) }
-        .to raise_error(PluginSystem::Registry::NotFound)
+        .to raise_error(PluginSystem::Registry::NotFound, /:missing.*registered.*:present/m)
     end
 
     it "raises Unavailable when the backend reports available? false" do

--- a/spec/models/concerns/pdf_renderable_spec.rb
+++ b/spec/models/concerns/pdf_renderable_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PdfRenderable do
+  # Test through Document — both Document and Material include this concern.
+  subject(:record) { build_stubbed(:document, metadata: starting_metadata) }
+
+  let(:starting_metadata) { {} }
+
+  describe "#pdf_renderer" do
+    context "when metadata['pdf_renderer'] is set" do
+      let(:starting_metadata) { { "pdf_renderer" => "prince" } }
+
+      it "returns the string value" do
+        expect(record.pdf_renderer).to eq("prince")
+      end
+    end
+
+    context "when metadata is empty" do
+      it "returns nil" do
+        expect(record.pdf_renderer).to be_nil
+      end
+    end
+
+    context "when metadata['pdf_renderer'] is empty string" do
+      let(:starting_metadata) { { "pdf_renderer" => "" } }
+
+      it "returns nil" do
+        expect(record.pdf_renderer).to be_nil
+      end
+    end
+
+    context "when metadata is nil" do
+      let(:starting_metadata) { nil }
+
+      it "returns nil" do
+        expect(record.pdf_renderer).to be_nil
+      end
+    end
+  end
+
+  describe "#pdf_renderer=" do
+    it "stores under metadata['pdf_renderer']" do
+      record.pdf_renderer = "prince"
+      expect(record.metadata["pdf_renderer"]).to eq("prince")
+    end
+
+    it "coerces symbols to strings" do
+      record.pdf_renderer = :prince
+      expect(record.metadata["pdf_renderer"]).to eq("prince")
+    end
+
+    it "removes the key when set to nil" do
+      record.metadata = { "pdf_renderer" => "prince", "other" => "keep" }
+      record.pdf_renderer = nil
+      expect(record.metadata).not_to have_key("pdf_renderer")
+      expect(record.metadata["other"]).to eq("keep")
+    end
+
+    it "preserves other metadata keys" do
+      record.metadata = { "subject" => "math" }
+      record.pdf_renderer = "prince"
+      expect(record.metadata).to include("subject" => "math", "pdf_renderer" => "prince")
+    end
+  end
+
+  describe "#accessibility" do
+    context "when set to a valid value" do
+      let(:starting_metadata) { { "accessibility" => "pdf_ua" } }
+
+      it "returns the string value" do
+        expect(record.accessibility).to eq("pdf_ua")
+      end
+    end
+
+    context "when unset" do
+      it "returns nil" do
+        expect(record.accessibility).to be_nil
+      end
+    end
+  end
+
+  describe "#accessibility=" do
+    it "accepts :none, :tagged, :pdf_ua" do
+      %w(none tagged pdf_ua).each do |level|
+        record.accessibility = level
+        expect(record.metadata["accessibility"]).to eq(level)
+      end
+    end
+
+    it "accepts symbols" do
+      record.accessibility = :pdf_ua
+      expect(record.metadata["accessibility"]).to eq("pdf_ua")
+    end
+
+    it "rejects unknown levels" do
+      expect { record.accessibility = "pdf_x" }
+        .to raise_error(ArgumentError, /accessibility must be one of/)
+    end
+
+    it "removes the key when set to nil" do
+      record.metadata = { "accessibility" => "pdf_ua" }
+      record.accessibility = nil
+      expect(record.metadata).not_to have_key("accessibility")
+    end
+  end
+
+  describe "exporter resolution chain" do
+    let(:document) { build_stubbed(:document, metadata: { "pdf_renderer" => "prince" }) }
+    let(:presenter) { DocumentPresenter.new(document, content_type: :lesson) }
+
+    it "presenter delegates pdf_renderer to model via SimpleDelegator" do
+      expect(presenter.pdf_renderer).to eq("prince")
+    end
+
+    it "exporter resolves the renderer name from the model" do
+      exporter = Exporters::Pdf::Document.new(presenter, {})
+      expect(exporter.send(:renderer_name)).to eq(:prince)
+    end
+
+    it "falls through to registry default when document.pdf_renderer is nil" do
+      bare = build_stubbed(:document, metadata: {})
+      exporter = Exporters::Pdf::Document.new(DocumentPresenter.new(bare, content_type: :lesson), {})
+      expect(exporter.send(:renderer_name)).to eq(Exporters::Pdf::RendererRegistry.default)
+    end
+
+    it "exporter resolves accessibility from the model" do
+      doc = build_stubbed(:document, metadata: { "accessibility" => "pdf_ua" })
+      exporter = Exporters::Pdf::Document.new(DocumentPresenter.new(doc, content_type: :lesson), {})
+      expect(exporter.send(:accessibility_level)).to eq(:pdf_ua)
+    end
+
+    it "per-call options[:accessible_pdf] = true overrides record-level :none" do
+      doc = build_stubbed(:document, metadata: { "accessibility" => "none" })
+      exporter = Exporters::Pdf::Document.new(
+        DocumentPresenter.new(doc, content_type: :lesson),
+        { accessible_pdf: true }
+      )
+      expect(exporter.send(:accessibility_level)).to eq(:pdf_ua)
+    end
+
+    it "per-call options[:renderer] overrides record-level pdf_renderer" do
+      exporter = Exporters::Pdf::Document.new(presenter, { renderer: :grover })
+      expect(exporter.send(:renderer_name)).to eq(:grover)
+    end
+  end
+end

--- a/spec/presenters/material_presenter_spec.rb
+++ b/spec/presenters/material_presenter_spec.rb
@@ -97,7 +97,9 @@ describe MaterialPresenter do
       end
 
       it "returns orientation from metadata" do
-        expect(presenter.orientation).to eq("landscape")
+        # RenderOptions normalizes orientation to a symbol in ALLOWED_ORIENTATION;
+        # the presenter delegates straight to render_options.orientation.
+        expect(presenter.orientation).to eq(:landscape)
       end
     end
 
@@ -113,7 +115,7 @@ describe MaterialPresenter do
       end
 
       it "normalizes to landscape" do
-        expect(presenter.orientation).to eq("landscape")
+        expect(presenter.orientation).to eq(:landscape)
       end
     end
 
@@ -129,7 +131,7 @@ describe MaterialPresenter do
       end
 
       it "normalizes to portrait" do
-        expect(presenter.orientation).to eq("portrait")
+        expect(presenter.orientation).to eq(:portrait)
       end
     end
   end

--- a/spec/support/shared_examples/pdf_renderer.rb
+++ b/spec/support/shared_examples/pdf_renderer.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+#
+# Conformance suite for PDF renderer plugins.
+#
+# Usage:
+#
+#   describe MyPdf::Renderer do
+#     it_behaves_like "a PDF renderer"
+#   end
+#
+# The examples verify the renderer satisfies the protocol that
+# `Exporters::Pdf::RendererRegistry` validates at registration time, plus a
+# few ergonomic checks (return types, registry round-trip). Runtime behavior
+# (does `#call` actually produce a valid PDF?) is NOT exercised here —
+# that requires the renderer's external dependencies to be installed and
+# belongs in the plugin's own integration tests.
+#
+shared_examples "a PDF renderer" do
+  describe "protocol conformance" do
+    it "exposes a Symbol identifier" do
+      expect(described_class.identifier).to be_a(Symbol)
+    end
+
+    it "implements #call as an instance method" do
+      expect(described_class.public_method_defined?(:call)).to be(true)
+    end
+
+    it "accepts an `options:` keyword argument on #call" do
+      params = described_class.instance_method(:call).parameters
+      keyword_names = params.select { |type, _| %i(keyreq key).include?(type) }.map(&:last)
+      expect(keyword_names).to include(:options)
+    end
+
+    it "advertises capabilities as a Set" do
+      expect(described_class.capabilities).to be_a(Set)
+    end
+
+    it "implements .available? returning a Boolean" do
+      expect([true, false]).to include(described_class.available?)
+    end
+
+    it "implements .layout_name returning a String" do
+      expect(described_class.layout_name).to be_a(String)
+    end
+  end
+
+  describe "registry integration" do
+    around do |example|
+      saved = Exporters::Pdf::RendererRegistry.instance_variable_get(:@store)&.dup
+      Exporters::Pdf::RendererRegistry.reset!
+      example.run
+    ensure
+      Exporters::Pdf::RendererRegistry.instance_variable_set(:@store, saved || {})
+    end
+
+    it "registers without raising ContractViolation" do
+      expect { Exporters::Pdf::RendererRegistry.register(described_class) }.not_to raise_error
+    end
+
+    it "appears under its identifier in RendererRegistry.all after registration" do
+      Exporters::Pdf::RendererRegistry.register(described_class)
+      expect(Exporters::Pdf::RendererRegistry.all).to include(described_class.identifier)
+    end
+
+    it "is fetchable by its identifier" do
+      Exporters::Pdf::RendererRegistry.register(described_class)
+      next unless described_class.available?
+
+      backend = Exporters::Pdf::RendererRegistry.fetch(described_class.identifier)
+      expect(backend).to be_a(described_class).or be(described_class)
+    end
+  end
+end


### PR DESCRIPTION
Refs:
- #57 
- #66

---

## Summary

Introduces a pluggable PDF rendering architecture (ADR-0001) that decouples
PDF generation from a single engine, and ships a **PrinceXML** renderer as a
plugin alongside the existing Grover/Chromium renderer. PDF generation also
becomes async with job-status polling.

## Changes

**Renderer architecture**
- Renderer registry, base renderer interface, and render-options abstraction
  (`lib/exporters/pdf/`)
- Grover renderer extracted behind the new interface; admin renderer-select UI
- Plugin system registry (`lib/plugin_system/registry.rb`)

**PrinceXML plugin** (`lib/plugins/prince_pdf/`)
- Renderer, executable wrapper, options translator, CSS/JS assets, PDF layout
- Full spec suite + RBS signatures

**Async PDF generation**
- `Api::DocumentJobsController` + `preview_generating` view for status polling
- `PdfRenderable` concern; document/material PDF jobs report statuses

**Extra changes**

- [description](https://github.com/learningtapestry/lcms-core/pull/69#issuecomment-4657937365)