### PR TITLE
(#73) Change metadata specs for units and lessons

### DIFF
--- a/app/presenters/unit_presenter.rb
+++ b/app/presenters/unit_presenter.rb
@@ -3,9 +3,9 @@
 class UnitPresenter < BasePresenter
   include HasGdocSource
 
-  delegate :acknowledgements, :copyright, :course, :description, :license,
+  delegate :copyright, :course_name, :description, :license,
            :unit_id, :unit_title_spanish, :unit_topic, :unit_topic_spanish,
-           to: :base_metadata
+           :version, to: :base_metadata
 
   def bundle_folder(bundle_type = nil)
     folder = "#{BUNDLE_S3_FOLDER}"

--- a/docs/core/lesson-metadata-specs.md
+++ b/docs/core/lesson-metadata-specs.md
@@ -8,7 +8,7 @@
 | lesson-title | text |
 | lesson-title-Spanish | text; can be blank |
 | lesson-label | Options: required, optional; can be blank |
-| lesson-type | text Options: |
+| lesson-type | text; can be blank Options: (client defined; not validated) |
 | standards | unique alphanumeric codes; comma separated list (e.g., MS-ESS2-4, MS-ESS2-5); codes will connect to spreadsheet with standards language for rendering |
 | description | text that describes the lesson: “In this lesson, we…” |
 | description-past | text that describes the lesson in past tense language; “In the previous lesson, we…”; will be blank for the last lesson of a unit |
@@ -30,7 +30,7 @@
 | activity-time | number |
 | activity-description | Text; can be blank |
 | activity-label | Options: required, optional; can be blank |
-| activity-type | text or unique alphanumeric code; can be blank Options: |
+| activity-type | text; can be blank Options: (client defined; not validated) |
 | activity-type-purpose | text; can be blank |
 | slide-id | text; can be blank |
 | lms-enabled | Yes or No |
@@ -44,12 +44,12 @@
 | grading-required | Yes or No |
 | grading-format | text; can be blank Options: completion, points (If we remove grading-required and this is blank, then grading-required \= No; if this is filled out then  grading-required \= Yes) |
 | total-points | Text; can be blank |
-| student-grouping | Options: individual, partners, small group, class  |
+| student-grouping | Options: individual, partners, group, class  |
 | activity-materials-student | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
 | activity-materials-pair | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
 | activity-materials-group | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
 | activity-materials-class | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
-| activity-metadata-teacher | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
+| activity-materials-teacher | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
 | vocabulary | text, comma separated list; can be blank |
 
 | \[lms-materials\] |  |

--- a/docs/core/material-metadata-specification.md
+++ b/docs/core/material-metadata-specification.md
@@ -3,7 +3,7 @@
 | subject |  |
 | grade |  |
 | material-id | unique alphanumeric code |
-| material-type | unique codes (e.g., Handout, Reference, Link); system needs to handle and specify both internal and external materials |
+| material-type | unique codes; system needs to handle and specify both internal and external materials. Options: handout, reference, link, key, assessment, overview, acknowledgements |
 | material-title | text |
 | material-title-Spanish |  |
 | material-order | numerical value \= or \> than 0 used to indicate the material \# relative to other materials used in the same lesson (e.g. “Student Handout 1” vs. “Student Handout 2”). If value \= 0 or left blank then number should not be rendered (i.e. “Student Handout” not “Student Handout 0”) |

--- a/docs/unit-metadata-spec.md
+++ b/docs/unit-metadata-spec.md
@@ -12,7 +12,7 @@ This document defines the `unit-metadata` table expected in Google Docs sources.
 | :---- | :---- | :---- |
 | `subject` | text | Required |
 | `grade` | number | Required |
-| `course` | text | Optional, can be blank |
+| `course-name` | text | Optional, can be blank |
 | `unit-id` | unique alphanumeric id | Required |
 | `unit-title` | text | Required |
 | `unit-title-Spanish` | text | Optional, can be blank |
@@ -21,7 +21,7 @@ This document defines the `unit-metadata` table expected in Google Docs sources.
 | `description` | text | Required |
 | `copyright` | text | Optional, can be blank |
 | `license` | text | Optional, can be blank |
-| `acknowledgements` | text | Optional, can be blank |
+| `version` | text | Optional, tracks the unit version |
 | `unit-materials` | comma separated list | Materials aligned to the unit level, using material ids |
 
 ## Validation Expectations
@@ -32,7 +32,7 @@ This document defines the `unit-metadata` table expected in Google Docs sources.
 `grade`
 : required numeric value
 
-`course`
+`course-name`
 : optional text value
 
 `unit-id`
@@ -59,7 +59,7 @@ This document defines the `unit-metadata` table expected in Google Docs sources.
 `license`
 : optional text value
 
-`acknowledgements`
+`version`
 : optional text value
 
 `unit-materials`

--- a/lib/doc_template/objects/activity.rb
+++ b/lib/doc_template/objects/activity.rb
@@ -21,7 +21,7 @@ module DocTemplate
         attribute :activity_materials_pair, :string
         attribute :activity_materials_group, :string
         attribute :activity_materials_class, :string
-        attribute :activity_metadata_teacher, :string
+        attribute :activity_materials_teacher, :string
         attribute :activity_standard, :string
         attribute :activity_mathematical_practice, :string
         attribute :activity_metacognition, :string

--- a/lib/doc_template/objects/unit.rb
+++ b/lib/doc_template/objects/unit.rb
@@ -3,9 +3,8 @@
 module DocTemplate
   module Objects
     class Unit < Base
-      attribute :acknowledgements, :string, default: ""
       attribute :copyright, :string, default: ""
-      attribute :course, :string, default: ""
+      attribute :course_name, :string, default: ""
       attribute :description, :string, default: ""
       attribute :grade, :string, default: ""
       attribute :license, :string, default: ""
@@ -16,6 +15,7 @@ module DocTemplate
       attribute :unit_title_spanish, :string, default: ""
       attribute :unit_topic, :string, default: ""
       attribute :unit_topic_spanish, :string, default: ""
+      attribute :version, :string, default: ""
     end
   end
 end

--- a/lib/doc_template/tables/activity.rb
+++ b/lib/doc_template/tables/activity.rb
@@ -7,8 +7,8 @@ module DocTemplate
       HTML_VALUE_FIELDS = %w(activity-description).freeze
       MATERIALS_KEYS = %w(activity-materials-student activity-materials-pair
                           activity-materials-group activity-materials-class
-                          activity-metadata-teacher).freeze
-      GROUPING_OPTIONS = ["individual", "partners", "small group", "class"].freeze
+                          activity-materials-teacher).freeze
+      GROUPING_OPTIONS = %w(individual partners group class).freeze
       LMS_TYPE_OPTIONS = %w(assignment discussion assessment reference).freeze
       LMS_FIELDS = %w(lms-title lms-title-spanish lms-instructions
                        lms-instructions-spanish lms-type).freeze

--- a/lib/doc_template/tables/unit.rb
+++ b/lib/doc_template/tables/unit.rb
@@ -4,7 +4,7 @@ module DocTemplate
   module Tables
     class Unit < Base
       HEADER_LABEL = "unit-metadata"
-      HTML_VALUE_FIELDS = %w(description acknowledgements).freeze
+      HTML_VALUE_FIELDS = %w(description).freeze
       MATERIALS_KEY = "unit-materials"
       REQUIRED_FIELDS = %w(subject grade unit-id unit-title unit-topic description).freeze
       UNIT_ID_REGEX = /\A[a-z0-9]+\z/i

--- a/spec/fixtures/tables/activity-metadata-valid.html
+++ b/spec/fixtures/tables/activity-metadata-valid.html
@@ -7,7 +7,7 @@
     <tbody>
       <tr><td colspan="2"><span>activity-metadata</span></td></tr>
       <tr><td><span>activity-title</span></td><td><span>Warm Up</span></td></tr>
-      <tr><td><span>student-grouping</span></td><td><span>small group</span></td></tr>
+      <tr><td><span>student-grouping</span></td><td><span>group</span></td></tr>
       <tr><td><span>lms-enabled</span></td><td><span>Yes</span></td></tr>
       <tr><td><span>lms-type</span></td><td><span>assignment</span></td></tr>
       <tr><td><span>lms-title</span></td><td><span>Warm Up Activity</span></td></tr>

--- a/spec/fixtures/tables/unit-metadata.html
+++ b/spec/fixtures/tables/unit-metadata.html
@@ -15,7 +15,7 @@
           <td><p><span>6</span></p></td>
         </tr>
         <tr>
-          <td><p><span>course</span></p></td>
+          <td><p><span>course-name</span></p></td>
           <td><p><span>Algebra</span></p></td>
         </tr>
         <tr>
@@ -53,10 +53,8 @@
           <td><p><span>CC BY-NC</span></p></td>
         </tr>
         <tr>
-          <td><p><span>acknowledgements</span></p></td>
-          <td>
-            <p><span>Created with district partners.</span></p>
-          </td>
+          <td><p><span>version</span></p></td>
+          <td><p><span>1.0</span></p></td>
         </tr>
         <tr>
           <td><p><span>unit-materials</span></p></td>

--- a/spec/lib/doc_template/objects/unit_spec.rb
+++ b/spec/lib/doc_template/objects/unit_spec.rb
@@ -8,9 +8,8 @@ describe DocTemplate::Objects::Unit do
 
     it "defaults string attributes to empty string" do
       %i(
-        acknowledgements
         copyright
-        course
+        course_name
         description
         grade
         license
@@ -20,6 +19,7 @@ describe DocTemplate::Objects::Unit do
         unit_title_spanish
         unit_topic
         unit_topic_spanish
+        version
       ).each do |attr|
         expect(unit.public_send(attr)).to eq("")
       end
@@ -39,7 +39,7 @@ describe DocTemplate::Objects::Unit do
       {
         "Subject" => "math",
         "Grade" => "6",
-        "Course" => "Algebra",
+        "Course-Name" => "Algebra",
         "Unit-ID" => "M6U1A",
         "Unit-Title" => "Expressions and Equations",
         "Unit-Title-Spanish" => "Expresiones y ecuaciones",
@@ -48,7 +48,7 @@ describe DocTemplate::Objects::Unit do
         "Description" => "<p>Unit description</p>",
         "Copyright" => "Learning Tapestry",
         "License" => "CC BY-NC",
-        "Acknowledgements" => "<p>Thanks</p>",
+        "Version" => "1.0",
         "Material-Ids" => [1, 2]
       }
     end
@@ -58,7 +58,7 @@ describe DocTemplate::Objects::Unit do
     it "maps metadata keys to unit attributes" do
       expect(unit.subject).to eq("math")
       expect(unit.grade).to eq("6")
-      expect(unit.course).to eq("Algebra")
+      expect(unit.course_name).to eq("Algebra")
       expect(unit.unit_id).to eq("M6U1A")
       expect(unit.unit_title).to eq("Expressions and Equations")
       expect(unit.unit_title_spanish).to eq("Expresiones y ecuaciones")
@@ -67,7 +67,7 @@ describe DocTemplate::Objects::Unit do
       expect(unit.description).to eq("<p>Unit description</p>")
       expect(unit.copyright).to eq("Learning Tapestry")
       expect(unit.license).to eq("CC BY-NC")
-      expect(unit.acknowledgements).to eq("<p>Thanks</p>")
+      expect(unit.version).to eq("1.0")
       expect(unit.material_ids).to eq([1, 2])
     end
   end

--- a/spec/lib/doc_template/tables/unit_spec.rb
+++ b/spec/lib/doc_template/tables/unit_spec.rb
@@ -22,7 +22,7 @@ describe DocTemplate::Tables::Unit do
         expect(parsed_table.data).to include(
           "subject" => "math",
           "grade" => "6",
-          "course" => "Algebra",
+          "course-name" => "Algebra",
           "unit-id" => "m6u1a",
           "unit-title" => "Expressions and Equations",
           "unit-title-spanish" => "Expresiones y ecuaciones",
@@ -30,6 +30,7 @@ describe DocTemplate::Tables::Unit do
           "unit-topic-spanish" => "Relaciones entre variables",
           "copyright" => "Learning Tapestry",
           "license" => "CC BY-NC",
+          "version" => "1.0",
           "unit-materials" => "MAT-1, MAT-2"
         )
       end
@@ -40,7 +41,6 @@ describe DocTemplate::Tables::Unit do
 
       it "preserves html fields" do
         expect(parsed_table.data["description"]).to include("<p>")
-        expect(parsed_table.data["acknowledgements"]).to include("<p>")
       end
 
       it "resolves unit materials to material ids" do

--- a/spec/services/unit_resource_upsert_service_spec.rb
+++ b/spec/services/unit_resource_upsert_service_spec.rb
@@ -8,7 +8,7 @@ describe UnitResourceUpsertService do
       {
         "subject" => "math",
         "grade" => "6",
-        "course" => "Algebra",
+        "course-name" => "Algebra",
         "unit_id" => "m6u1a",
         "unit_title" => "Expressions and Equations",
         "description" => "<p>Students analyze variable relationships.</p>",


### PR DESCRIPTION
https://github.com/learningtapestry/lcms-core/issues/73

### Unit metadata
- Remove `acknowledgements` field
- Rename `course` → `course-name`
- Add `version` field (text, for tracking)

### Lesson / activity metadata
- `lesson-type` and `activity-type` are now free-text and not validated (client-defined values)
- Rename `student-grouping` option `small group` → `group`
- Fix typo: `activity-metadata-teacher` → `activity-materials-teacher`