### PR TITLE
(#76) Styling improvements for Lesson and Materials PDF/Google Doc exports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,9 @@ gem "combine_pdf", "~> 1.0"
 gem "rubyzip", "~> 2.3"
 gem "nokogiri", "~> 1.19"
 gem "sanitize", "~> 7.0"
+# Inlines the Gdoc <style> CSS onto each element: Google Docs' HTML import
+# ignores <style>/global CSS, so styling must be per-element inline.
+gem "premailer", "~> 1.27"
 
 # HTTP & External APIs
 gem "httparty", "~> 0.24"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    css_parser (3.0.0)
+      addressable
+      ssrf_filter (~> 1.5)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -456,6 +459,10 @@ GEM
       activesupport (>= 6.1)
     pp (0.6.3)
       prettyprint
+    premailer (1.29.0)
+      addressable
+      css_parser (>= 1.19.0)
+      htmlentities (>= 4.0.0)
     prettyprint (0.2.0)
     prism (1.9.0)
     pstore (0.1.4)
@@ -661,7 +668,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
-    ssrf_filter (1.3.0)
+    ssrf_filter (1.5.0)
     steep (1.10.0)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
@@ -690,7 +697,6 @@ GEM
     thruster (0.1.18-aarch64-linux)
     thruster (0.1.18-arm64-darwin)
     thruster (0.1.18-x86_64-linux)
-    tilt (2.7.0)
     timeout (0.6.0)
     traceroute (0.8.1)
       rails (>= 3.0.0)
@@ -799,6 +805,7 @@ DEPENDENCIES
   overcommit
   pg (~> 1.6)
   pg_search (~> 2.3, >= 2.3.2)
+  premailer (~> 1.27)
   pstore
   puma (>= 5.0)
   rack (~> 3.2)

--- a/app/assets/stylesheets/_tokens.scss
+++ b/app/assets/stylesheets/_tokens.scss
@@ -1,0 +1,50 @@
+// =========================================================================
+// LCMS Core styling design tokens — single source of truth
+// =========================================================================
+// Spec: "LCMS Core Styling Defaults". Open items live in
+// docs/core/styling-defaults-needs-clarification.md.
+//
+// Shared by every export stylesheet (pdf.scss, gdoc.scss, pdf_plain.scss)
+// so font, color, size, and spacing values are declared in ONE place.
+// Changing a token here updates all targets — do not re-declare these in
+// the consuming files.
+//
+// All tokens are `!default`, so a fork overrides them by importing its own
+// values BEFORE this partial:
+//
+//   @import "overrides"; // sets e.g. $font-family-body
+//   @import "tokens";    // !default assignments below are then skipped
+//
+// "Configure in code, not UI": this partial is the configuration surface.
+
+// --- Fonts ---------------------------------------------------------------
+// Approved families (client preference order): Lexend, Arial, Calibri,
+// Helvetica, Verdana. Lexend is delivered via the Google Fonts CDN @import
+// in the consuming stylesheets (decision Q5).
+
+$font-family-body: "Lexend", Arial, Calibri, Helvetica, Verdana, sans-serif !default;
+$font-family-heading: $font-family-body !default;
+
+// --- Colors --------------------------------------------------------------
+
+$color-text: #000000 !default;
+$color-text-muted: #434343 !default;
+
+// --- Sizes ---------------------------------------------------------------
+
+$font-size-body: 11pt !default;
+$font-size-caption: 9pt !default;
+$font-size-footer-bold: 10pt !default;
+$line-height-body: 1.15 !default;
+
+$font-size-h1: 22pt !default;
+$font-size-h2: 18pt !default;
+$font-size-h3: 14pt !default;
+$font-size-h4: 13pt !default;
+$font-size-h5: 12pt !default;
+$font-size-h6: 11pt !default;
+
+// --- Heading paragraph-after spacing -------------------------------------
+
+$space-heading-large: 6pt !default;  // H1, H2 paragraph-after
+$space-heading-medium: 4pt !default; // H3 paragraph-after

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -10,3 +10,27 @@ $fa-font-path: '/assets';
 @import '@fortawesome/fontawesome-free/scss/v4-shims';
 
 @import 'ckeditor';
+
+// --- Admin: callout type list --------------------------------------------
+// Icon preview in admin Settings > Documents > Callout Types
+// (app/views/admin/settings/show/_callout_list.html.erb).
+//
+// The size cap has to live here and not only in the uploader: icons uploaded
+// before CalloutIconUploader started downscaling are still stored at their
+// original resolution, and without a cap the browser lays them out at natural
+// size — a 1024px icon turns one table row into a full screen of page.
+.c-callout-list__icon-preview {
+  width: 40px;
+  height: 40px;
+  // `contain` so a non-square icon is letterboxed rather than stretched.
+  object-fit: contain;
+  flex: 0 0 auto;
+}
+
+// Keeps the preview beside the file input instead of stacked above it, so a
+// row with an icon is the same height as a row without one.
+.c-callout-list__icon-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/app/assets/stylesheets/gdoc.scss
+++ b/app/assets/stylesheets/gdoc.scss
@@ -25,27 +25,22 @@
 //     the layout body. !important keeps our defaults visible until the
 //     normalization pass (Q6) lands.
 
-// --- Design tokens (kept in sync with pdf.scss) --------------------------
+// --- Design tokens -------------------------------------------------------
+// Single source of truth, shared with pdf.scss and pdf_plain.scss.
 
-$font-family-body: "Lexend", Arial, sans-serif !default;
-$font-family-heading: $font-family-body !default;
+@import "tokens";
 
-$color-text: #000000 !default;
-$color-text-muted: #434343 !default;
+// --- Font override for the Gdoc target -----------------------------------
+// Google Docs' HTML import resolves a multi-font CSS stack unreliably: given
+// "Lexend", Arial, Calibri, ... it picked Calibri (the 3rd fallback) instead
+// of Lexend. Name ONLY the native Lexend Google Font here so the imported doc
+// uses it directly; if Lexend were unavailable, Google Docs falls back to its
+// own default (Arial) — still preferable to an arbitrary stack member. The PDF
+// keeps the full fallback stack from _tokens.scss (Chromium loads Lexend via
+// the Google Fonts @import there).
 
-$font-size-body: 11pt !default;
-$font-size-caption: 9pt !default;
-$line-height-body: 1.15 !default;
-
-$font-size-h1: 22pt !default;
-$font-size-h2: 18pt !default;
-$font-size-h3: 14pt !default;
-$font-size-h4: 13pt !default;
-$font-size-h5: 12pt !default;
-$font-size-h6: 11pt !default;
-
-$space-heading-large: 6pt !default;
-$space-heading-medium: 4pt !default;
+$font-family-body: "Lexend";
+$font-family-heading: "Lexend";
 
 // --- Base / body ---------------------------------------------------------
 
@@ -84,56 +79,55 @@ p {
   background-color: transparent !important;
 }
 
-// --- Headings ------------------------------------------------------------
+// A near-invisible blank paragraph used only to break Google Docs' import rule
+// that demotes a heading which is the first child of a container / directly
+// after another heading (see documents/gdoc/_header.html.erb, before the
+// authored prep body). It must import as a real Normal paragraph so the next
+// heading maps, but must not add a visible blank line. !important so premailer's
+// generic `p { font-size }` rule cannot override the tiny size at inline time.
+.c-gdoc-heading-break {
+  font-size: 1pt !important;
+  line-height: 1 !important;
+  margin: 0 !important;
+}
 
-%heading-base {
+// --- Headings ------------------------------------------------------------
+// Google Docs' HTML import maps <h1>–<h6> to real Heading styles ONLY when the
+// tag is left PURE. Any CSS on the tag — which premailer would inline at export
+// (lib/exporters/gdoc/base.rb#inline_css) — degrades it back to Normal text.
+// So heading tags carry NO rules; the gdoc templates wrap the heading text in
+// an inner <span class="o-gdoc-h*"> and the typography below targets that span.
+// Premailer inlines these onto the span, leaving the <h*> tag clean. (Margins
+// are omitted: Google Docs drops them on import; heading spacing comes from the
+// named Heading style.)
+
+%gdoc-heading {
   font-family: $font-family-heading !important;
   font-weight: bold !important;
-  text-align: left !important;
-  margin-top: 0;
 }
 
-h1 {
-  @extend %heading-base;
+.o-gdoc-h1 {
+  @extend %gdoc-heading;
   font-size: $font-size-h1 !important;
   color: $color-text !important;
-  margin-bottom: $space-heading-large;
 }
 
-h2 {
-  @extend %heading-base;
+.o-gdoc-h2 {
+  @extend %gdoc-heading;
   font-size: $font-size-h2 !important;
   color: $color-text !important;
-  margin-bottom: $space-heading-large;
 }
 
-h3 {
-  @extend %heading-base;
+.o-gdoc-h3 {
+  @extend %gdoc-heading;
   font-size: $font-size-h3 !important;
   color: $color-text-muted !important;
-  margin-bottom: $space-heading-medium;
 }
 
-h4 {
-  @extend %heading-base;
+.o-gdoc-h4 {
+  @extend %gdoc-heading;
   font-size: $font-size-h4 !important;
   color: $color-text !important;
-  margin-bottom: 0;
-}
-
-h5 {
-  @extend %heading-base;
-  font-size: $font-size-h5 !important;
-  color: $color-text-muted !important;
-  margin-bottom: 0;
-}
-
-h6 {
-  @extend %heading-base;
-  font-size: $font-size-h6 !important;
-  color: $color-text !important;
-  font-style: italic !important;
-  margin-bottom: 0;
 }
 
 // --- Images --------------------------------------------------------------
@@ -149,7 +143,21 @@ figcaption {
   text-align: right;
 }
 
+.o-ld-image__credit {
+  font-family: $font-family-body !important;
+  font-size: $font-size-caption !important;
+  color: $color-text !important;
+  text-align: right;
+  margin: 0;
+  padding-bottom: 2pt;
+  border-bottom: 1pt solid $color-text;
+}
+
 // --- Material tag --------------------------------------------------------
+
+// Rendered by lib/doc_template/tags/material_tag.rb as
+// <span class="o-ld-material">. Material tag is "normal text, but
+// italicized" — it is not a link.
 
 .o-ld-material {
   font-style: italic !important;
@@ -266,16 +274,25 @@ figcaption {
   }
 }
 
+// --- Lesson preparation (lesson-prep-directions) -------------------------
+// Rendered by app/views/documents/gdoc/_header.html.erb from the lesson-prep
+// table's directions field — rich HTML (sub-headings + nested lists) emitted
+// verbatim, so styling leans on the global heading/list rules.
+
+.c-lesson-prep__body {
+  margin: 0 0 $space-heading-large 0;
+
+  ol,
+  ul {
+    margin: 0;
+    padding-left: 36pt;
+  }
+}
+
 // --- Activity (flowing layout) -------------------------------------------
 
 .o-ld-activity {
   margin: $space-heading-large 0 0;
-
-  &__divider {
-    border: 0;
-    border-top: 1pt solid $color-text-muted;
-    margin: $space-heading-large 0;
-  }
 
   &__heading {
     margin-bottom: 4pt;
@@ -294,6 +311,11 @@ figcaption {
     font-size: $font-size-body !important;
     color: $color-text !important;
     margin: 0 0 4pt 0;
+  }
+
+  // activity-description: blank line above, then the authored intro paragraph.
+  &__description {
+    margin: $space-heading-large 0 0 0;
   }
 
   &__guidance {
@@ -338,10 +360,19 @@ figcaption {
     margin-bottom: 4pt;
   }
 
+  // Client-configured icon image (admin Settings > Documents > Callout
+  // Types), rendered in place of the default "+" — see
+  // gdoc/callout_inline.html.erb.
+  .o-ld-callout__icon-img {
+    max-width: 24pt;
+    max-height: 24pt;
+    vertical-align: middle;
+  }
+
   .o-ld-callout__type {
     font-family: $font-family-body !important;
     font-size: $font-size-body !important;
-    font-weight: 400 !important;
+    font-weight: bold !important;
     color: $color-text !important;
     line-height: $line-height-body;
   }
@@ -354,5 +385,74 @@ figcaption {
       margin: 0;
       padding: 0;
     }
+  }
+}
+
+// --- Material external assets --------------------------------------------
+// Rendered by app/views/materials/_external_assets.html.erb. The anchors keep
+// their target/href through Google Docs import; class styling is best-effort.
+.o-m-external-assets {
+  margin: $space-heading-large 0;
+
+  &__list {
+    margin: 0;
+    padding-left: 16pt;
+  }
+
+  &__label {
+    font-weight: bold !important;
+    margin-right: 4pt;
+  }
+
+  &__link {
+    text-decoration: underline;
+    word-break: break-all;
+  }
+}
+
+// --- Unit acknowledgements -----------------------------------------------
+// Rendered by app/views/units/gdoc/show.html.erb from the unit-metadata
+// `acknowledgements` field: an injected H1 page title followed by the
+// authored sub-section H3s ("Steering Committee", "Reviewers", …) and their
+// name paragraphs. Core typography comes from the global heading/body rules;
+// this only adds breathing room between the authored groups.
+
+.c-unit-acknowledgements {
+  h3 {
+    margin-top: $space-heading-large;
+  }
+}
+
+// --- Material Name/Date row ----------------------------------------------
+// Worksheet fill-in line rendered before the Document Title when the
+// material-metadata name-date field is Yes (app/views/materials/{pdf,gdoc}/
+// _header.html.erb). Label + a border-bottom "rule" cell that fills the
+// remaining width; the date rule is fixed-narrow on the right.
+.o-m-namedate {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 $space-heading-large 0;
+
+  td {
+    padding: 0;
+    vertical-align: bottom;
+  }
+
+  &__label {
+    white-space: nowrap;
+    font-weight: bold !important;
+    padding-right: 4pt;
+  }
+
+  &__label--date {
+    padding-left: 12pt;
+  }
+
+  &__rule {
+    border-bottom: 1pt solid $color-text;
+  }
+
+  &__rule--date {
+    width: 25%;
   }
 }

--- a/app/assets/stylesheets/gdoc.scss
+++ b/app/assets/stylesheets/gdoc.scss
@@ -456,3 +456,22 @@ figcaption {
     width: 25%;
   }
 }
+
+// --- Nested list levels --------------------------------------------------
+// HtmlSanitizer#keep_bullets_level turns a Google Docs `<li>`'s margin-left
+// into a depth class (u-ld-indent--l2, --l3, …) at PARSE time, discarding the
+// original margin. Without these rules the class is inert and every nested
+// level renders flush with its parent — a numbered step's sub-bullets sit at
+// the same indent as the steps themselves.
+//
+// One level is 36pt, matching the step Google Docs uses. Level 1 is the list's
+// own indent, so classes start at 2. The range runs past level 6 because
+// documents parsed before the level formula was corrected carry classes from
+// the old ((margin - 50) / 30) + 2 scale, which emitted l7/l8 for deep lists —
+// their content is a parse-time snapshot, so those classes must stay styled
+// until such documents are re-imported.
+@for $level from 2 through 8 {
+  .u-ld-indent--l#{$level} {
+    margin-left: #{($level - 1) * 36}pt;
+  }
+}

--- a/app/assets/stylesheets/gdoc.scss
+++ b/app/assets/stylesheets/gdoc.scss
@@ -73,9 +73,33 @@ ol {
 }
 
 // --- Highlighting --------------------------------------------------------
+// Spec: not included by default; clients must request.
+//
+// HtmlSanitizer allows `background-color` through and its #post_clean_styles
+// pass only reaches p/span/sub/sup AND skips anything with a <td> ancestor, so
+// author highlight survives on list items, on inline emphasis, and on any
+// p/span inside a table cell. This clears it at export time.
+//
+// NO h1–h6 here, unlike pdf.scss: any CSS on a heading tag is inlined by
+// premailer and degrades it back to Normal text on import (see the Headings
+// note below). Heading text lives in an inner `span`, which this already covers.
+//
+// td/th/tr are deliberately NOT listed: cell shading is an authored design
+// choice about a table, not stray highlight.
 
 span,
-p {
+p,
+li,
+a,
+b,
+i,
+u,
+s,
+em,
+strong,
+mark,
+sub,
+sup {
   background-color: transparent !important;
 }
 
@@ -131,9 +155,12 @@ p {
 }
 
 // --- Images --------------------------------------------------------------
-// Caption rendered by lib/doc_template/templates/gdoc/image.html.erb as a
-// <td class="o-ld-image__caption"> inside a layout table. Class-based, so
-// may be brittle through Google Docs import — verify per render.
+// Rendered by lib/doc_template/templates/gdoc/image.html.erb as a
+// single-column table: image, caption, credit — the same stacking order as the
+// PDF figure. Google Docs' HTML import styles text runs and drops cell-level
+// text formatting, so these classes sit on the inner <p> elements, NOT on the
+// <td> (the caption previously took its class from the cell and lost its
+// size/alignment on the way in).
 
 .o-ld-image__caption,
 figcaption {
@@ -141,6 +168,7 @@ figcaption {
   font-size: $font-size-caption !important;
   color: $color-text !important;
   text-align: right;
+  margin: 0;
 }
 
 .o-ld-image__credit {
@@ -149,6 +177,13 @@ figcaption {
   color: $color-text !important;
   text-align: right;
   margin: 0;
+}
+
+// The credit's hairline rule lives on the containing cell, not the <p>: Google
+// Docs drops paragraph borders on import but honours table cell borders, so
+// this is the only form of the rule that survives. The PDF draws the same line
+// directly on .o-ld-image__credit (see pdf.scss).
+.o-ld-image__credit-cell {
   padding-bottom: 2pt;
   border-bottom: 1pt solid $color-text;
 }

--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -16,26 +16,9 @@
 // Once that lands, !important here can be removed.
 
 // --- Design tokens -------------------------------------------------------
+// Single source of truth, shared with gdoc.scss and pdf_plain.scss.
 
-$font-family-body: "Lexend", Arial, sans-serif !default;
-$font-family-heading: $font-family-body !default;
-
-$color-text: #000000 !default;
-$color-text-muted: #434343 !default;
-
-$font-size-body: 11pt !default;
-$font-size-caption: 9pt !default;
-$line-height-body: 1.15 !default;
-
-$font-size-h1: 22pt !default;
-$font-size-h2: 18pt !default;
-$font-size-h3: 14pt !default;
-$font-size-h4: 13pt !default;
-$font-size-h5: 12pt !default;
-$font-size-h6: 11pt !default;
-
-$space-heading-large: 6pt !default;  // H1, H2 paragraph-after
-$space-heading-medium: 4pt !default; // H3 paragraph-after
+@import "tokens";
 
 // --- Base / body ---------------------------------------------------------
 
@@ -54,8 +37,24 @@ td,
 th {
   font-family: $font-family-body !important;
   font-size: $font-size-body !important;
-  color: $color-text !important;
+  // Default brand text color. NOT !important, so authored inline color in
+  // material content survives (see docs/core/table-rendering-limitations.md L1).
+  // Lesson content re-enforces the brand color below.
+  color: $color-text;
   line-height: $line-height-body !important;
+}
+
+// Lessons normalize all text to the brand color (authored colors stripped),
+// scoped to the lesson page wrapper (`.o-page--cg-<subject>`) so material
+// content (`.o-m-content`, which has no such wrapper) keeps authored color.
+[class*="o-page--cg-"] {
+  p,
+  span,
+  li,
+  td,
+  th {
+    color: $color-text !important;
+  }
 }
 
 p {
@@ -129,12 +128,63 @@ h6 {
 }
 
 // --- Images --------------------------------------------------------------
-// Caption rendered by lib/doc_template/templates/image.html.erb as
-// <figcaption>. The "credit" element from the spec is not yet present in
-// the template markup (tracked in clarification doc, Q7).
+// Rendered by lib/doc_template/templates/image.html.erb. The image tag
+// (`[image: id align=<a> size=<s>]`) sets alignment and size modifiers:
+//   * align=center -> block, centered, no text wrapping; caption + credit show
+//   * align=left|right -> float so body text wraps; caption + credit suppressed
+//     (the tag omits them, so only the float behavior lives here)
+//   * size=small|medium|large -> max-width 33% / 50% / 100%
+// Caption + credit are Lexend 9pt, right-justified; the credit is underlined
+// by a hairline rule beneath it.
 
 figure {
   margin: 0;
+}
+
+.o-ld-image {
+  margin: $space-heading-large 0;
+
+  img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  // Width presets cap the rendered image (and its float) width.
+  &--small {
+    max-width: 33%;
+  }
+
+  &--medium {
+    max-width: 50%;
+  }
+
+  &--large {
+    max-width: 100%;
+  }
+
+  // Centered: a constrained block horizontally centered; no float, so text
+  // never wraps alongside it.
+  &--center {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  // Left/right: float the whole figure so surrounding body text wraps.
+  &--left {
+    float: left;
+    margin: 0 12pt 4pt 0;
+  }
+
+  &--right {
+    float: right;
+    margin: 0 0 4pt 12pt;
+  }
+}
+
+// Clears any preceding float so consecutive images don't overlap.
+.o-ld-image--clearfix {
+  clear: both;
 }
 
 figcaption {
@@ -144,9 +194,20 @@ figcaption {
   text-align: right;
 }
 
+.o-ld-image__credit {
+  font-family: $font-family-body !important;
+  font-size: $font-size-caption !important;
+  color: $color-text !important;
+  text-align: right;
+  margin: 0;
+  padding-bottom: 2pt;
+  border-bottom: 1pt solid $color-text;
+}
+
 // --- Material tag --------------------------------------------------------
 // Rendered by lib/doc_template/tags/material_tag.rb as
-// <a class="o-ld-material">.
+// <span class="o-ld-material">. Material tag is "normal text, but
+// italicized" — it is not a link.
 
 .o-ld-material {
   font-style: italic !important;
@@ -272,6 +333,39 @@ figcaption {
   }
 }
 
+// --- Lesson preparation (lesson-prep-directions) -------------------------
+// Rendered by app/views/documents/pdf/_header.html.erb from the lesson-prep
+// table's directions field — rich HTML (sub-headings + nested lists) emitted
+// verbatim, so styling leans on the global heading/list rules.
+
+.c-lesson-prep__heading {
+  // The Materials table directly precedes this heading, and the heading base
+  // sets margin-top: 0, so "Lesson Preparation" would butt against the table's
+  // bottom border. Add a clear blank-line break above it. (The Gdoc header
+  // can't use this — Google Drive discards heading margins on import — so it
+  // forces the gap with a spacer paragraph; see gdoc/_header.html.erb.)
+  margin-top: $space-heading-large * 4;
+}
+
+.c-lesson-prep__body {
+  margin: 0 0 $space-heading-large 0;
+
+  ol,
+  ul {
+    margin: 0;
+    padding-left: 36pt;
+  }
+}
+
+// --- Lesson Content section heading --------------------------------------
+// Introduces the activities, between the lesson front-matter (header/prep) and
+// the body content. A clear blank-line break sets it apart from the section
+// above. (The Gdoc show can't use this — Google Drive discards heading margins
+// on import — so it forces the gap with a spacer paragraph; see gdoc/show.html.erb.)
+.c-lesson-content__heading {
+  margin-top: $space-heading-large * 4;
+}
+
 // --- Activity (flowing layout) -------------------------------------------
 // Rendered by lib/doc_template/templates/activity.html.erb. Drops the
 // legacy bordered-table wrapping in favor of an H3 heading + plain text
@@ -279,12 +373,6 @@ figcaption {
 
 .o-ld-activity {
   margin: $space-heading-large 0 0;
-
-  &__divider {
-    border: 0;
-    border-top: 1pt solid $color-text-muted;
-    margin: $space-heading-large 0;
-  }
 
   &__heading {
     // Inherits H3 typography (14pt bold #434343) from headings ladder above.
@@ -304,6 +392,11 @@ figcaption {
     font-size: $font-size-body !important;
     color: $color-text !important;
     margin: 0 0 4pt 0;
+  }
+
+  // activity-description: blank line above, then the authored intro paragraph.
+  &__description {
+    margin: $space-heading-large 0 0 0;
   }
 
   &__guidance {
@@ -348,10 +441,18 @@ figcaption {
     margin-bottom: 4pt;
   }
 
+  // Client-configured icon image (admin Settings > Documents > Callout
+  // Types), rendered in place of the default "+" — see callout_inline.html.erb.
+  .o-ld-callout__icon-img {
+    max-width: 24pt;
+    max-height: 24pt;
+    vertical-align: middle;
+  }
+
   .o-ld-callout__type {
     font-family: $font-family-body !important;
     font-size: $font-size-body !important;
-    font-weight: 400 !important;
+    font-weight: bold !important;
     color: $color-text !important;
     line-height: $line-height-body;
   }
@@ -364,5 +465,97 @@ figcaption {
       margin: 0;
       padding: 0;
     }
+  }
+}
+
+// --- Material Name/Date row ----------------------------------------------
+// Worksheet fill-in line rendered before the Document Title when the
+// material-metadata name-date field is Yes (app/views/materials/{pdf,gdoc}/
+// _header.html.erb). Label + a border-bottom "rule" cell that fills the
+// remaining width; the date rule is fixed-narrow on the right.
+.o-m-namedate {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 $space-heading-large 0;
+
+  td {
+    padding: 0;
+    vertical-align: bottom;
+  }
+
+  &__label {
+    white-space: nowrap;
+    font-weight: bold !important;
+    padding-right: 4pt;
+  }
+
+  &__label--date {
+    padding-left: 12pt;
+  }
+
+  &__rule {
+    border-bottom: 1pt solid $color-text;
+  }
+
+  &__rule--date {
+    width: 25%;
+  }
+}
+
+// --- Page break ----------------------------------------------------------
+// Emitted by lib/doc_template/tags/page_break_tag.rb as
+// <div class="u-pdf-alwaysbreak">. Forces the following content onto a new
+// page in Grover/Chromium. `break-before` is the modern property; the
+// legacy `page-break-before` alias keeps older print engines honest.
+.u-pdf-alwaysbreak {
+  break-before: page;
+  page-break-before: always;
+}
+
+// --- Material content tables ---------------------------------------------
+// Author-drawn tables inside a material (.o-m-content). These get a baseline
+// house style so an un-bordered authored table still reads as a table; every
+// declaration is non-!important, so any authored inline border/padding/
+// alignment overrides it (see docs/core/table-rendering-limitations.md L3).
+// A pinned header row repeats across page breaks via table-header-group (L4;
+// relies on Google Docs exporting the header as <thead>).
+.o-m-content {
+  .c-ld-table {
+    border-collapse: collapse;
+
+    td,
+    th {
+      border: 1pt solid $color-text;
+      padding: 4pt 6pt;
+      vertical-align: top;
+    }
+  }
+
+  thead {
+    display: table-header-group;
+  }
+}
+
+// --- Material external assets --------------------------------------------
+// Rendered by app/views/materials/_external_assets.html.erb: links to a
+// material's external representations (Google Slides, PDF, video, etc.) as
+// target="_blank" anchors. Surfaces external-asset materials, which may have
+// no authored body of their own.
+.o-m-external-assets {
+  margin: $space-heading-large 0;
+
+  &__list {
+    margin: 0;
+    padding-left: 16pt;
+  }
+
+  &__label {
+    font-weight: bold !important;
+    margin-right: 4pt;
+  }
+
+  &__link {
+    text-decoration: underline;
+    word-break: break-all;
   }
 }

--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -215,7 +215,8 @@ figcaption {
 
 // --- Lesson banner -------------------------------------------------------
 // Rendered by app/views/documents/pdf/_header.html.erb. Top-of-document
-// strip: brandmark | lesson type / estimated time, divider, H1, standards.
+// strip: brandmark | unit title / lesson type / estimated time, divider, H1,
+// standards.
 
 .c-lesson-banner__strip {
   width: 100%;
@@ -239,6 +240,7 @@ figcaption {
   max-width: 120pt;
 }
 
+.c-lesson-banner__unit,
 .c-lesson-banner__type {
   font-family: $font-family-body !important;
   font-size: 12pt !important;
@@ -557,5 +559,24 @@ figcaption {
   &__link {
     text-decoration: underline;
     word-break: break-all;
+  }
+}
+
+// --- Nested list levels --------------------------------------------------
+// HtmlSanitizer#keep_bullets_level turns a Google Docs `<li>`'s margin-left
+// into a depth class (u-ld-indent--l2, --l3, …) at PARSE time, discarding the
+// original margin. Without these rules the class is inert and every nested
+// level renders flush with its parent — a numbered step's sub-bullets sit at
+// the same indent as the steps themselves.
+//
+// One level is 36pt, matching the step Google Docs uses. Level 1 is the list's
+// own indent, so classes start at 2. The range runs past level 6 because
+// documents parsed before the level formula was corrected carry classes from
+// the old ((margin - 50) / 30) + 2 scale, which emitted l7/l8 for deep lists —
+// their content is a parse-time snapshot, so those classes must stay styled
+// until such documents are re-imported.
+@for $level from 2 through 8 {
+  .u-ld-indent--l#{$level} {
+    margin-left: #{($level - 1) * 36}pt !important;
   }
 }

--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -68,10 +68,37 @@ ol {
 
 // --- Highlighting --------------------------------------------------------
 // Spec: not included by default; clients must request.
-// Strip Google-Doc inline background-color on inline text elements.
+// Strip Google-Doc inline background-color on text-level elements.
+//
+// HtmlSanitizer allows `background-color` through (default_config[:css]
+// [:properties]) and its #post_clean_styles pass only reaches p/span/sub/sup
+// AND skips anything with a <td> ancestor — so author highlight survives on
+// list items, on inline emphasis, and on any p/span inside a table cell. This
+// is the net that catches all of it.
+//
+// td/th/tr are deliberately NOT listed: cell shading is a design choice an
+// author makes about a table, not stray highlight, and clearing it here would
+// flatten intentionally shaded tables.
 
 span,
-p {
+p,
+li,
+a,
+b,
+i,
+u,
+s,
+em,
+strong,
+mark,
+sub,
+sup,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   background-color: transparent !important;
 }
 
@@ -143,6 +170,13 @@ figure {
 
 .o-ld-image {
   margin: $space-heading-large 0;
+  // Keep the image with its caption and credit. Without this the renderer is
+  // free to break between them and orphan the caption onto the next page —
+  // the gdoc template carried a `u-pdf-nobreak--around` class for this, but it
+  // sat on the wrong export (Gdoc ignores CSS pagination) and was never defined.
+  // Legacy alias alongside the modern property, as in .u-pdf-alwaysbreak.
+  break-inside: avoid;
+  page-break-inside: avoid;
 
   img {
     max-width: 100%;
@@ -240,10 +274,20 @@ figcaption {
   max-width: 120pt;
 }
 
-.c-lesson-banner__unit,
 .c-lesson-banner__type {
   font-family: $font-family-body !important;
   font-size: 12pt !important;
+  font-weight: bold !important;
+  color: $color-text !important;
+  text-align: right;
+}
+
+// Unit title sits one step below the lesson type — body size, still bold.
+// Mirrored in the Gdoc running header by HEADER_UNIT_TITLE_SIZE
+// (config/scripts/Code.gs).
+.c-lesson-banner__unit {
+  font-family: $font-family-body !important;
+  font-size: $font-size-body !important;
   font-weight: bold !important;
   color: $color-text !important;
   text-align: right;

--- a/app/assets/stylesheets/pdf_plain.scss
+++ b/app/assets/stylesheets/pdf_plain.scss
@@ -10,11 +10,16 @@
 // this in a separate Chromium document, so we re-declare the body font
 // and footer-specific styles here.
 
-$footer-font-family: "Lexend", Arial, sans-serif;
-$footer-color: #000000;
-$footer-color-muted: #434343;
-$footer-size-small: 9pt;
-$footer-size-bold: 10pt;
+// Shared design tokens (single source of truth). Footer-local aliases below
+// keep the footer rules readable while drawing values from the same tokens
+// as pdf.scss / gdoc.scss.
+@import "tokens";
+
+$footer-font-family: $font-family-body;
+$footer-color: $color-text;
+$footer-color-muted: $color-text-muted;
+$footer-size-small: $font-size-caption;
+$footer-size-bold: $font-size-footer-bold;
 
 body {
   font-family: $footer-font-family;
@@ -26,6 +31,8 @@ body {
 .c-lesson-footer {
   font-family: $footer-font-family;
   width: 100%;
+  border-top: 0.5pt solid $footer-color-muted;
+  padding-top: 4pt;
 }
 
 .c-lesson-footer__copyright {
@@ -37,11 +44,19 @@ body {
   padding: 0;
 }
 
+// Course name line — bold, matching the unit/lesson line below it.
+.c-lesson-footer__course {
+  font-family: $footer-font-family;
+  font-size: $footer-size-bold;
+  font-weight: bold;
+  color: $footer-color;
+  margin: 0;
+  padding: 0;
+}
+
 .c-lesson-footer__line {
   width: 100%;
   border-collapse: collapse;
-  border-top: 0.5pt solid $footer-color-muted;
-  margin-top: 2pt;
 
   td {
     padding: 4pt 0 0 0;

--- a/app/assets/stylesheets/pdf_plain.scss
+++ b/app/assets/stylesheets/pdf_plain.scss
@@ -35,7 +35,10 @@ body {
   padding-top: 4pt;
 }
 
-.c-lesson-footer__copyright {
+// Copyright boilerplate (Settings) and the per-lesson cc-attribution share one
+// treatment: both are fine-print legal lines above the breadcrumb.
+.c-lesson-footer__copyright,
+.c-lesson-footer__attribution {
   font-family: $footer-font-family;
   font-size: $footer-size-small;
   font-weight: 400;
@@ -44,16 +47,8 @@ body {
   padding: 0;
 }
 
-// Course name line — bold, matching the unit/lesson line below it.
-.c-lesson-footer__course {
-  font-family: $footer-font-family;
-  font-size: $footer-size-bold;
-  font-weight: bold;
-  color: $footer-color;
-  margin: 0;
-  padding: 0;
-}
-
+// The course no longer gets a line of its own — it leads the breadcrumb below
+// (DocumentPresenter#footer_course_lesson).
 .c-lesson-footer__line {
   width: 100%;
   border-collapse: collapse;

--- a/app/forms/settings_form/flat_group.rb
+++ b/app/forms/settings_form/flat_group.rb
@@ -25,7 +25,14 @@ class SettingsForm
       submitted.merge!(process_callout_list_fields(processed))
       # Compare against the defaults-merged values so a submission equal to the
       # current/default value is not persisted as a redundant override.
-      changes = submitted.reject { |k, v| current_with_defaults[k.to_sym] == v }
+      #
+      # Both sides are normalized to string keys first: the submitted list/map
+      # fields are built with string keys, while current_with_defaults comes
+      # back deep-symbolized from Settings.merge_with_defaults. Comparing them
+      # raw means {"tip" => …} never equals {tip: …}, so every save would write
+      # the shipped defaults into the DB as an explicit override — pinning them
+      # against later releases.
+      changes = submitted.reject { |k, v| same_value?(current_with_defaults[k.to_sym], v) }
       return if changes.empty?
 
       Settings.set(key, stored.merge(changes))
@@ -54,6 +61,25 @@ class SettingsForm
     end
 
     private
+
+    # Key-agnostic equality for a settings value: scalars compare directly,
+    # Hashes/Arrays-of-Hashes compare through #comparable.
+    def same_value?(current, submitted)
+      comparable(current) == comparable(submitted)
+    end
+
+    # Normalizes a value for comparison: string keys, plus nil-valued keys
+    # dropped so a normalizer that always emits a key (normalize_callout_list
+    # writes `"image" => nil` for a row with no icon) still matches a shipped
+    # default that simply omits it. Nils are dropped on BOTH sides, so clearing
+    # a value that IS currently set still reads as a change and gets persisted.
+    def comparable(value)
+      case value
+      when Hash then value.deep_stringify_keys.compact.transform_values { |v| comparable(v) }
+      when Array then value.map { |v| comparable(v) }
+      else value
+      end
+    end
 
     def field_keys
       @schema.keys.map(&:to_s)

--- a/app/forms/settings_form/flat_group.rb
+++ b/app/forms/settings_form/flat_group.rb
@@ -19,7 +19,10 @@ class SettingsForm
 
     def commit
       processed = process_image_uploads(@params)
-      submitted = processed.permit(field_keys).to_h
+      submitted = processed.permit(field_keys - list_keys - label_map_keys - callout_list_keys).to_h
+      submitted.merge!(process_list_fields(processed))
+      submitted.merge!(process_label_map_fields(processed))
+      submitted.merge!(process_callout_list_fields(processed))
       # Compare against the defaults-merged values so a submission equal to the
       # current/default value is not persisted as a redundant override.
       changes = submitted.reject { |k, v| current_with_defaults[k.to_sym] == v }
@@ -64,6 +67,26 @@ class SettingsForm
       @schema[sub_key.to_sym] == :image
     end
 
+    def list_keys
+      @schema.select { |_k, type| type == :key_value_list }.keys.map(&:to_s)
+    end
+
+    def label_map_keys
+      @schema.select { |_k, type| type == :label_map }.keys.map(&:to_s)
+    end
+
+    def callout_list_keys
+      @schema.select { |_k, type| type == :callout_list }.keys.map(&:to_s)
+    end
+
+    # The fixed key set a :label_map field's submitted Hash may use, mirroring
+    # the same coupling documented in the show/_label_map.html.erb partial.
+    # `student_groupings` is currently the only :label_map field; if a second
+    # one is added, turn this into a field-name => keys registry instead.
+    def label_map_key_options
+      DocTemplate::Tables::Activity::GROUPING_OPTIONS
+    end
+
     def stored
       Settings.get(key) || {}
     end
@@ -93,6 +116,157 @@ class SettingsForm
         end
       end
       ActionController::Parameters.new(modified)
+    end
+
+    # Permits every :key_value_list field as an array of {abbr, label} rows
+    # (e.g. `lesson_types[][abbr]` / `lesson_types[][label]`) and normalizes
+    # each into an ordered Hash keyed by abbreviation, ready to merge into the
+    # scalar-only `submitted` hash built in #commit.
+    #
+    # Only a field the widget actually rendered/submitted is processed, marked
+    # by a hidden `<key>_submitted` sentinel (see the _key_value_list partial).
+    # Without this guard an omitted field would normalize to {} and wipe the
+    # stored map — unlike scalar fields, which are simply preserved when absent
+    # from the params. Submitting the sentinel with no rows still clears it.
+    def process_list_fields(params)
+      return {} if list_keys.empty?
+
+      permitted = params.permit(list_keys.index_with { [:abbr, :label] }).to_h
+      list_keys.each_with_object({}) do |k, result|
+        next unless params.key?("#{k}_submitted")
+
+        result[k] = normalize_list(permitted[k])
+      end
+    end
+
+    # Builds the ordered abbreviation => label Hash from submitted rows.
+    # Drops incomplete rows (blank abbreviation OR blank label): a mapping needs
+    # both halves, and a blank-label entry would in any case be stripped on the
+    # next read by Settings' deep_reject_blank_strings, silently losing the row.
+    # Dedupes case-insensitively — DocumentPresenter#lesson_type_label folds keys
+    # to lowercase for lookup, so two abbreviations differing only in case are
+    # indistinguishable at render time; the later row wins (keeping its casing).
+    def normalize_list(rows)
+      Array(rows).each_with_object({}) do |row, hash|
+        abbr = row["abbr"].to_s.strip
+        label = row["label"].to_s.strip
+        next if abbr.blank? || label.blank?
+
+        hash.delete_if { |existing, _| existing.casecmp?(abbr) }
+        hash[abbr] = label
+      end
+    end
+
+    # Permits every :label_map field as a Hash restricted to its fixed key set
+    # (e.g. `student_groupings[class]`) and normalizes it into a key => label
+    # Hash ready to merge into `submitted`.
+    #
+    # Unlike :key_value_list the widget always submits a value for every fixed
+    # key, so blank simply means "use the default" and no `_submitted`
+    # sentinel is needed to tell that apart from "field omitted". A field
+    # genuinely absent from params (e.g. a request that doesn't touch this
+    # group) is left out of the result entirely here, exactly like scalar
+    # fields — so it's preserved rather than wiped.
+    def process_label_map_fields(params)
+      return {} if label_map_keys.empty?
+
+      permitted = params.permit(label_map_keys.index_with { label_map_key_options }).to_h
+      label_map_keys.each_with_object({}) do |k, result|
+        next unless params.key?(k)
+
+        result[k] = normalize_label_map(permitted[k])
+      end
+    end
+
+    # Builds the key => label Hash from the submitted map, stripping labels
+    # and dropping blanks: an unconfigured key stays absent so the render
+    # helper's titleized fallback applies, and a blank-label entry would in
+    # any case be stripped on the next read by Settings' deep_reject_blank_strings.
+    def normalize_label_map(map)
+      Hash(map).each_with_object({}) do |(key, label), hash|
+        label = label.to_s.strip
+        hash[key] = label if label.present?
+      end
+    end
+
+    # Permits every :callout_list field as an array of {type, title, image}
+    # rows (e.g. `callout_types[][type]` / `[][title]` / `[][image]`) and
+    # normalizes each into an ordered Array of Hashes, ready to merge into the
+    # scalar-only `submitted` hash built in #commit.
+    #
+    # `image` is only ever an uploaded file (or absent) here: a row's `image`
+    # param is either an UploadedFile (permit's scalar allowlist includes it)
+    # or nothing, never a client-supplied string. #normalize_callout_list
+    # resolves the actual stored URL — see its comment for why a plain string
+    # is never trusted, same rationale as #process_image_uploads.
+    #
+    # Same `_submitted` sentinel gate as #process_list_fields: only a field
+    # the widget actually rendered is processed, so an omitted field is left
+    # untouched while a submitted-with-zero-rows field clears the list.
+    def process_callout_list_fields(params)
+      return {} if callout_list_keys.empty?
+
+      permitted = params.permit(callout_list_keys.index_with { [:type, :title, :image] }).to_h
+      callout_list_keys.each_with_object({}) do |k, result|
+        next unless params.key?("#{k}_submitted")
+
+        result[k] = normalize_callout_list(permitted[k], k)
+      end
+    end
+
+    # Builds the ordered Array of {type, title, image} row Hashes from the
+    # submitted rows for one :callout_list field.
+    #
+    # Drops rows with a blank type (a callout type needs a key to be looked up
+    # by `[callout: <type>]`); a renamed type with no re-upload simply loses
+    # its icon, which is an accepted trade-off. Type is folded to a lowercase
+    # key to match DocTemplate::Tags::CalloutTag's marker parsing; title is
+    # only stripped, since it's a display string. Dedupes by type, later row
+    # wins (mirrors #normalize_list) — the image upload for a dropped/blank
+    # row is simply never resolved (see the `next` below), so it's never
+    # actually stored, even transiently.
+    def normalize_callout_list(rows, list_key)
+      existing_images = stored_callout_images(list_key)
+
+      Array(rows).each_with_object({}) do |row, hash|
+        type = row["type"].to_s.strip.downcase
+        next if type.blank?
+
+        hash.delete(type)
+        hash[type] = {
+          "type" => type,
+          "title" => row["title"].to_s.strip,
+          "image" => resolve_callout_image(row["image"], type, existing_images)
+        }
+      end.values
+    end
+
+    # The type => image URL map currently persisted for a :callout_list field
+    # (the raw stored value, NOT the defaults-merged one — a shipped default
+    # has no icon to fall back to anyway), used to keep a row's icon when its
+    # submission carries no new upload.
+    def stored_callout_images(list_key)
+      Array(stored[list_key]).each_with_object({}) do |row, hash|
+        type = row["type"].to_s.strip.downcase
+        hash[type] = row["image"] if type.present?
+      end
+    end
+
+    # An image field only ever accepts an uploaded file, exactly like
+    # #process_image_uploads: a row's `image` sent as a plain string is never
+    # persisted as a URL (arbitrary path/URL, later fed to image_tag/gdoc
+    # inlining — path traversal / XSS risk). A row with no new upload instead
+    # reuses whatever URL is already stored for that type, so an unrelated
+    # edit (e.g. retitling) doesn't drop an existing icon — the client never
+    # gets to supply that URL itself.
+    def resolve_callout_image(file, type, existing_images)
+      if file.respond_to?(:tempfile)
+        uploader = ImageUploader.new
+        uploader.store!(file)
+        uploader.url
+      else
+        existing_images[type]
+      end
     end
   end
 end

--- a/app/forms/settings_form/flat_group.rb
+++ b/app/forms/settings_form/flat_group.rb
@@ -287,7 +287,11 @@ class SettingsForm
     # gets to supply that URL itself.
     def resolve_callout_image(file, type, existing_images)
       if file.respond_to?(:tempfile)
-        uploader = ImageUploader.new
+        # CalloutIconUploader, not ImageUploader: it downscales the source to
+        # CalloutIconUploader::MAX_EDGE so an oversized upload cannot blow up
+        # the admin row, the 24pt export icon, or the base64 payload the Gdoc
+        # export inlines once per callout.
+        uploader = CalloutIconUploader.new
         uploader.store!(file)
         uploader.url
       else

--- a/app/helpers/asset_helper.rb
+++ b/app/helpers/asset_helper.rb
@@ -29,24 +29,15 @@ module AssetHelper
     def inline_data_uri(url, cache: false)
       return nil if url.blank?
 
-      key = "#{REDIS_PREFIX}-data-uri:#{Digest::SHA1.hexdigest(url)}"
-      if cache
-        cached = redis.get(key)
-        return cached if cached.present?
-      end
+      # Per-request/job memo (reset by Rails between units of work): a document
+      # render inlines the same URL more than once (e.g. several callouts of one
+      # type share an icon), and each inline is a blocking remote fetch. Memoize
+      # the result — including a nil failure — so the same URL is fetched at most
+      # once per render regardless of the Redis cache flag.
+      memo = (Current.inline_data_uris ||= {})
+      return memo[url] if memo.key?(url)
 
-      content = fetch_remote(url)
-      return nil if content.blank?
-
-      mime = mime_for(url, content)
-      encoded = Base64.strict_encode64(content)
-      data_uri = "data:#{mime};base64,#{encoded}"
-
-      redis.set(key, data_uri, ex: 1.day.to_i) if cache
-      data_uri
-    rescue StandardError => e
-      Rails.logger.warn "AssetHelper.inline_data_uri failed for #{url}: #{e.message}"
-      nil
+      memo[url] = build_inline_data_uri(url, cache:)
     end
 
     def inlined(path)
@@ -60,6 +51,27 @@ module AssetHelper
     end
 
     private
+
+    def build_inline_data_uri(url, cache:)
+      key = "#{REDIS_PREFIX}-data-uri:#{Digest::SHA1.hexdigest(url)}"
+      if cache
+        cached = redis.get(key)
+        return cached if cached.present?
+      end
+
+      content, remote_type = fetch_remote(url)
+      return nil if content.blank?
+
+      mime = mime_for(url, content, remote_type)
+      encoded = Base64.strict_encode64(content)
+      data_uri = "data:#{mime};base64,#{encoded}"
+
+      redis.set(key, data_uri, ex: 1.day.to_i) if cache
+      data_uri
+    rescue StandardError => e
+      Rails.logger.warn "AssetHelper.inline_data_uri failed for #{url}: #{e.message}"
+      nil
+    end
 
     def encode(path)
       if Rails.env.development? || Rails.env.test? || Rails.env.qa?
@@ -80,11 +92,15 @@ module AssetHelper
       Rails.application.config.redis
     end
 
+    # Returns [body, content_type] where content_type is the HTTP
+    # Content-Type reported by the server (nil for local/unknown), so callers
+    # can determine the MIME type even when the URL has no file extension.
     def fetch_remote(url)
       uri = URI.parse(url)
       case uri.scheme
       when "http", "https"
-        uri.open(
+        remote_type = nil
+        body = uri.open(
           open_timeout: DATA_URI_OPEN_TIMEOUT,
           read_timeout: DATA_URI_READ_TIMEOUT,
           content_length_proc: ->(size) {
@@ -92,21 +108,49 @@ module AssetHelper
               raise "remote asset too large: #{size} bytes"
             end
           }
-        ) { |io| io.read(DATA_URI_FETCH_LIMIT + 1) }.then do |body|
-          raise "remote asset exceeds #{DATA_URI_FETCH_LIMIT} bytes" if body.bytesize > DATA_URI_FETCH_LIMIT
-
-          body
+        ) do |io|
+          remote_type = io.content_type
+          io.read(DATA_URI_FETCH_LIMIT + 1)
         end
+        raise "remote asset exceeds #{DATA_URI_FETCH_LIMIT} bytes" if body.bytesize > DATA_URI_FETCH_LIMIT
+
+        [body, remote_type]
       else
         raise "unsupported URL scheme: #{uri.scheme.inspect}"
       end
     end
 
-    def mime_for(url, content)
+    # Resolves the MIME type from (in order): SVG sniffing, an *image* URL
+    # extension, the server-reported Content-Type, then a non-image extension.
+    # Only falls back to application/octet-stream when none of these yield a
+    # type — so a URL served as an image (via Content-Type) still renders in the
+    # data URI even when its path has no, or a non-image, extension.
+    def mime_for(url, content, remote_type = nil)
       ext = File.extname(URI.parse(url).path).delete_prefix(".").downcase
-      return "image/svg+xml" if ext == "svg" || content.byteslice(0, 256).to_s.lstrip.start_with?("<svg", "<?xml")
+      return "image/svg+xml" if ext == "svg" || svg_content?(content)
 
-      Mime::Type.lookup_by_extension(ext)&.to_s || "application/octet-stream"
+      from_ext = Mime::Type.lookup_by_extension(ext)&.to_s
+      # Only an image extension is authoritative. A recognized NON-image
+      # extension (e.g. a handler URL ending .txt/.html that actually serves an
+      # image) must NOT win over the server Content-Type, or the data: URI gets
+      # a non-image MIME and the <img> renders broken.
+      return from_ext if from_ext&.start_with?("image/")
+
+      normalized = remote_type.to_s[/\A[^;]+/].to_s.strip.presence
+      return normalized if normalized && normalized != "application/octet-stream"
+
+      from_ext.presence || "application/octet-stream"
+    end
+
+    # True only for actual SVG payloads: a leading `<svg` tag, or an XML prolog
+    # (`<?xml …`) whose head contains an `<svg` element. A plain, non-SVG XML
+    # document (which also starts with `<?xml`) is NOT reported as SVG, so its
+    # server Content-Type / extension can win instead of a wrong image MIME.
+    def svg_content?(content)
+      head = content.byteslice(0, 256).to_s.lstrip
+      return true if head.start_with?("<svg")
+
+      head.start_with?("<?xml") && content.byteslice(0, 1024).to_s.include?("<svg")
     end
   end
 end

--- a/app/helpers/asset_helper.rb
+++ b/app/helpers/asset_helper.rb
@@ -7,6 +7,10 @@ module AssetHelper
   DATA_URI_FETCH_LIMIT = 5.megabytes
   DATA_URI_OPEN_TIMEOUT = 5
   DATA_URI_READ_TIMEOUT = 10
+  # Wall-clock ceiling for one remote fetch. read_timeout only bounds a SINGLE
+  # read, so a server dripping a byte just inside it can hold an export job open
+  # indefinitely; this bounds the whole transfer. Generous for a ≤5 MB asset.
+  DATA_URI_TOTAL_TIMEOUT = 30
 
   class << self
     def base64_encoded(path, cache: false)
@@ -92,6 +96,14 @@ module AssetHelper
       Rails.application.config.redis
     end
 
+    # open-uri progress callback that aborts a transfer once it passes
+    # DATA_URI_FETCH_LIMIT. Extracted so the bound is testable without a server.
+    def fetch_limit_guard
+      lambda do |transferred|
+        raise "remote asset exceeds #{DATA_URI_FETCH_LIMIT} bytes" if transferred.to_i > DATA_URI_FETCH_LIMIT
+      end
+    end
+
     # Returns [body, content_type] where content_type is the HTTP
     # Content-Type reported by the server (nil for local/unknown), so callers
     # can determine the MIME type even when the URL has no file extension.
@@ -100,17 +112,28 @@ module AssetHelper
       case uri.scheme
       when "http", "https"
         remote_type = nil
-        body = uri.open(
-          open_timeout: DATA_URI_OPEN_TIMEOUT,
-          read_timeout: DATA_URI_READ_TIMEOUT,
-          content_length_proc: ->(size) {
-            if size && size > DATA_URI_FETCH_LIMIT
-              raise "remote asset too large: #{size} bytes"
-            end
-          }
-        ) do |io|
-          remote_type = io.content_type
-          io.read(DATA_URI_FETCH_LIMIT + 1)
+        body = Timeout.timeout(DATA_URI_TOTAL_TIMEOUT) do
+          uri.open(
+            open_timeout: DATA_URI_OPEN_TIMEOUT,
+            read_timeout: DATA_URI_READ_TIMEOUT,
+            # Declared size, when the server sends one: rejects an oversized
+            # asset before a single byte is transferred.
+            content_length_proc: ->(size) {
+              if size && size > DATA_URI_FETCH_LIMIT
+                raise "remote asset too large: #{size} bytes"
+              end
+            },
+            # Transferred size, always: a chunked response carries no
+            # Content-Length, so content_length_proc never fires and open-uri
+            # would stream the WHOLE body (spilling to a Tempfile) before the
+            # block below could look at it. progress_proc is called with the
+            # running total as it downloads, so raising here aborts the
+            # transfer mid-stream instead of after the fact.
+            progress_proc: fetch_limit_guard
+          ) do |io|
+            remote_type = io.content_type
+            io.read(DATA_URI_FETCH_LIMIT + 1)
+          end
         end
         raise "remote asset exceeds #{DATA_URI_FETCH_LIMIT} bytes" if body.bytesize > DATA_URI_FETCH_LIMIT
 

--- a/app/javascript/components/admin/Initializer.jsx
+++ b/app/javascript/components/admin/Initializer.jsx
@@ -17,6 +17,8 @@ class Initializer {
     // Initialize simple HTML objects
     Initializer.#initializeResourcesList();
     Initializer.#initializeSelectAll();
+    Initializer.#initializeKeyValueLists();
+    Initializer.#initializeCalloutLists();
   }
 
   static #initializeCurriculumEditor() {
@@ -69,6 +71,59 @@ class Initializer {
       const el = $(ev.target);
       const checked = el.prop('checked');
       $('.table input[type=checkbox][name="selected_ids[]"]').prop('checked', checked);
+    });
+  }
+
+  // Wires the admin/settings/show/_key_value_list.html.erb widget: "Add row"
+  // clones the row <template> into the tbody, "Remove" deletes its own row.
+  // Vanilla JS (no Stimulus in this app); each .js-key-value-list wrapper is
+  // wired independently (via querySelectorAll + a data-attribute guard) so
+  // multiple lists on the same page — and repeat Turbo page loads — don't
+  // collide or double-bind.
+  static #initializeKeyValueLists() {
+    document.querySelectorAll('.js-key-value-list').forEach(widget => {
+      if (widget.dataset.keyValueListBound) return;
+      widget.dataset.keyValueListBound = 'true';
+
+      const rows = widget.querySelector('.js-key-value-list-rows');
+      const template = widget.querySelector('.js-key-value-list-template');
+      const addButton = widget.querySelector('.js-key-value-list-add');
+
+      addButton.addEventListener('click', () => {
+        rows.appendChild(template.content.cloneNode(true));
+      });
+
+      rows.addEventListener('click', event => {
+        const removeButton = event.target.closest('.js-key-value-list-remove');
+        if (!removeButton) return;
+
+        removeButton.closest('.js-key-value-list-row').remove();
+      });
+    });
+  }
+
+  // Wires the admin/settings/show/_callout_list.html.erb widget: same
+  // add/remove-row behavior as #initializeKeyValueLists, scoped to
+  // .js-callout-list so it doesn't collide with the key-value-list widget.
+  static #initializeCalloutLists() {
+    document.querySelectorAll('.js-callout-list').forEach(widget => {
+      if (widget.dataset.calloutListBound) return;
+      widget.dataset.calloutListBound = 'true';
+
+      const rows = widget.querySelector('.js-callout-list-rows');
+      const template = widget.querySelector('.js-callout-list-template');
+      const addButton = widget.querySelector('.js-callout-list-add');
+
+      addButton.addEventListener('click', () => {
+        rows.appendChild(template.content.cloneNode(true));
+      });
+
+      rows.addEventListener('click', event => {
+        const removeButton = event.target.closest('.js-callout-list-remove');
+        if (!removeButton) return;
+
+        removeButton.closest('.js-callout-list-row').remove();
+      });
     });
   }
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -8,4 +8,15 @@ class Current < ActiveSupport::CurrentAttributes
   # once per unit of work, and a settings edit is picked up on the next
   # request/job without a process restart (the store is reset between them).
   attribute :doc_template
+
+  # Per-render memo of `[material: id]` token lookups (downcased identifier =>
+  # Material or nil), so a lesson's many activity Materials lines resolve
+  # against one query set instead of one per activity. See
+  # DocTemplate::Tags::MaterialTokens.lookup.
+  attribute :material_tokens
+
+  # Per-render memo of inlined asset data URIs (url => data-URI String or nil),
+  # so repeated blocking remote fetches of the same asset (e.g. a shared callout
+  # icon) happen at most once per render. See AssetHelper.inline_data_uri.
+  attribute :inline_data_uris
 end

--- a/app/presenters/content_presenter.rb
+++ b/app/presenters/content_presenter.rb
@@ -4,6 +4,12 @@ class ContentPresenter < BasePresenter
   DEFAULT_CONFIG = :default
   MATERIALS_CONFIG_PATH = Rails.root.join("config", "materials_rules.yml")
 
+  # Upper bound on the base64 brandmark passed inline to the Apps Script. The
+  # bytes ride inside the scripts.run request body, which has a size ceiling, so
+  # an unexpectedly large upload degrades to "no logo" instead of bloating (or
+  # failing) the request. A real header logo is a few KB; 1 MB is generous.
+  BRANDMARK_MAX_ENCODED_BYTES = 1.megabyte
+
   # PDF rendering config, read through the cached `Settings` interface
   # (Rails.cache-backed and auto-invalidated on write). The DB may be
   # unavailable during `assets:precompile` and similar no-database tasks, so
@@ -23,6 +29,48 @@ class ContentPresenter < BasePresenter
   def base_filename
     name = short_breadcrumb(join_with: "_", with_short_lesson: true)
     "#{name}_v#{version.presence || 1}"
+  end
+
+  # Client logo/brandmark for the document banner, from Settings.
+  #
+  # Inlined as a data URI so the image survives HTML→Gdoc import (and the
+  # gdoc_pdf renderer, which routes PDF through Drive). Falls back to the raw
+  # URL if the fetch fails — works for Grover/Chromium.
+  def brandmark_url
+    raw = brandmark_source_url
+    return nil if raw.blank?
+
+    AssetHelper.inline_data_uri(raw, cache: ViewHelper::ENABLE_BASE64_CACHING) || raw
+  end
+
+  # Raw brandmark URL from Settings, NOT inlined as a data URI. Used as the
+  # source both for #brandmark_url (PDF/inline HTML) and #brandmark_data_uri
+  # (Gdoc). Blank when no brandmark is configured.
+  def brandmark_source_url
+    Settings.get(:documents, include_defaults: true)&.dig(:brandmark).presence
+  end
+
+  # Base64 data URI of the brandmark for the Gdoc running header. The Apps
+  # Script (config/scripts/Code.gs) decodes this and inserts it at the
+  # {brandmark_url} placeholder. Passing the bytes inline avoids UrlFetchApp in
+  # the script (and its script.external_request OAuth scope) and the need for
+  # the source URL to be publicly fetchable by Google — Rails inlines it once
+  # (cached) from a URL only it must reach. Blank when no brandmark is
+  # configured, inlining fails, or the encoded image exceeds
+  # BRANDMARK_MAX_ENCODED_BYTES (so an oversized upload degrades to "no logo").
+  def brandmark_data_uri
+    raw = brandmark_source_url
+    return "" if raw.blank?
+
+    data_uri = AssetHelper.inline_data_uri(raw, cache: ViewHelper::ENABLE_BASE64_CACHING)
+    return "" if data_uri.blank?
+
+    if data_uri.bytesize > BRANDMARK_MAX_ENCODED_BYTES
+      Rails.logger.warn "[Gdoc] brandmark skipped: encoded image #{data_uri.bytesize} bytes exceeds #{BRANDMARK_MAX_ENCODED_BYTES}"
+      return ""
+    end
+
+    data_uri
   end
 
   def config

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -3,58 +3,79 @@
 class DocumentPresenter < ContentPresenter
   include Rails.application.routes.url_helpers
 
-  delegate :cc_attribution, :description_future, :description_past, :estimated_time, :grade,
+  delegate :grade,
            :lesson_title, :lesson_number, :lesson_type, :section_number, :subject, :unit_id,
-           :vocabulary, :teaser,
+           :teaser,
            to: :base_metadata
+
+  # A single class period is 45 minutes; the banner "Estimated Time" rounds
+  # the lesson's total activity time up to whole class periods.
+  CLASS_PERIOD_MINUTES = 45
 
   MATERIALS_ROWS = {
     "Individual Student Materials" => "activity-materials-student",
     "Pair Materials" => "activity-materials-pair",
     "Small Group Materials" => "activity-materials-group",
     "Class Materials" => "activity-materials-class",
-    "Teacher Materials" => "activity-metadata-teacher"
+    "Teacher Materials" => "activity-materials-teacher"
   }.freeze
-
-  def brandmark_url
-    raw = Settings.get(:documents, include_defaults: true)&.dig(:brandmark)
-    return nil if raw.blank?
-
-    # Inline as data URI so the image survives HTML→Gdoc import (and the
-    # gdoc_pdf renderer, which routes PDF through Drive). Falls back
-    # to the raw URL if the fetch fails — works for Grover/Chromium.
-    AssetHelper.inline_data_uri(raw, cache: ViewHelper::ENABLE_BASE64_CACHING) || raw
-  end
 
   def copyright_text
     Settings.get(:documents, include_defaults: true)&.dig(:copyright_text).presence
   end
 
-  # Bold breadcrumb line used in the lesson footer.
-  # @return [String, nil] e.g. "Grade 6/Course • Unit Title • Lesson 2"
-  def footer_breadcrumb
-    parts = [grade_label, unit_title, lesson_label].compact_blank
-    parts.any? ? parts.join(" • ") : nil
+  # Converts a lesson's stored `lesson-type` abbreviation (e.g. "AP") into its
+  # full label (e.g. "Anchoring Phenomenon") using the client-configurable
+  # Settings lesson_types map (see admin Settings > Documents). Each LCMS
+  # instance defines its own abbr => label list, so the lookup is
+  # case-insensitive and falls back to titleizing the abbreviation when it
+  # isn't in the map — preserving the prior behavior for unmapped values.
+  def lesson_type_label
+    Settings.map_label(:lesson_types, lesson_type)
+  end
+
+  # Footer line 1: boilerplate copyright/company text (Settings) with the unit
+  # version appended — e.g. "© Company Name, v1.0".
+  def footer_copyright
+    [copyright_text.presence, unit_version.presence].compact.join(", ").presence
+  end
+
+  # Footer line 2: the course name, from unit-metadata.
+  def footer_course
+    unit_metadata&.course.presence
+  end
+
+  # Footer line 3 (left cell): "Unit Title • Lesson N".
+  def footer_unit_lesson
+    [unit_title, lesson_label].compact_blank.join(" • ").presence
   end
 
   # Aggregates activity-metadata material fields into the 5-row lesson
   # Materials summary table. Each row collects values across all
   # activities, dedupes, joins, and resolves any [material: id] tokens
   # to italicized identifier links (matching how MaterialTag renders
-  # inline). Empty rows render as "None".
+  # inline). A category with no materials in the lesson renders "None", so
+  # the table always shows all five rows (including a lesson with no
+  # activities, where every row is "None").
   #
-  # @return [Hash{String => String}] heading => joined materials HTML.
-  #   Returns {} when the document has no activity metadata so the view
-  #   can skip the Materials block entirely.
+  # @return [Hash{String => String}] heading => joined materials HTML
+  #   (or "None" for an empty category).
   def materials_summary
     activities = Array.wrap(activity_metadata)
-    return {} if activities.empty?
 
-    MATERIALS_ROWS.transform_values do |key|
-      values = activities.flat_map { |a| split_list(a[key]) }.uniq.compact_blank
+    rows = MATERIALS_ROWS.transform_values do |key|
+      activities.flat_map { |a| split_list(a[key]) }.uniq.compact_blank
+    end
+
+    # Single query for every [material: id] token across all five rows.
+    known = DocTemplate::Tags::MaterialTokens.lookup(
+      rows.values.flatten.flat_map { |v| DocTemplate::Tags::MaterialTokens.identifiers_in(v) }
+    )
+
+    rows.transform_values do |values|
       next "None" if values.empty?
 
-      values.map { |v| resolve_material_tokens(v) }.join(", ")
+      values.map { |v| DocTemplate::Tags::MaterialTokens.resolve(v, known:) }.join(", ")
     end
   end
 
@@ -66,38 +87,104 @@ class DocumentPresenter < ContentPresenter
     base_metadata.description
   end
 
+  # Banner "Estimated Time", computed from the sum of every activity's
+  # activity-time at 45 minutes per class period, rounded up:
+  # ≤45 → "1 Class Period", 46–90 → "2 Class Periods", etc. Falls back to the
+  # authored lesson-metadata estimated-time when no activity defines a time.
+  def estimated_time
+    class_periods || base_metadata.estimated_time.presence
+  end
+
+  # Rich HTML for the Lesson Preparation section, sourced from the lesson-prep
+  # table's `lesson-prep-directions` field (sub-headings + nested lists).
+  # `[material: id]` tokens are resolved to inline identifier links (same as the
+  # Materials summary and activity Materials line), so a slide/worksheet
+  # reference renders identically here instead of showing the raw tag.
+  # Blank when the lesson defines no preparation directions.
+  def lesson_prep_directions
+    @lesson_prep_directions ||=
+      DocTemplate::Tags::MaterialTokens.resolve(base_metadata.lesson_prep&.lesson_prep_directions)
+  end
+
+  # Overview bullet "In the previous lesson, we…" — the preceding lesson's
+  # past-tense self-description. Per the lesson-metadata spec, each lesson's
+  # `description-past` is authored to be shown in the FOLLOWING lesson, so it
+  # is read from the previous lesson in the same unit. Nil when this is the
+  # first lesson of the unit (no predecessor).
+  def overview_past
+    neighbor_lesson(:previous)&.description_past.presence
+  end
+
+  # Overview bullet "In the next lesson, we will…" — the following lesson's
+  # future-tense self-description. Each lesson's `description-future` is
+  # authored to be shown in the PRECEDING lesson, so it is read from the next
+  # lesson in the same unit. Nil when this is the last lesson of the unit.
+  def overview_future
+    neighbor_lesson(:next)&.description_future.presence
+  end
+
+  # Lesson-banner vocabulary line compiled from every activity's `vocabulary`
+  # field across the lesson, de-duplicated and comma-joined. Blank when no
+  # activity defines vocabulary, so the view can skip the line. Distinct from
+  # the lesson-metadata `vocabulary` field (see lesson-metadata-specs.md).
+  def vocabulary
+    Array.wrap(activity_metadata)
+      .flat_map { |a| split_list(a["vocabulary"]) }
+      .uniq
+      .compact_blank
+      .join(", ")
+  end
+
   # Footer data for Google Apps Script post-processing.
   # Used in Google::ScriptService#parameters.
   #
-  # NOTE: kept at the original 2-row shape. The R2 footer design (copyright
-  # line + breadcrumb) is fully implemented in the PDF footer. To land it in
-  # generated Gdocs we need to (a) update the Apps Script template doc in
-  # Drive to use new placeholders AND (b) extend this array. Doing only (b)
-  # makes the Apps Script post-processing hang on unfamiliar args.
+  # Mirrors the R2 PDF footer (three lines: copyright, course, unit • lesson)
+  # so the generated Gdoc matches the PDF.
   #
-  # @return [Array<Array<String>>] 2D array with placeholder/value pairs:
-  #   [["{placeholder}"], [replacement_value]]
+  # STRUCTURE (see config/scripts/Code.gs#postProcessing): exactly two parallel
+  # arrays — [all_placeholders, all_values] — consumed as the Apps Script's
+  # footerPatterns / footerReplaceTexts args, which it loops as
+  # replaceText(patterns[i], values[i]). NOT a list of [placeholder, value]
+  # pairs (that mis-aligns the positional args and drops the header entirely).
+  #
+  # IMPORTANT: the Apps Script template doc in Drive
+  # (GOOGLE_APPLICATION_TEMPLATE_PORTRAIT / _LANDSCAPE) MUST define these exact
+  # placeholders in its footer — {copyright}, {course}, {unit_lesson}. The
+  # template's footer is copied verbatim into the doc, then these are replaced.
+  #
+  # @return [Array(Array<String>, Array<String>)] [patterns, values]
   def gdoc_footer
     [
-      ["{attribution}"],
-      [
-        [copyright_text.presence, cc_attribution.presence]
-          .compact
-          .join(" — ")
-          .presence || "Copyright attribution here"
-      ]
+      ["{copyright}", "{course}", "{unit_lesson}"],
+      [footer_copyright, footer_course, footer_unit_lesson]
     ]
   end
 
   # Header data for Google Apps Script post-processing.
   # Used in Google::ScriptService#parameters.
   #
-  # @return [Array<Array<String>>] 2D array with placeholder/value pairs:
-  #   [["{placeholder}"], [replacement_value]]
+  # Mirrors the banner in the body header (documents/gdoc/_header.html.erb):
+  # title, lesson type, and estimated time — substituted into the template
+  # doc's running header.
+  #
+  # STRUCTURE (see config/scripts/Code.gs#postProcessing): exactly two parallel
+  # arrays — [all_placeholders, all_values] — consumed as the Apps Script's
+  # headerPatterns / headerReplaceTexts args. NOT a list of [placeholder, value]
+  # pairs.
+  #
+  # IMPORTANT: the Apps Script template doc in Drive
+  # (GOOGLE_APPLICATION_TEMPLATE_PORTRAIT / _LANDSCAPE) MUST define the exact
+  # placeholders it uses in its header. `{title}` may be absent (the title also
+  # renders in the body banner) — a missing placeholder is a harmless no-op.
+  # `{estimated_time}` carries the value only (e.g. "2 Class Periods"); keep any
+  # "Estimated Time:" label as static text so a blank value leaves no dangling
+  # label.
+  #
+  # @return [Array(Array<String>, Array<String>)] [patterns, values]
   def gdoc_header
     [
-      ["{title}"],
-      [lesson_title]
+      ["{title}", "{lesson_type}", "{estimated_time}"],
+      [lesson_title, lesson_type_label, estimated_time]
     ]
   end
 
@@ -150,14 +237,60 @@ class DocumentPresenter < ContentPresenter
 
   private
 
-  def grade_label
-    return nil if grade.blank?
+  # Total activity time across the lesson, expressed in whole 45-minute class
+  # periods (rounded up). Nil when no activity defines a time, so the banner
+  # can fall back to the authored estimated-time.
+  def class_periods
+    total = Array.wrap(activity_metadata).sum { |a| a["activity-time"].to_i }
+    return nil unless total.positive?
 
-    "Grade #{grade}/Course"
+    count = (total.to_f / CLASS_PERIOD_MINUTES).ceil
+    "#{count} #{'Class Period'.pluralize(count)}"
+  end
+
+  # Builds the adjacent lesson (:previous / :next) within the SAME unit as a
+  # DocTemplate::Objects::Lesson, or nil at a unit boundary, when the document
+  # has no resource, or when the neighbor has no active document.
+  def neighbor_lesson(direction)
+    return nil unless resource&.lesson?
+
+    sibling = resource.public_send(direction)
+    return nil unless sibling&.lesson? && same_unit?(sibling)
+
+    doc = sibling.document
+    return nil unless doc
+
+    DocTemplate::Objects::Lesson.build_from(doc.metadata)
+  end
+
+  # True when `other` shares this lesson's unit ancestor.
+  def same_unit?(other)
+    unit_resource.present? && other.ancestors.include?(unit_resource)
+  end
+
+  # The unit-level Resource ancestor of this lesson (populated by
+  # UnitBuildService), or nil when the document has no unit ancestor.
+  def unit_resource
+    return @unit_resource if defined?(@unit_resource)
+
+    @unit_resource = resource&.ancestors&.find(&:unit?)
+  end
+
+  # unit-metadata for this lesson's unit, as a DocTemplate::Objects::Unit built
+  # from the unit Resource's stored metadata. Nil without a unit ancestor.
+  def unit_metadata
+    return @unit_metadata if defined?(@unit_metadata)
+
+    @unit_metadata = unit_resource && DocTemplate::Objects::Unit.build_from(unit_resource.metadata)
+  end
+
+  def unit_version
+    unit_metadata&.version
   end
 
   def unit_title
-    resource&.ancestors&.find(&:unit?)&.title.presence ||
+    unit_metadata&.unit_title.presence ||
+      unit_resource&.title.presence ||
       (unit_id.present? ? "Unit #{unit_id.to_s.upcase}" : nil)
   end
 
@@ -169,23 +302,5 @@ class DocumentPresenter < ContentPresenter
     return [] if value.blank?
 
     value.to_s.split(",").map(&:strip).reject(&:blank?)
-  end
-
-  # Replaces `[material: id]` tokens in raw activity-metadata text with the
-  # italicized identifier markup that MaterialTag emits inline. Plain text
-  # is passed through unchanged.
-  MATERIAL_TOKEN_RE = /\[material:\s*([^\]]+)\]/i
-
-  def resolve_material_tokens(text)
-    text.to_s.gsub(MATERIAL_TOKEN_RE) do
-      identifier = ::Regexp.last_match(1).to_s.strip
-      next identifier if identifier.blank?
-
-      if ::Material.exists?(identifier: identifier.downcase)
-        %(<a class="o-ld-material">#{identifier}</a>)
-      else
-        identifier
-      end
-    end
   end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -3,7 +3,8 @@
 class DocumentPresenter < ContentPresenter
   include Rails.application.routes.url_helpers
 
-  delegate :grade,
+  delegate :cc_attribution,
+           :grade,
            :lesson_title, :lesson_number, :lesson_type, :section_number, :subject, :unit_id,
            :teaser,
            to: :base_metadata
@@ -20,6 +21,14 @@ class DocumentPresenter < ContentPresenter
     "Teacher Materials" => "activity-materials-teacher"
   }.freeze
 
+  # current key => key it was authored under before the rename. Documents keep
+  # their parsed activity_metadata forever, so a lesson imported before
+  # `activity-metadata-teacher` became `activity-materials-teacher` still stores
+  # the old key and would otherwise report "None" for Teacher Materials.
+  # (DocTemplate::Objects::Activity.apply_defaults does the same for the
+  # per-activity "Materials:" line.)
+  LEGACY_MATERIALS_KEYS = { "activity-materials-teacher" => "activity-metadata-teacher" }.freeze
+
   def copyright_text
     Settings.get(:documents, include_defaults: true)&.dig(:copyright_text).presence
   end
@@ -34,20 +43,72 @@ class DocumentPresenter < ContentPresenter
     Settings.map_label(:lesson_types, lesson_type)
   end
 
+  # Title of the lesson's unit, shown in the lesson header (PDF banner strip and
+  # Gdoc running header) and in the footer breadcrumb. Prefers the authored
+  # unit-metadata title, falls back to the unit Resource's title, then to
+  # "Unit {id}". Blank when the document has no unit ancestor and no unit_id.
+  def unit_title
+    unit_metadata&.unit_title.presence ||
+      unit_resource&.title.presence ||
+      (unit_id.present? ? "Unit #{unit_id.to_s.upcase}" : nil)
+  end
+
+  # First-page H1 for both exports (PDF banner and Gdoc body): the lesson title
+  # prefixed with its lesson number — e.g. "Lesson 5: How does our stuff impact
+  # climate change?". Falls back to the bare title when the lesson has no
+  # number, and to the bare "Lesson N" when it has no title, so neither side of
+  # the separator can render alone with a dangling colon. Distinct from the Gdoc
+  # RUNNING header's {title}, which stays unprefixed (see #gdoc_header).
+  def banner_title
+    [lesson_label, lesson_title.presence].compact_blank.join(": ")
+  end
+
   # Footer line 1: boilerplate copyright/company text (Settings) with the unit
   # version appended — e.g. "© Company Name, v1.0".
   def footer_copyright
     [copyright_text.presence, unit_version.presence].compact.join(", ").presence
   end
 
-  # Footer line 2: the course name, from unit-metadata.
+  # Per-lesson licence/attribution authored in lesson-metadata `cc-attribution`
+  # (e.g. "Adapted from OpenSciEd, CC BY-NC-SA 4.0"). Distinct from
+  # #footer_copyright, which is the site-wide Settings boilerplate: this one is
+  # a per-lesson legal statement, so it must survive into every export rather
+  # than being replaced by the global line. Blank for lessons that set none.
+  def footer_attribution
+    cc_attribution.presence
+  end
+
+  # The course name, from unit-metadata. Feeds #footer_course_lesson rather than
+  # a line of its own — see there.
   def footer_course
     unit_metadata&.course.presence
   end
 
-  # Footer line 3 (left cell): "Unit Title • Lesson N".
-  def footer_unit_lesson
-    [unit_title, lesson_label].compact_blank.join(" • ").presence
+  # Footer breadcrumb: "Course • Lesson 1 of 12".
+  #
+  # The course, NOT the unit title. A lesson whose unit was created implicitly
+  # by the lesson import (no unit-metadata document of its own) has no authored
+  # unit title, and falling back down the chain printed the importer's generated
+  # resource label — e.g. "Science G10 gg" — into every exported footer.
+  #
+  # Blank parts drop out of the join, so a unit with no metadata at all degrades
+  # to a bare "Lesson 7" instead of inventing a placeholder.
+  def footer_course_lesson
+    [footer_course, footer_lesson_label].compact_blank.join(" • ").presence
+  end
+
+  # "Lesson 1 of 12" — the lesson's number plus how many lessons its unit holds.
+  #
+  # Falls back to the bare "Lesson 1" whenever the total can't be trusted: no
+  # unit ancestor, a unit whose lessons were never imported, or a count lower
+  # than this lesson's own number (which happens when a lesson doc with a blank
+  # `section-number` lands on a section-typed resource, leaving its unit with no
+  # lesson resources at all). Better a short label than a wrong "of".
+  def footer_lesson_label
+    total = unit_lesson_count.to_i
+    return lesson_label if lesson_label.blank? || total < lesson_number.to_i
+
+    I18n.t("lesson.footer.lesson_of", number: lesson_number, total:)
   end
 
   # Aggregates activity-metadata material fields into the 5-row lesson
@@ -64,7 +125,7 @@ class DocumentPresenter < ContentPresenter
     activities = Array.wrap(activity_metadata)
 
     rows = MATERIALS_ROWS.transform_values do |key|
-      activities.flat_map { |a| split_list(a[key]) }.uniq.compact_blank
+      activities.flat_map { |a| split_list(activity_field(a, key)) }.uniq.compact_blank
     end
 
     # Single query for every [material: id] token across all five rows.
@@ -75,7 +136,15 @@ class DocumentPresenter < ContentPresenter
     rows.transform_values do |values|
       next "None" if values.empty?
 
-      values.map { |v| DocTemplate::Tags::MaterialTokens.resolve(v, known:) }.join(", ")
+      # These fields hold DECODED PLAIN TEXT (activity-materials-* is not in
+      # Tables::Activity::HTML_VALUE_FIELDS), but both header views emit the
+      # result with `raw` so MaterialTokens can inject its <span> markup.
+      # Escape the authored text first — otherwise an entry like
+      # "Beakers <250ml>" is parsed as a tag and silently disappears from the
+      # rendered table. `[material: id]` tokens survive escaping untouched, so
+      # resolution still works on the escaped string.
+      values.map { |v| DocTemplate::Tags::MaterialTokens.resolve(ERB::Util.html_escape(v), known:) }
+            .join(", ")
     end
   end
 
@@ -106,21 +175,36 @@ class DocumentPresenter < ContentPresenter
       DocTemplate::Tags::MaterialTokens.resolve(base_metadata.lesson_prep&.lesson_prep_directions)
   end
 
-  # Overview bullet "In the previous lesson, we…" — the preceding lesson's
-  # past-tense self-description. Per the lesson-metadata spec, each lesson's
-  # `description-past` is authored to be shown in the FOLLOWING lesson, so it
-  # is read from the previous lesson in the same unit. Nil when this is the
-  # first lesson of the unit (no predecessor).
-  def overview_past
-    neighbor_lesson(:previous)&.description_past.presence
+  # "Lesson Preparation (30 minutes)" — the section heading carrying the
+  # authored lesson-prep-time, mirroring how an activity heading carries its
+  # activity-time. Falls back to the bare heading when the lesson-prep table
+  # defines no time (or a non-positive one), so no empty parentheses render.
+  def lesson_prep_heading
+    heading = I18n.t("lesson.preparation.heading")
+    minutes = base_metadata.lesson_prep&.lesson_prep_time.to_i
+    return heading unless minutes.positive?
+
+    I18n.t("lesson.preparation.heading_with_time",
+           heading:, time: I18n.t("lesson.preparation.minutes", count: minutes))
   end
 
-  # Overview bullet "In the next lesson, we will…" — the following lesson's
-  # future-tense self-description. Each lesson's `description-future` is
-  # authored to be shown in the PRECEDING lesson, so it is read from the next
-  # lesson in the same unit. Nil when this is the last lesson of the unit.
+  # Overview bullet 1 — "In the previous lesson, we…", this lesson's OWN
+  # `description-past`.
+  #
+  # All three Overview bullets come from the lesson's own lesson-metadata: the
+  # author writes the recap, the summary and the look-ahead in one table, and
+  # all three render in that lesson. (An earlier implementation read the recap
+  # and look-ahead off the neighbouring lessons instead; that is not how these
+  # documents are authored.) Blank when the field is empty, so the view drops
+  # the bullet.
+  def overview_past
+    base_metadata.description_past.presence
+  end
+
+  # Overview bullet 3 — "In the next lesson, we will…", this lesson's OWN
+  # `description-future`. See #overview_past.
   def overview_future
-    neighbor_lesson(:next)&.description_future.presence
+    base_metadata.description_future.presence
   end
 
   # Lesson-banner vocabulary line compiled from every activity's `vocabulary`
@@ -138,7 +222,7 @@ class DocumentPresenter < ContentPresenter
   # Footer data for Google Apps Script post-processing.
   # Used in Google::ScriptService#parameters.
   #
-  # Mirrors the R2 PDF footer (three lines: copyright, course, unit • lesson)
+  # Mirrors the PDF footer (copyright, optional attribution, course • lesson)
   # so the generated Gdoc matches the PDF.
   #
   # STRUCTURE (see config/scripts/Code.gs#postProcessing): exactly two parallel
@@ -152,20 +236,32 @@ class DocumentPresenter < ContentPresenter
   # placeholders in its footer — {copyright}, {course}, {unit_lesson}. The
   # template's footer is copied verbatim into the doc, then these are replaced.
   #
+  # {page_number} is deliberately NOT in this list. A Google Doc page number is
+  # its own PageNumber element, not text, so replaceText could only stamp one
+  # fixed number onto every page; config/scripts/Code.gs#insertFooterPageNumber
+  # swaps that placeholder for a live element instead.
+  #
+  # {course} and {unit_lesson} are legacy placeholder NAMES kept as-is because
+  # they already exist in the Drive template: renaming them here would leave the
+  # old literal text sitting in every generated footer until the template was
+  # hand-edited. The course now rides in the {unit_lesson} breadcrumb, so
+  # {course} is blanked — delete that paragraph from the template when
+  # convenient and this slot becomes a no-op.
+  #
   # @return [Array(Array<String>, Array<String>)] [patterns, values]
   def gdoc_footer
     [
-      ["{copyright}", "{course}", "{unit_lesson}"],
-      [footer_copyright, footer_course, footer_unit_lesson]
+      ["{copyright}", "{attribution}", "{course}", "{unit_lesson}"],
+      [footer_copyright, footer_attribution, nil, footer_course_lesson]
     ]
   end
 
   # Header data for Google Apps Script post-processing.
   # Used in Google::ScriptService#parameters.
   #
-  # Mirrors the banner in the body header (documents/gdoc/_header.html.erb):
-  # title, lesson type, and estimated time — substituted into the template
-  # doc's running header.
+  # Mirrors the banner in the PDF header (documents/pdf/_header.html.erb):
+  # title, unit title, lesson type, and estimated time — substituted into the
+  # template doc's running header.
   #
   # STRUCTURE (see config/scripts/Code.gs#postProcessing): exactly two parallel
   # arrays — [all_placeholders, all_values] — consumed as the Apps Script's
@@ -175,7 +271,8 @@ class DocumentPresenter < ContentPresenter
   # IMPORTANT: the Apps Script template doc in Drive
   # (GOOGLE_APPLICATION_TEMPLATE_PORTRAIT / _LANDSCAPE) MUST define the exact
   # placeholders it uses in its header. `{title}` may be absent (the title also
-  # renders in the body banner) — a missing placeholder is a harmless no-op.
+  # renders in the body banner) — a missing placeholder is a harmless no-op, so
+  # `{unit_title}` only shows up once it is added to the template header.
   # `{estimated_time}` carries the value only (e.g. "2 Class Periods"); keep any
   # "Estimated Time:" label as static text so a blank value leaves no dangling
   # label.
@@ -183,8 +280,8 @@ class DocumentPresenter < ContentPresenter
   # @return [Array(Array<String>, Array<String>)] [patterns, values]
   def gdoc_header
     [
-      ["{title}", "{lesson_type}", "{estimated_time}"],
-      [lesson_title, lesson_type_label, estimated_time]
+      ["{title}", "{unit_title}", "{lesson_type}", "{estimated_time}"],
+      [lesson_title, unit_title, lesson_type_label, estimated_time]
     ]
   end
 
@@ -248,32 +345,21 @@ class DocumentPresenter < ContentPresenter
     "#{count} #{'Class Period'.pluralize(count)}"
   end
 
-  # Builds the adjacent lesson (:previous / :next) within the SAME unit as a
-  # DocTemplate::Objects::Lesson, or nil at a unit boundary, when the document
-  # has no resource, or when the neighbor has no active document.
-  def neighbor_lesson(direction)
-    return nil unless resource&.lesson?
-
-    sibling = resource.public_send(direction)
-    return nil unless sibling&.lesson? && same_unit?(sibling)
-
-    doc = sibling.document
-    return nil unless doc
-
-    DocTemplate::Objects::Lesson.build_from(doc.metadata)
-  end
-
-  # True when `other` shares this lesson's unit ancestor.
-  def same_unit?(other)
-    unit_resource.present? && other.ancestors.include?(unit_resource)
-  end
-
   # The unit-level Resource ancestor of this lesson (populated by
   # UnitBuildService), or nil when the document has no unit ancestor.
   def unit_resource
     return @unit_resource if defined?(@unit_resource)
 
     @unit_resource = resource&.ancestors&.find(&:unit?)
+  end
+
+  # How many lesson Resources this lesson's unit holds, across all its sections
+  # — the "of 12" in the footer breadcrumb. One COUNT query, memoized. Nil
+  # without a unit ancestor.
+  def unit_lesson_count
+    return @unit_lesson_count if defined?(@unit_lesson_count)
+
+    @unit_lesson_count = unit_resource&.descendants&.lessons&.count
   end
 
   # unit-metadata for this lesson's unit, as a DocTemplate::Objects::Unit built
@@ -288,19 +374,28 @@ class DocumentPresenter < ContentPresenter
     unit_metadata&.version
   end
 
-  def unit_title
-    unit_metadata&.unit_title.presence ||
-      unit_resource&.title.presence ||
-      (unit_id.present? ? "Unit #{unit_id.to_s.upcase}" : nil)
-  end
-
   def lesson_label
     lesson_number.to_i.positive? ? "Lesson #{lesson_number}" : nil
   end
 
+  # Reads an activity-metadata field, falling back to the key the field was
+  # authored under before it was renamed (see LEGACY_MATERIALS_KEYS).
+  def activity_field(activity, key)
+    value = activity[key]
+    return value if value.present?
+
+    legacy = LEGACY_MATERIALS_KEYS[key]
+    legacy ? activity[legacy] : value
+  end
+
+  # Splits an authored list cell into entries on the SAME separators the rest of
+  # DocTemplate uses (Tables::Base#fetch_materials resolves `[material: id]`
+  # tokens from these very cells with SPLIT_REGEX). Splitting on "," alone left
+  # a semicolon-separated cell as one run-on entry, which also defeated the
+  # dedupe against activities that used commas.
   def split_list(value)
     return [] if value.blank?
 
-    value.to_s.split(",").map(&:strip).reject(&:blank?)
+    value.to_s.split(DocTemplate::Tables::Base::SPLIT_REGEX).map(&:strip).reject(&:blank?)
   end
 end

--- a/app/presenters/material_presenter.rb
+++ b/app/presenters/material_presenter.rb
@@ -7,8 +7,37 @@ class MaterialPresenter < ContentPresenter
 
   DEFAULT_TITLE = "Material"
 
+  # External-asset representations (from the external-asset-representation
+  # metadata table), in display order, mapping the stored key to a label.
+  EXTERNAL_ASSETS = {
+    "pdf" => "PDF",
+    "doc" => "Document",
+    "slides" => "Slides",
+    "sheet" => "Sheet",
+    "form" => "Form",
+    "video" => "Video",
+    "webpage" => "Webpage"
+  }.freeze
+
   def base_filename
     base_metadata.material_id
+  end
+
+  # URL schemes allowed for external-asset links. Authored asset URLs are
+  # rendered as clickable <a href> on the public material page, so a value like
+  # "javascript:…" would be stored XSS. Only web/mail links (and schemeless,
+  # i.e. relative) are permitted; any other explicit scheme is dropped.
+  ALLOWED_EXTERNAL_ASSET_SCHEMES = %w(http https mailto).freeze
+
+  # Populated external links for this material as {label:, url:} hashes, in
+  # EXTERNAL_ASSETS order. Empty when the material has no external assets.
+  # URLs with a disallowed scheme are dropped (see #safe_asset_url?).
+  def external_assets
+    raw = metadata["external_assets"] || {}
+    EXTERNAL_ASSETS.filter_map do |key, label|
+      url = raw[key].to_s.strip
+      { label:, url: } if url.present? && safe_asset_url?(url)
+    end
   end
 
   def content_for(context_type, options = {})
@@ -61,6 +90,15 @@ class MaterialPresenter < ContentPresenter
   end
 
   private
+
+  # True when `url` is safe to emit as an href: schemeless (relative) or one of
+  # ALLOWED_EXTERNAL_ASSET_SCHEMES. Blocks javascript:/data:/vbscript: and any
+  # other injection scheme. The scheme is read with a regex (not URI.parse) so a
+  # value with stray characters can't raise instead of being rejected.
+  def safe_asset_url?(url)
+    scheme = url[/\A\s*([a-z][a-z0-9+.\-]*):/i, 1]&.downcase
+    scheme.nil? || ALLOWED_EXTERNAL_ASSET_SCHEMES.include?(scheme)
+  end
 
   def base_metadata
     @base_metadata ||= DocTemplate::Objects::Material.build_from(metadata)

--- a/app/services/document_build_service.rb
+++ b/app/services/document_build_service.rb
@@ -53,10 +53,16 @@ class DocumentBuildService
     document_params.merge(name: downloader.file.name)
   end
 
+  # Previews were generated from the previous parse, so they are stale after a
+  # (re)import. Drop them so the next Preview click regenerates from the fresh
+  # content instead of redirecting to the cached doc (see
+  # DocumentsController#preview_gdoc / #preview_pdf). The gdoc preview lives in
+  # the separate `preview_links` field, which is cleared wholesale.
   def clear_preview_link
     links = document.links
     links["pdf"]&.delete("preview")
     document.links = links
+    document.preview_links = {}
   end
 
   #

--- a/app/services/google/script_service.rb
+++ b/app/services/google/script_service.rb
@@ -18,7 +18,8 @@ module Google
     def execute(id)
       request = ::Google::Apis::ScriptV1::ExecutionRequest.new(
         function: SCRIPT_FUNCTION,
-        parameters: [id, gdoc_template_id, *Array.wrap(parameters)]
+        parameters: [id, gdoc_template_id, *Array.wrap(parameters)],
+        dev_mode: dev_mode?
       )
       response = service.run_script(SCRIPT_ID, request)
 
@@ -28,6 +29,18 @@ module Google
     private
 
     attr_reader :document
+
+    # When true, scripts.run executes the most recently SAVED (HEAD) version of
+    # the Apps Script instead of the version pinned to the API Executable
+    # deployment — so an editor Save is enough and no redeploy / version bump is
+    # needed. Requires the authenticated identity to have edit access to the
+    # script. Keep false in production (run the stable, deployed version); set
+    # GOOGLE_APPLICATION_SCRIPT_DEV_MODE=true on QA/staging to iterate on
+    # config/scripts/Code.gs without redeploying each change. Read per call
+    # (not memoized) so flipping the env var takes effect without a restart.
+    def dev_mode?
+      ENV.fetch("GOOGLE_APPLICATION_SCRIPT_DEV_MODE", "false") == "true"
+    end
 
     def ensure_not_nil_params_for(data)
       data&.map { |row| row.map { _1 || "" } }
@@ -48,24 +61,42 @@ module Google
 
 
     # Parameters passed to Google Apps Script for document post-processing.
+    # Positional — must line up with config/scripts/Code.gs#postProcessing(
+    #   documentId, templateId, isLandscape,
+    #   footerPatterns, footerReplaceTexts, headerPatterns, headerReplaceTexts,
+    #   gradeColors, brandmarkData).
     #
-    # Structure:
-    #   [0] Boolean - true if landscape orientation
-    #   [1..n] gdoc_footer rows - placeholder/value pairs for footer replacement
-    #   [n+1..m] gdoc_header rows - placeholder/value pairs for header replacement
+    # Structure (after documentId/templateId, prepended in #execute):
+    #   [0] Boolean            - true if landscape orientation
+    #   [1] footerPatterns     - Array of all footer placeholders
+    #   [2] footerReplaceTexts - Array of footer values (parallel to [1])
+    #   [3] headerPatterns     - Array of all header placeholders
+    #   [4] headerReplaceTexts - Array of header values (parallel to [3])
+    #   [5] gradeColors        - reserved positional slot (unused; kept so the
+    #                            brandmark data lands on postProcessing's 9th arg)
+    #   [6] brandmarkData      - base64 data URI of the logo, decoded + inserted
+    #                            by the script into the header's {brandmark_url}
+    #                            placeholder (inline bytes, so the script needs
+    #                            no UrlFetchApp / script.external_request scope)
     #
-    # gdoc_footer format (from DocumentPresenter#gdoc_footer):
-    #   [["{attribution}"], [cc_attribution || "Copyright attribution here"]]
+    # So gdoc_footer / gdoc_header MUST each be exactly [patterns, values] —
+    # two parallel arrays, NOT a list of [placeholder, value] pairs. The Apps
+    # Script loops replaceText(patterns[i], values[i]) over its footer/header.
     #
-    # gdoc_header format (from DocumentPresenter#gdoc_header):
-    #   [["{title}"], [title]]
+    # gdoc_footer (DocumentPresenter):
+    #   [["{copyright}", "{course}", "{unit_lesson}"], [copyright, course, unit_lesson]]
+    # gdoc_header (DocumentPresenter):
+    #   [["{title}", "{lesson_type}", "{estimated_time}"], [title, lesson_type, estimated_time]]
+    #   (MaterialPresenter uses the single [["{attribution}"], [value]] shape.)
     #
     # @return [Array]
     def parameters
       [
         document.orientation&.downcase == "landscape",
         *ensure_not_nil_params_for(document.gdoc_footer),
-        *ensure_not_nil_params_for(document.gdoc_header)
+        *ensure_not_nil_params_for(document.gdoc_header),
+        [], # gradeColors — reserved positional slot before brandmarkData
+        document.try(:brandmark_data_uri).to_s
       ].compact
     end
 

--- a/app/services/google/script_service.rb
+++ b/app/services/google/script_service.rb
@@ -86,7 +86,8 @@ module Google
     # gdoc_footer (DocumentPresenter):
     #   [["{copyright}", "{course}", "{unit_lesson}"], [copyright, course, unit_lesson]]
     # gdoc_header (DocumentPresenter):
-    #   [["{title}", "{lesson_type}", "{estimated_time}"], [title, lesson_type, estimated_time]]
+    #   [["{title}", "{unit_title}", "{lesson_type}", "{estimated_time}"],
+    #    [title, unit_title, lesson_type, estimated_time]]
     #   (MaterialPresenter uses the single [["{attribution}"], [value]] shape.)
     #
     # @return [Array]

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -117,7 +117,7 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
           "sub" => %w(style),
           "sup" => %w(style),
           "td" => %w(colspan rowspan style),
-          "th" => %w(colspan rowspan),
+          "th" => %w(colspan rowspan style),
           "tr" => %w(style)
         },
         protocols: {
@@ -126,7 +126,7 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
         },
         css: {
           properties: %w(background-color border-bottom-width border-left-width border-right-width border-top-width
-                         border-bottom border-left border-right border-top height font-style font-weight
+                         border-bottom border-left border-right border-top color height font-style font-weight
                          list-style-type text-align text-decoration vertical-align width)
         },
         transformers: [ # These transformers Will be executed via .call(), as lambdas
@@ -150,6 +150,11 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
       %w(p span sub sup).each do |tag|
         nodes.xpath(".//#{tag}").each do |node|
           next if node.ancestors("td").present?
+
+          # Keep the activity heading's inline styles intact. In the Gdoc the
+          # title is a styled <p> (Google Docs' import discards <h3> formatting),
+          # so its Lexend/14pt/bold/color must survive this stripping.
+          next if node["class"]&.include?("o-ld-activity__heading")
 
           # do not sanitize Mathjax elements
           if node["class"]&.index("mjx").nil?

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -151,10 +151,13 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
         nodes.xpath(".//#{tag}").each do |node|
           next if node.ancestors("td").present?
 
-          # Keep the activity heading's inline styles intact. In the Gdoc the
-          # title is a styled <p> (Google Docs' import discards <h3> formatting),
-          # so its Lexend/14pt/bold/color must survive this stripping.
-          next if node["class"]&.include?("o-ld-activity__heading")
+          # NOTE: an `o-ld-activity__heading` exemption used to sit here, meant
+          # to protect the activity title's inline styles. It could never fire —
+          # that class is only emitted on an <h3> (templates/activity.html.erb),
+          # an element this loop does not visit — so it was removed rather than
+          # left as a guard that reads as active. The activity heading takes its
+          # styling from pdf.scss / gdoc.scss instead; the Gdoc export inlines
+          # those rules at export time, after this pass.
 
           # do not sanitize Mathjax elements
           if node["class"]&.index("mjx").nil?
@@ -256,12 +259,24 @@ class HtmlSanitizer # rubocop:disable Metrics/ClassLength
       end
     end
 
+    # Preserves a list item's nesting depth as a class, since the sanitizer
+    # drops the source margin-left. Google Docs indents one level per 36pt
+    # (36 / 72 / 108 …), so the level is the margin in whole 36pt steps and the
+    # matching indent lives in pdf.scss / gdoc.scss (.u-ld-indent--lN).
+    #
+    # Level 1 is the list's own indent and needs no class. The previous formula,
+    # ((indent - 50) / 30) + 2, did not step with the source: it mapped 144pt to
+    # l5 and skipped l4 entirely, so a 4-level list jumped two indents while
+    # deeper levels emitted classes no stylesheet defined.
+    INDENT_STEP_PT = 36
+
     def keep_bullets_level(env)
       node = env[:node]
       return unless node.element? && node.name == "li" && node["style"].to_s.include?("margin-left")
 
       indent = /margin-left\s*:\s*(\d+)/.match(node["style"]).try(:[], 1).to_i
-      add_css_class(node, "u-ld-indent--l#{((indent - 50) / 30) + 2}") if indent >= 50
+      level = (indent.to_f / INDENT_STEP_PT).round
+      add_css_class(node, "u-ld-indent--l#{level}") if level >= 2
     end
 
     def post_processing_default(nodes)

--- a/app/uploaders/callout_icon_uploader.rb
+++ b/app/uploaders/callout_icon_uploader.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "carrierwave/processing/mini_magick"
+
+# Icons for the client-configurable callout types (admin Settings > Documents >
+# Callout Types, rendered by DocTemplate::Tags::CalloutTag).
+#
+# A subclass rather than a `process` on ImageUploader itself, because that class
+# is shared with the brandmark/logo (SettingsForm::FlatGroup#process_image_uploads)
+# and the generic Admin::SettingsController#upload_image endpoint, which have
+# their own size needs. Only callout icons are normalized here.
+class CalloutIconUploader < ImageUploader
+  include CarrierWave::MiniMagick
+
+  # Longest edge kept for the stored icon.
+  #
+  # The icon renders at 24pt (.o-ld-callout__icon-img in pdf.scss / gdoc.scss),
+  # which is the convergent value for a margin-column callout icon in print:
+  # Asciidoctor PDF's admonition theme defaults to 24pt and LaTeX's awesomebox
+  # uses \Huge (24.88pt), both against a ~10.5pt body. It is also the standard
+  # "standalone icon" step in Material and Carbon. So the display size is not
+  # the thing to change here — only the stored source.
+  #
+  # At the 300dpi the PDF printers are configured with (Settings::DEFAULTS
+  # [:pdf][:default][:image_dpi]), 24pt needs just 24/72 * 300 = 100px. 256px
+  # is ~2.5x that, and still covers a future bump to a 48pt display size (which
+  # would need 200px) without a re-upload.
+  #
+  # Deliberately below the ~512px a general-purpose icon guideline would
+  # suggest, because of a constraint specific to this pipeline: the Gdoc export
+  # inlines the icon as a base64 data URI once per callout OCCURRENCE in the
+  # document (CalloutTag#callout_icon_url). A lesson with 20 callouts carries 20
+  # copies, so source pixels beyond what 300dpi actually needs are paid for 20
+  # times over in the Drive import payload.
+  MAX_EDGE = 256
+
+  # resize_to_limit, not resize_to_fit: it only ever shrinks, so a small icon
+  # that is already the right size is passed through untouched rather than
+  # upscaled into a blurry one. Aspect ratio is preserved either way, so a
+  # non-square icon stays non-square.
+  process resize_to_limit: [MAX_EDGE, MAX_EDGE]
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -22,9 +22,21 @@ class ImageUploader < CarrierWave::Uploader::Base
     return super unless self.class.storage == CarrierWave::Storage::Fog
 
     bucket = ENV.fetch("AWS_S3_BUCKET_NAME", nil)
-    return super if bucket.blank? || path.blank?
+    region = fog_region
+    # Without the bucket's actual region we can't build a correct virtual-hosted
+    # host (a wrong region 301s and the image fails to load), so fall back to
+    # CarrierWave's default URL rather than guess. That fallback is a short-lived
+    # presigned URL (fog_public = false), which will 403 once expired if it gets
+    # persisted into Settings and embedded in generated documents — so warn.
+    if bucket.blank? || region.blank? || path.blank?
+      Rails.logger.warn(
+        "ImageUploader#url: falling back to a presigned (expiring) URL — " \
+        "bucket=#{bucket.present?}, region=#{region.present?}, path=#{path.present?}. " \
+        "A persisted image URL may expire in already-generated documents."
+      )
+      return super
+    end
 
-    region = ENV.fetch("AWS_REGION", "us-east-1")
     "https://#{bucket}.s3.#{region}.amazonaws.com/#{path}"
   end
 
@@ -89,6 +101,14 @@ class ImageUploader < CarrierWave::Uploader::Base
   private_class_method :local_url?, :s3_url?, :delete_local, :delete_from_s3
 
   private
+
+  # The AWS region CarrierWave/Fog is actually configured with, so the public
+  # URL host matches the bucket's region (see config/initializers/carrier_wave.rb)
+  # instead of a divergent hardcoded default.
+  def fog_region
+    configured = fog_credentials&.dig(:region).presence if respond_to?(:fog_credentials)
+    configured || ENV["AWS_REGION"].presence
+  end
 
   def extension_fallback
     return ".#{file.extension}" if file.present? && file.respond_to?(:extension) && file.extension.present?

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -16,7 +16,11 @@
         <%= render partial: group.to_partial_path, locals: { group: group } %>
       <% end %>
 
-      <%= form_with url: admin_settings_path, method: :patch, id: "settings-form", data: { turbo: false } do |f| %>
+      <%# multipart: true so the callout_types icon file inputs (rendered
+          outside this form, attached via form="settings-form" — see
+          show/_callout_list.html.erb) actually upload their file content
+          instead of just a filename string. %>
+      <%= form_with url: admin_settings_path, method: :patch, id: "settings-form", multipart: true, data: { turbo: false } do |f| %>
         <button
           type="submit"
           class="btn btn-primary disabled"
@@ -39,10 +43,23 @@
       }
     }
 
-    document.querySelectorAll("[form='settings-form']")
-      .forEach(el => el.addEventListener("change", enableSave));
+    // Delegated on document so rows added later by the key-value/callout "Add
+    // row" widgets are covered too. The fields carry form="settings-form" but
+    // live outside the <form> element, so their events never bubble to it —
+    // binding per-field at load also misses anything added afterward.
+    ["input", "change"].forEach(type =>
+      document.addEventListener(type, event => {
+        if (event.target.closest("[form='settings-form']")) enableSave();
+      })
+    );
 
-    const form = document.getElementById("settings-form");
-    if (form) form.addEventListener("change", enableSave);
+    // Adding or removing a row changes what will be submitted without firing an
+    // input/change on any field, so enable Save on those clicks directly.
+    document.addEventListener("click", event => {
+      if (event.target.closest(
+        ".js-key-value-list-add, .js-key-value-list-remove, " +
+        ".js-callout-list-add, .js-callout-list-remove"
+      )) enableSave();
+    });
   })();
 </script>

--- a/app/views/admin/settings/show/_callout_list.html.erb
+++ b/app/views/admin/settings/show/_callout_list.html.erb
@@ -13,7 +13,12 @@
     a row's icon. So, unlike the abbr/label columns, there is no hidden field
     carrying the current icon URL — it's shown here only as an <img> preview,
     for reference, alongside a file input that replaces it when a new file is
-    chosen. %>
+    chosen.
+
+    The preview is capped by .c-callout-list__icon-preview
+    (application.bootstrap.scss), NOT by the intrinsic image size: icons
+    uploaded before CalloutIconUploader began downscaling are still stored at
+    full resolution and would otherwise render the row screen-tall. %>
 <% setting_value = setting_value.presence || [] %>
 <%# Sentinel so the form always signals this field was submitted, even with
     zero rows. FlatGroup#process_callout_list_fields only clears the stored
@@ -39,10 +44,12 @@
             <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][title]" form="<%= form_id %>" value="<%= row[:title] %>">
           </td>
           <td>
-            <% if row[:image].present? %>
-              <%= image_tag row[:image], class: "img-thumbnail c-callout-list__icon-preview", alt: row[:title].to_s %>
-            <% end %>
-            <input type="file" class="form-control form-control-sm" name="<%= setting_key %>[][image]" form="<%= form_id %>" accept="image/*">
+            <div class="c-callout-list__icon-cell">
+              <% if row[:image].present? %>
+                <%= image_tag row[:image], class: "img-thumbnail c-callout-list__icon-preview", alt: row[:title].to_s %>
+              <% end %>
+              <input type="file" class="form-control form-control-sm" name="<%= setting_key %>[][image]" form="<%= form_id %>" accept="image/*">
+            </div>
           </td>
           <td>
             <button type="button" class="btn btn-sm btn-outline-danger js-callout-list-remove">
@@ -66,7 +73,9 @@
         <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][title]" form="<%= form_id %>" value="">
       </td>
       <td>
-        <input type="file" class="form-control form-control-sm" name="<%= setting_key %>[][image]" form="<%= form_id %>" accept="image/*">
+        <div class="c-callout-list__icon-cell">
+          <input type="file" class="form-control form-control-sm" name="<%= setting_key %>[][image]" form="<%= form_id %>" accept="image/*">
+        </div>
       </td>
       <td>
         <button type="button" class="btn btn-sm btn-outline-danger js-callout-list-remove">

--- a/app/views/admin/settings/show/_callout_list.html.erb
+++ b/app/views/admin/settings/show/_callout_list.html.erb
@@ -1,0 +1,78 @@
+<%# An editable list of callout types: type (key), title, and an icon image.
+    Submitted as `<setting_key>[][type]` / `<setting_key>[][title]` /
+    `<setting_key>[][image]` (file) arrays. `setting_value` is the stored (or
+    defaults-merged) Array of row Hashes — symbol-keyed :type/:title/:image,
+    see Settings::DEFAULTS[:documents][:callout_types] and
+    Settings.merge_with_defaults — possibly nil/empty. Rows are added/removed
+    client-side (see app/javascript/components/admin/Initializer.jsx,
+    #initializeCalloutLists), scoped to this widget via the .js-callout-list
+    wrapper so multiple lists on the same page don't collide.
+
+    A client-supplied image URL is never accepted (see
+    FlatGroup#resolve_callout_image): only a freshly uploaded file can change
+    a row's icon. So, unlike the abbr/label columns, there is no hidden field
+    carrying the current icon URL — it's shown here only as an <img> preview,
+    for reference, alongside a file input that replaces it when a new file is
+    chosen. %>
+<% setting_value = setting_value.presence || [] %>
+<%# Sentinel so the form always signals this field was submitted, even with
+    zero rows. FlatGroup#process_callout_list_fields only clears the stored
+    list when it sees this — an omitted field is left untouched. %>
+<input type="hidden" name="<%= setting_key %>_submitted" value="1" form="<%= form_id %>">
+<div class="c-callout-list js-callout-list">
+  <table class="table table-sm table-borderless align-middle mb-2 c-callout-list__table">
+    <thead>
+      <tr>
+        <th><%= t("admin.settings.callout_list.type") %></th>
+        <th><%= t("admin.settings.callout_list.title") %></th>
+        <th><%= t("admin.settings.callout_list.icon") %></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody class="js-callout-list-rows">
+      <% setting_value.each do |row| %>
+        <tr class="js-callout-list-row">
+          <td>
+            <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][type]" form="<%= form_id %>" value="<%= row[:type] %>">
+          </td>
+          <td>
+            <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][title]" form="<%= form_id %>" value="<%= row[:title] %>">
+          </td>
+          <td>
+            <% if row[:image].present? %>
+              <%= image_tag row[:image], class: "img-thumbnail c-callout-list__icon-preview", alt: row[:title].to_s %>
+            <% end %>
+            <input type="file" class="form-control form-control-sm" name="<%= setting_key %>[][image]" form="<%= form_id %>" accept="image/*">
+          </td>
+          <td>
+            <button type="button" class="btn btn-sm btn-outline-danger js-callout-list-remove">
+              <%= t("admin.settings.callout_list.remove") %>
+            </button>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <button type="button" class="btn btn-sm btn-outline-secondary js-callout-list-add">
+    <i class="bi bi-plus-lg"></i>
+    <%= t("admin.settings.callout_list.add_row") %>
+  </button>
+  <template class="js-callout-list-template">
+    <tr class="js-callout-list-row">
+      <td>
+        <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][type]" form="<%= form_id %>" value="">
+      </td>
+      <td>
+        <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][title]" form="<%= form_id %>" value="">
+      </td>
+      <td>
+        <input type="file" class="form-control form-control-sm" name="<%= setting_key %>[][image]" form="<%= form_id %>" accept="image/*">
+      </td>
+      <td>
+        <button type="button" class="btn btn-sm btn-outline-danger js-callout-list-remove">
+          <%= t("admin.settings.callout_list.remove") %>
+        </button>
+      </td>
+    </tr>
+  </template>
+</div>

--- a/app/views/admin/settings/show/_key_value_list.html.erb
+++ b/app/views/admin/settings/show/_key_value_list.html.erb
@@ -1,0 +1,58 @@
+<%# An editable list of abbreviation => label rows (e.g. lesson-type
+    abbreviations), submitted as `<setting_key>[][abbr]` / `<setting_key>[][label]`
+    arrays. `setting_value` is the stored Hash (possibly nil/empty). Rows are
+    added/removed client-side (see app/javascript/components/admin/Initializer.jsx,
+    #initializeKeyValueLists), scoped to this widget via the .js-key-value-list
+    wrapper so multiple lists on the same page don't collide. %>
+<% setting_value = setting_value.presence || {} %>
+<%# Sentinel so the form always signals this field was submitted, even with
+    zero rows. FlatGroup#process_list_fields only clears the stored map when it
+    sees this — an omitted field is left untouched (see the partial's Ruby). %>
+<input type="hidden" name="<%= setting_key %>_submitted" value="1" form="<%= form_id %>">
+<div class="c-key-value-list js-key-value-list">
+  <table class="table table-sm table-borderless align-middle mb-2 c-key-value-list__table">
+    <thead>
+      <tr>
+        <th><%= t("admin.settings.key_value_list.abbr") %></th>
+        <th><%= t("admin.settings.key_value_list.label") %></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody class="js-key-value-list-rows">
+      <% setting_value.each do |abbr, label| %>
+        <tr class="js-key-value-list-row">
+          <td>
+            <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][abbr]" form="<%= form_id %>" value="<%= abbr %>">
+          </td>
+          <td>
+            <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][label]" form="<%= form_id %>" value="<%= label %>">
+          </td>
+          <td>
+            <button type="button" class="btn btn-sm btn-outline-danger js-key-value-list-remove">
+              <%= t("admin.settings.key_value_list.remove") %>
+            </button>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <button type="button" class="btn btn-sm btn-outline-secondary js-key-value-list-add">
+    <i class="bi bi-plus-lg"></i>
+    <%= t("admin.settings.key_value_list.add_row") %>
+  </button>
+  <template class="js-key-value-list-template">
+    <tr class="js-key-value-list-row">
+      <td>
+        <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][abbr]" form="<%= form_id %>" value="">
+      </td>
+      <td>
+        <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[][label]" form="<%= form_id %>" value="">
+      </td>
+      <td>
+        <button type="button" class="btn btn-sm btn-outline-danger js-key-value-list-remove">
+          <%= t("admin.settings.key_value_list.remove") %>
+        </button>
+      </td>
+    </tr>
+  </template>
+</div>

--- a/app/views/admin/settings/show/_label_map.html.erb
+++ b/app/views/admin/settings/show/_label_map.html.erb
@@ -1,0 +1,35 @@
+<%# A fixed-key label map: one row per key from a hardcoded list, the key
+    shown as a static label and a text input for its custom value, submitted
+    as `<setting_key>[<key>]` (a Hash). The client can rename the labels but
+    can't add/remove keys, unlike the editable :key_value_list widget.
+
+    `student_groupings` is currently the only :label_map field, so its fixed
+    key list is read directly off DocTemplate::Tables::Activity::GROUPING_OPTIONS
+    here. If a second :label_map field is added, move this key lookup to a
+    setting_key => keys registry instead of hardcoding the constant. %>
+<% keys = DocTemplate::Tables::Activity::GROUPING_OPTIONS %>
+<%# `setting_value` comes from FlatGroup#value_for, which reads the
+    defaults-merged Settings value — its keys are deep_symbolize_keys'd
+    (see Settings.merge_with_defaults), so they're stringified here to match
+    the plain-string GROUPING_OPTIONS keys used for lookup/name attributes. %>
+<% setting_value = (setting_value.presence || {}).transform_keys(&:to_s) %>
+<div class="c-label-map">
+  <table class="table table-sm table-borderless align-middle mb-2 c-label-map__table">
+    <thead>
+      <tr>
+        <th><%= t("admin.settings.label_map.key") %></th>
+        <th><%= t("admin.settings.label_map.label") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% keys.each do |key| %>
+        <tr>
+          <td><%= key.titleize %></td>
+          <td>
+            <input type="text" class="form-control form-control-sm" name="<%= setting_key %>[<%= key %>]" form="<%= form_id %>" value="<%= setting_value[key] %>">
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/documents/gdoc/_header.html.erb
+++ b/app/views/documents/gdoc/_header.html.erb
@@ -4,7 +4,7 @@
     avoid duplicating them at the top of page 1. This diverges on purpose from
     the PDF banner (documents/pdf/_header.html.erb), which keeps logo/type/time
     because the Grover PDF has no running header. %>
-<h1><span class="o-gdoc-h1"><%= document.lesson_title %></span></h1>
+<h1><span class="o-gdoc-h1"><%= document.banner_title %></span></h1>
 <% if document.standards.present? %>
   <p class="c-lesson-banner__standards"><strong>Standards:</strong> <%= document.standards&.upcase %></p>
 <% end %>
@@ -20,7 +20,9 @@
 <% end %>
 
 <% if document.vocabulary.present? %>
-  <p class="c-lesson-vocabulary"><%= t("lesson.vocabulary.label") %>: <%= document.vocabulary %></p>
+  <%# Bold label, italic terms — semantic tags rather than CSS so the emphasis
+      survives the HTML→Gdoc import as well as the PDF render. %>
+  <p class="c-lesson-vocabulary"><strong><%= t("lesson.vocabulary.label") %>:</strong> <em><%= document.vocabulary %></em></p>
 <% end %>
 
 <% materials_summary = document.materials_summary %>
@@ -43,7 +45,7 @@
       and the inline font-size sets its blank-line height. (The PDF uses
       .c-lesson-prep__heading margin-top in pdf.scss instead.) %>
   <p class="c-gdoc-heading-spacer" style="margin: 0; font-size: 18pt;">&nbsp;</p>
-  <h2><span class="o-gdoc-h2"><%= t("lesson.preparation.heading") %></span></h2>
+  <h2><span class="o-gdoc-h2"><%= document.lesson_prep_heading %></span></h2>
   <%# Leading break paragraph INSIDE the prep body. Its first element is often a
       heading (e.g. "Before teaching Class Session 1"), and Google Docs' import
       demotes a heading that is the FIRST child of a container to Normal text.

--- a/app/views/documents/gdoc/_header.html.erb
+++ b/app/views/documents/gdoc/_header.html.erb
@@ -1,31 +1,17 @@
-<table class="c-lesson-banner__strip">
-  <tr>
-    <td class="c-lesson-banner__brand" rowspan="2">
-      <% if document.brandmark_url.present? %>
-        <img class="c-lesson-banner__brand-img" src="<%= document.brandmark_url %>" alt="" width="160" height="48">
-      <% end %>
-    </td>
-    <td class="c-lesson-banner__type">
-      <%= document.lesson_type.to_s.titleize %>
-    </td>
-  </tr>
-  <tr>
-    <td class="c-lesson-banner__time">
-      <% if document.estimated_time.present? %>
-        <%= t("lesson.banner.estimated_time_label") %>: <%= document.estimated_time %>
-      <% end %>
-    </td>
-  </tr>
-</table>
-<hr class="c-lesson-banner__divider">
-<h1 class="c-lesson-banner__title"><%= document.lesson_title %></h1>
+<%# Logo, lesson type, and estimated time are rendered in the Apps Script
+    template's running header for the Gdoc export (substituted via
+    DocumentPresenter#gdoc_header), so they are intentionally omitted here to
+    avoid duplicating them at the top of page 1. This diverges on purpose from
+    the PDF banner (documents/pdf/_header.html.erb), which keeps logo/type/time
+    because the Grover PDF has no running header. %>
+<h1><span class="o-gdoc-h1"><%= document.lesson_title %></span></h1>
 <% if document.standards.present? %>
-  <p class="c-lesson-banner__standards"><%= document.standards %></p>
+  <p class="c-lesson-banner__standards"><strong>Standards:</strong> <%= document.standards&.upcase %></p>
 <% end %>
 
-<% overview_items = [document.description_past, document.description, document.description_future].reject(&:blank?) %>
+<% overview_items = [document.overview_past, document.description, document.overview_future].reject(&:blank?) %>
 <% if overview_items.any? %>
-  <h2 class="c-lesson-overview__heading"><%= t("lesson.overview.heading") %></h2>
+  <h2><span class="o-gdoc-h2"><%= t("lesson.overview.heading") %></span></h2>
   <ul class="c-lesson-overview__list">
     <% overview_items.each do |item| %>
       <li><%= raw item %></li>
@@ -39,7 +25,7 @@
 
 <% materials_summary = document.materials_summary %>
 <% if materials_summary.any? %>
-  <h2 class="c-lesson-materials__heading"><%= t("lesson.materials.heading") %></h2>
+  <h2><span class="o-gdoc-h2"><%= t("lesson.materials.heading") %></span></h2>
   <table class="c-lesson-materials__table">
     <% materials_summary.each do |label, value| %>
       <tr>
@@ -48,4 +34,21 @@
       </tr>
     <% end %>
   </table>
+<% end %>
+
+<% if document.lesson_prep_directions.present? %>
+  <%# Google Drive imports <h2> as its Heading 2 named paragraph style and
+      discards the heading's own top margin, so the gap above is forced with an
+      explicit spacer paragraph — a <p> survives import as a Normal paragraph,
+      and the inline font-size sets its blank-line height. (The PDF uses
+      .c-lesson-prep__heading margin-top in pdf.scss instead.) %>
+  <p class="c-gdoc-heading-spacer" style="margin: 0; font-size: 18pt;">&nbsp;</p>
+  <h2><span class="o-gdoc-h2"><%= t("lesson.preparation.heading") %></span></h2>
+  <%# Leading break paragraph INSIDE the prep body. Its first element is often a
+      heading (e.g. "Before teaching Class Session 1"), and Google Docs' import
+      demotes a heading that is the FIRST child of a container to Normal text.
+      A near-invisible (1pt) paragraph makes that authored heading no longer
+      first, so it maps to its Heading style — without adding a visible blank
+      line (see .c-gdoc-heading-break in gdoc.scss). %>
+  <div class="c-lesson-prep__body"><p class="c-gdoc-heading-break">&nbsp;</p><%= raw document.lesson_prep_directions %></div>
 <% end %>

--- a/app/views/documents/gdoc/show.html.erb
+++ b/app/views/documents/gdoc/show.html.erb
@@ -1,2 +1,10 @@
 <%= render 'documents/gdoc/header', document: @document, options: @options %>
+<%# "Lesson Content" section heading between the lesson front-matter (header/
+    prep) and the activities. Google Drive imports <h2> as its Heading 2 named
+    paragraph style and discards the heading's own top margin, so the gap above
+    is forced with an explicit spacer paragraph — a <p> survives import as a
+    Normal paragraph, and the inline font-size sets its blank-line height.
+    (The PDF uses .c-lesson-content__heading margin-top in pdf.scss instead.) %>
+<p class="c-gdoc-heading-spacer" style="margin: 0; font-size: 18pt;">&nbsp;</p>
+<h2><span class="o-gdoc-h2"><%= t("lesson.content.heading") %></span></h2>
 <%= render 'documents/gdoc/content', document: @document, options: @options %>

--- a/app/views/documents/pdf/_footer.erb
+++ b/app/views/documents/pdf/_footer.erb
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <body>
   <div class="c-lesson-footer" style="<%= @document.footer_margin_styles %>">
-    <% if @document.copyright_text.present? %>
-      <p class="c-lesson-footer__copyright"><%= @document.copyright_text %></p>
+    <% if @document.footer_copyright.present? %>
+      <p class="c-lesson-footer__copyright"><%= @document.footer_copyright %></p>
+    <% end %>
+    <% if @document.footer_course.present? %>
+      <p class="c-lesson-footer__course"><%= @document.footer_course %></p>
     <% end %>
     <table class="c-lesson-footer__line">
       <tr>
-        <td class="c-lesson-footer__breadcrumb"><%= @document.footer_breadcrumb %></td>
+        <td class="c-lesson-footer__breadcrumb"><%= @document.footer_unit_lesson %></td>
         <td class="c-lesson-footer__page">
           <span class="pageNumber"></span>
         </td>

--- a/app/views/documents/pdf/_footer.erb
+++ b/app/views/documents/pdf/_footer.erb
@@ -4,12 +4,14 @@
     <% if @document.footer_copyright.present? %>
       <p class="c-lesson-footer__copyright"><%= @document.footer_copyright %></p>
     <% end %>
-    <% if @document.footer_course.present? %>
-      <p class="c-lesson-footer__course"><%= @document.footer_course %></p>
+    <%# Per-lesson cc-attribution. Rendered only when the lesson authors one,
+        so the R2 three-line footer is unchanged for lessons without it. %>
+    <% if @document.footer_attribution.present? %>
+      <p class="c-lesson-footer__attribution"><%= @document.footer_attribution %></p>
     <% end %>
     <table class="c-lesson-footer__line">
       <tr>
-        <td class="c-lesson-footer__breadcrumb"><%= @document.footer_unit_lesson %></td>
+        <td class="c-lesson-footer__breadcrumb"><%= @document.footer_course_lesson %></td>
         <td class="c-lesson-footer__page">
           <span class="pageNumber"></span>
         </td>

--- a/app/views/documents/pdf/_header.html.erb
+++ b/app/views/documents/pdf/_header.html.erb
@@ -7,7 +7,7 @@
         <% end %>
       </td>
       <td class="c-lesson-banner__type">
-        <%= document.lesson_type.to_s.titleize %>
+        <%= document.lesson_type_label %>
       </td>
     </tr>
     <tr>
@@ -21,10 +21,10 @@
   <hr class="c-lesson-banner__divider">
   <h1 class="c-lesson-banner__title"><%= document.lesson_title %></h1>
   <% if document.standards.present? %>
-    <p class="c-lesson-banner__standards"><%= document.standards %></p>
+    <p class="c-lesson-banner__standards"><strong>Standards:</strong> <%= document.standards&.upcase %></p>
   <% end %>
 
-  <% overview_items = [document.description_past, document.description, document.description_future].reject(&:blank?) %>
+  <% overview_items = [document.overview_past, document.description, document.overview_future].reject(&:blank?) %>
   <% if overview_items.any? %>
     <h2 class="c-lesson-overview__heading"><%= t("lesson.overview.heading") %></h2>
     <ul class="c-lesson-overview__list">
@@ -49,5 +49,10 @@
         </tr>
       <% end %>
     </table>
+  <% end %>
+
+  <% if document.lesson_prep_directions.present? %>
+    <h2 class="c-lesson-prep__heading"><%= t("lesson.preparation.heading") %></h2>
+    <div class="c-lesson-prep__body"><%= raw document.lesson_prep_directions %></div>
   <% end %>
 </div>

--- a/app/views/documents/pdf/_header.html.erb
+++ b/app/views/documents/pdf/_header.html.erb
@@ -1,11 +1,16 @@
 <div class="c-lesson-banner" style="<%= document.padding_styles %>">
   <table class="c-lesson-banner__strip">
     <tr>
-      <td class="c-lesson-banner__brand" rowspan="2">
+      <td class="c-lesson-banner__brand" rowspan="3">
         <% if document.brandmark_url.present? %>
           <img class="c-lesson-banner__brand-img" src="<%= document.brandmark_url %>" alt="" width="160" height="48">
         <% end %>
       </td>
+      <td class="c-lesson-banner__unit">
+        <%= document.unit_title %>
+      </td>
+    </tr>
+    <tr>
       <td class="c-lesson-banner__type">
         <%= document.lesson_type_label %>
       </td>
@@ -19,7 +24,7 @@
     </tr>
   </table>
   <hr class="c-lesson-banner__divider">
-  <h1 class="c-lesson-banner__title"><%= document.lesson_title %></h1>
+  <h1 class="c-lesson-banner__title"><%= document.banner_title %></h1>
   <% if document.standards.present? %>
     <p class="c-lesson-banner__standards"><strong>Standards:</strong> <%= document.standards&.upcase %></p>
   <% end %>
@@ -35,7 +40,9 @@
   <% end %>
 
   <% if document.vocabulary.present? %>
-    <p class="c-lesson-vocabulary"><%= t("lesson.vocabulary.label") %>: <%= document.vocabulary %></p>
+    <%# Bold label, italic terms — semantic tags rather than CSS so the emphasis
+        survives the HTML→Gdoc import as well as the PDF render. %>
+    <p class="c-lesson-vocabulary"><strong><%= t("lesson.vocabulary.label") %>:</strong> <em><%= document.vocabulary %></em></p>
   <% end %>
 
   <% materials_summary = document.materials_summary %>
@@ -52,7 +59,7 @@
   <% end %>
 
   <% if document.lesson_prep_directions.present? %>
-    <h2 class="c-lesson-prep__heading"><%= t("lesson.preparation.heading") %></h2>
+    <h2 class="c-lesson-prep__heading"><%= document.lesson_prep_heading %></h2>
     <div class="c-lesson-prep__body"><%= raw document.lesson_prep_directions %></div>
   <% end %>
 </div>

--- a/app/views/documents/pdf/show.html.erb
+++ b/app/views/documents/pdf/show.html.erb
@@ -4,9 +4,14 @@
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-<%= render 'documents/pdf/header', document: @document unless @document.content_type == 'sm' %>
+<%= render 'documents/pdf/header', document: @document unless @document.content_type.to_s == 'sm' %>
 <div class="o-page--cg-<%= @document.subject %>">
   <div class="c-ld__body o-page--pdf-ld c-ld__body--pdf" style="<%= @document.padding_styles %>">
+    <%# "Lesson Content" section heading, shown for lessons (same guard as the
+        header above), between the lesson front-matter and the activities. %>
+    <% unless @document.content_type.to_s == 'sm' %>
+      <h2 class="c-lesson-content__heading"><%= t("lesson.content.heading") %></h2>
+    <% end %>
     <%= raw @document.content_for(:default, @options) %>
   </div>
 </div>

--- a/app/views/materials/_external_assets.html.erb
+++ b/app/views/materials/_external_assets.html.erb
@@ -1,0 +1,16 @@
+<%# External-asset links for a material (Google Slides, PDF, video, etc.). %>
+<%# Each populated representation renders as a target="_blank" link. %>
+<% assets = material.external_assets %>
+<% if assets.any? %>
+  <div class="o-m-external-assets">
+    <h4 class="o-m-external-assets__title">External materials</h4>
+    <ul class="o-m-external-assets__list">
+      <% assets.each do |asset| %>
+        <li>
+          <span class="o-m-external-assets__label"><%= asset[:label] %>:</span>
+          <a class="o-m-external-assets__link" href="<%= asset[:url] %>" target="_blank" rel="noopener noreferrer"><%= asset[:url] %></a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/materials/gdoc/_header.html.erb
+++ b/app/views/materials/gdoc/_header.html.erb
@@ -1,19 +1,30 @@
+<%# Material banner: brandmark (left) + material-type (right), divider, an %>
+<%# optional Name/Date fill-in row (when material-metadata name-date = Yes), %>
+<%# then the Document Title (= material-title). Reuses the shared %>
+<%# .c-lesson-banner styling — lesson and material banners are identical. %>
 <% if document.header? %>
-  <h1 class="u-txt--m-header-title"><%= document.title %></h1>
+  <table class="c-lesson-banner__strip">
+    <tr>
+      <td class="c-lesson-banner__brand">
+        <% if document.brandmark_url.present? %>
+          <img class="c-lesson-banner__brand-img" src="<%= document.brandmark_url %>" alt="" width="160" height="48">
+        <% end %>
+      </td>
+      <td class="c-lesson-banner__type"><%= document.material_type.to_s.titleize %></td>
+    </tr>
+  </table>
+  <hr class="c-lesson-banner__divider">
+
   <% if document.name_date %>
-    <table class="o-m-header--gdoc">
+    <table class="o-m-namedate">
       <tr>
-        <td class="o-m-header__title u-txt--m-header-dt-title o-m-header--border-bottom">
-          <p>Name</p>
-        </td>
-        <td class="o-m-header__title u-txt--m-header-dt-title o-m-header--border-bottom">
-          <p>Date</p>
-        </td>
-        <td class="o-m-header__date-value o-m-header--border-bottom"></td>
+        <td class="o-m-namedate__label"><%= t("material.namedate.name") %></td>
+        <td class="o-m-namedate__rule"></td>
+        <td class="o-m-namedate__label o-m-namedate__label--date"><%= t("material.namedate.date") %></td>
+        <td class="o-m-namedate__rule o-m-namedate__rule--date"></td>
       </tr>
     </table>
-    <p class="do-not-strip"></p>
   <% end %>
-<% else %>
-  <h1 class="u-txt--m-header-title"><%= document.title %></h1>
 <% end %>
+
+<h1><span class="o-gdoc-h1"><%= document.title %></span></h1>

--- a/app/views/materials/gdoc/show.html.erb
+++ b/app/views/materials/gdoc/show.html.erb
@@ -1,3 +1,5 @@
 <%= render "materials/gdoc/header", document: @document %>
 
 <%= raw @document.content_for(:gdoc) %>
+
+<%= render "materials/external_assets", material: @document %>

--- a/app/views/materials/pdf/_header.html.erb
+++ b/app/views/materials/pdf/_header.html.erb
@@ -1,14 +1,32 @@
+<%# Material banner: brandmark (left) + material-type (right), divider, an %>
+<%# optional Name/Date fill-in row (when material-metadata name-date = Yes), %>
+<%# then the Document Title (= material-title). Reuses the shared %>
+<%# .c-lesson-banner styling — lesson and material banners are identical. %>
 <div>
   <% if document.header? %>
-    <h1 class="u-pdf-txt--m-header-title"><%= document.title %></h1>
+    <table class="c-lesson-banner__strip">
+      <tr>
+        <td class="c-lesson-banner__brand">
+          <% if document.brandmark_url.present? %>
+            <img class="c-lesson-banner__brand-img" src="<%= document.brandmark_url %>" alt="" width="160" height="48">
+          <% end %>
+        </td>
+        <td class="c-lesson-banner__type"><%= document.material_type.to_s.titleize %></td>
+      </tr>
+    </table>
+    <hr class="c-lesson-banner__divider">
+
     <% if document.name_date %>
-      <table class="o-m-header u-padding-top--base">
-        <td class="o-m-header__title u-pdf-txt--m-header-dt-title">Name</td>
-        <td class="o-m-header__title u-pdf-txt--m-header-dt-title">Date</td>
-        <td class="o-m-header__date-value"></td>
+      <table class="o-m-namedate">
+        <tr>
+          <td class="o-m-namedate__label"><%= t("material.namedate.name") %></td>
+          <td class="o-m-namedate__rule"></td>
+          <td class="o-m-namedate__label o-m-namedate__label--date"><%= t("material.namedate.date") %></td>
+          <td class="o-m-namedate__rule o-m-namedate__rule--date"></td>
+        </tr>
       </table>
     <% end %>
-  <% else %>
-    <h1 class="u-pdf-txt--m-header-title"><%= document.title %></h1>
   <% end %>
+
+  <h1 class="c-lesson-banner__title"><%= document.title %></h1>
 </div>

--- a/app/views/materials/pdf/show.html.erb
+++ b/app/views/materials/pdf/show.html.erb
@@ -8,6 +8,7 @@
   <div class="o-m-content">
     <div class="o-m-content__base">
       <%= raw @document.content_for(:default) %>
+      <%= render "materials/external_assets", material: @document %>
     </div>
   </div>
 </div>

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -24,4 +24,5 @@
 
 <div class="container-fluid">
   <%= raw @material.content_for(:default) %>
+  <%= render "materials/external_assets", material: @material %>
 </div>

--- a/app/views/units/gdoc/show.html.erb
+++ b/app/views/units/gdoc/show.html.erb
@@ -1,0 +1,8 @@
+<%# Unit gdoc body — Acknowledgements page. Page header (logo) and footer %>
+<%# (copyright/course/unit-title) are applied later via Apps Script, not here. %>
+<% if @unit.acknowledgements.present? %>
+  <div class="c-unit-acknowledgements">
+    <h1><span class="o-gdoc-h1"><%= t("unit.acknowledgements.heading") %></span></h1>
+    <%= raw @unit.acknowledgements %>
+  </div>
+<% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -251,6 +251,30 @@
         79
       ],
       "note": ""
+    },
+    {
+      "warning_type": "Dangerous Eval",
+      "warning_code": 13,
+      "fingerprint": "bc744e93b3e4b07573628c3b2e9be65cd5c6a172ccde112abc532b17edb3b6a7",
+      "check_name": "Evaluation",
+      "message": "Dynamic code evaluation",
+      "file": "lib/doc_template/tags/base_tag.rb",
+      "line": 174,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
+      "code": "binding.eval(Erubi::Engine.new(File.read(template_path(template_name)), :escape => true, :escapefunc => \"::ERB::Util.html_escape\").src, template_path(template_name).to_s)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "DocTemplate::Tags::BaseTag",
+        "method": "parse_template"
+      },
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        913,
+        95
+      ],
+      "note": "Compiling an ERB template is necessarily an eval - this is how every ERB engine works, Rails' own ActionView ERB handler included. The evaluated string is Erubi's compiled output for a template file shipped in lib/doc_template/templates/, selected by template_name from a tag's TEMPLATES constant (or the lcms.yml templates override); no request or document data reaches it. This call site exists specifically to turn HTML-escaping ON for tag templates (escape: true), replacing a plain ERB.new(...).result(binding) that escaped nothing."
     }
   ],
   "brakeman_version": "8.0.1"

--- a/config/initializers/lcms_constants.rb
+++ b/config/initializers/lcms_constants.rb
@@ -39,7 +39,13 @@ SUBJECT_DEFAULT = "math"
 #
 # A group's value is either:
 #   - a Hash of `leaf_key => field_type` (flat scalar fields, each rendered
-#     with the matching `settings/show/<type>` partial), or
+#     with the matching `settings/show/<type>` partial) — `:key_value_list`
+#     lets the operator define both keys and values (e.g. `lesson_types`,
+#     `activity_types`), while `:label_map` is a fixed-key variant where only
+#     the values are editable (e.g. `student_groupings`, keyed by
+#     `DocTemplate::Tables::Activity::GROUPING_OPTIONS`), and `:callout_list`
+#     is a repeatable-row variant with an icon upload per row (`callout_types`,
+#     rendered by DocTemplate::Tags::CalloutTag), or
 #   - the symbol `:form`, meaning the group is a structured (nested) setting
 #     backed by a virtual model `Setting::<Group>` (e.g. `Setting::Pdf`). The
 #     model defines the editable schema (types + validations); the admin form
@@ -56,7 +62,11 @@ SETTINGS = {
   admin_view_links: :form,
   documents: {
     brandmark: :image,
-    copyright_text: :text
+    copyright_text: :text,
+    lesson_types: :key_value_list,
+    activity_types: :key_value_list,
+    student_groupings: :label_map,
+    callout_types: :callout_list
   },
   pdf_renderer: {
     default_renderer: :renderer_select

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -329,10 +329,28 @@ en:
         documents:
           brandmark: Brandmark
           copyright_text: Copyright Text (e.g., "© Company Name, Spring 2026")
+          lesson_types: Lesson Types
+          activity_types: Activity Types
+          student_groupings: Student Groupings
+          callout_types: Callout Types
         pdf_renderer:
           default_renderer: Default PDF renderer
       renderer_select:
         use_fallback: "(use system default)"
+      key_value_list:
+        abbr: Abbreviation
+        label: Label
+        add_row: Add row
+        remove: Remove
+      label_map:
+        key: Grouping
+        label: Label
+      callout_list:
+        type: Type
+        title: Title
+        icon: Icon
+        add_row: Add row
+        remove: Remove
       index:
         key: Key
         value: Value

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,12 +17,22 @@ en:
       estimated_time_label: "Estimated Time"
     content:
       heading: "Lesson Content"
+    footer:
+      # Breadcrumb lesson label, e.g. "Lesson 1 of 12". Rendered without the
+      # total when the unit's lesson count is unknown.
+      lesson_of: "Lesson %{number} of %{total}"
     materials:
       heading: "Materials"
     overview:
       heading: "Overview"
     preparation:
       heading: "Lesson Preparation"
+      # Appended to the heading when lesson-prep-time is authored, mirroring the
+      # "(5 minutes)" an activity heading carries.
+      heading_with_time: "%{heading} (%{time})"
+      minutes:
+        one: "%{count} minute"
+        other: "%{count} minutes"
     vocabulary:
       label: "Vocabulary"
   unit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,12 +15,19 @@ en:
   lesson:
     banner:
       estimated_time_label: "Estimated Time"
+    content:
+      heading: "Lesson Content"
     materials:
       heading: "Materials"
     overview:
       heading: "Overview"
+    preparation:
+      heading: "Lesson Preparation"
     vocabulary:
       label: "Vocabulary"
+  unit:
+    acknowledgements:
+      heading: "Acknowledgements"
   grades:
     ela:
       grade_9: Grade 9
@@ -37,6 +44,9 @@ en:
       rubric: Rubric
       tool: Tool
       reference_guide: Reference Guide
+    namedate:
+      name: "Name:"
+      date: "Date:"
   resources_count:
     one: resource
     other: resources

--- a/config/scripts/Code.gs
+++ b/config/scripts/Code.gs
@@ -488,11 +488,13 @@ function pageNumberInsert(document) {
   if (!found) return 'skipped — {page_number} not found in footer';
 
   var textEl = found.getElement().asText();
-  // asParagraph(): getParent() returns a generic ContainerElement, which has no
-  // appendPageNumber (same cast as brandmarkInsert / styleHeaderRight).
-  var paragraph = textEl.getParent().asParagraph();
 
   try {
+    // asParagraph(): getParent() returns a generic ContainerElement, which has
+    // no appendPageNumber (same cast as brandmarkInsert / styleHeaderRight).
+    // Inside the try: a placeholder whose parent is not a paragraph would
+    // otherwise throw uncaught and abort the whole of postProcessing.
+    var paragraph = textEl.getParent().asParagraph();
     // Insert the live element BEFORE deleting the placeholder text: if this
     // throws, the footer keeps its {page_number} marker instead of losing both
     // (this catch only reaches Logger).
@@ -536,12 +538,13 @@ function brandmarkInsert(document, brandmarkData) {
   if (!match) return 'skipped — brandmark is not a base64 data URI';
 
   var textEl = found.getElement().asText();
-  // asParagraph(): getParent() returns a generic ContainerElement, which has no
-  // appendInlineImage — calling it there throws (see styleHeaderRight, which
-  // casts the same way).
-  var paragraph = textEl.getParent().asParagraph();
 
   try {
+    // asParagraph(): getParent() returns a generic ContainerElement, which has
+    // no appendInlineImage (see styleHeaderRight, which casts the same way).
+    // Inside the try: this runs BEFORE insertFooterPageNumber, so an uncaught
+    // throw here would abort postProcessing and silently skip the page number.
+    var paragraph = textEl.getParent().asParagraph();
     var blob = Utilities.newBlob(Utilities.base64Decode(match[2]), match[1], 'brandmark');
     // Insert the logo BEFORE dropping the placeholder text: if the insert
     // throws, the header keeps its {brandmark_url} marker instead of losing

--- a/config/scripts/Code.gs
+++ b/config/scripts/Code.gs
@@ -17,6 +17,9 @@ var BRAND_FONT = 'Lexend';
 // weight. Keep in sync with the PDF banner (.c-lesson-banner__type / __time in
 // app/assets/stylesheets/gdoc.scss).
 var HEADER_LESSON_TYPE_SIZE = 12;
+// Unit title sits one step below the lesson type, matching
+// .c-lesson-banner__unit in app/assets/stylesheets/pdf.scss.
+var HEADER_UNIT_TITLE_SIZE = 11;
 var HEADER_ESTIMATED_TIME_SIZE = 11;
 // Footer typography (see footerLineStyles): the copyright line is normal weight; the
 // course and unit/lesson lines are bold and one point larger. Sizes are set for
@@ -326,6 +329,10 @@ function copyHeader(document, template, isLandscape, patterns, replaceTexts, gra
   var tmplHeader = template.getHeader();
   if (!tmplHeader || !tmplHeader.getTables()) return;
   var header = document.getHeader() || document.addHeader();
+  // Capture which paragraph holds {unit_title} BEFORE substitution replaces it
+  // with a value there is no longer anything to match on. The footer does the
+  // same (see footerLineStyles).
+  var unitTitleIndex = headerParagraphIndex(tmplHeader, '{unit_title}');
   copyContentTo(
     document,
     template,
@@ -337,6 +344,36 @@ function copyHeader(document, template, isLandscape, patterns, replaceTexts, gra
     gradeColors
   );
   styleHeaderRight(header);
+  styleHeaderUnitTitle(header, unitTitleIndex);
+}
+
+/**
+ * Index of the template-header paragraph containing `placeholder`, or -1 when
+ * the template does not define it. copyContentTo's updateParagraphStyles pass
+ * re-aligns the generated header's paragraphs 1:1 with the template's, so the
+ * same index identifies the line in the generated header.
+ */
+function headerParagraphIndex(tmplHeader, placeholder) {
+  var paragraphs = tmplHeader.getParagraphs();
+  for (var i = 0; i < paragraphs.length; i++) {
+    if (paragraphs[i].getText().indexOf(placeholder) !== -1) return i;
+  }
+  return -1;
+}
+
+/**
+ * Drops the unit-title line to HEADER_UNIT_TITLE_SIZE. Must run AFTER
+ * styleHeaderRight, which paints every header line except "Estimated Time" at
+ * HEADER_LESSON_TYPE_SIZE — this is the exception to that. No-op when the
+ * template has no {unit_title} placeholder.
+ */
+function styleHeaderUnitTitle(header, index) {
+  if (!header || index < 0) return;
+
+  var paragraphs = header.getParagraphs();
+  if (index >= paragraphs.length) return;
+
+  styleParagraphFont(paragraphs[index], HEADER_UNIT_TITLE_SIZE, true);
 }
 
 /**

--- a/config/scripts/Code.gs
+++ b/config/scripts/Code.gs
@@ -8,6 +8,22 @@ var PX_TO_PT = 0.75;
 var IMAGE_MARGIN = 0;
 // default font size for elements we're copying
 var DEFAULT_FONT_SIZE = 10;
+// brand font applied to copied header/footer paragraphs that have no explicit
+// font, so they match the Lexend body (keep in sync with $font-family-body in
+// app/assets/stylesheets/gdoc.scss)
+var BRAND_FONT = 'Lexend';
+// Header right-side typography (see styleHeaderRight): the lesson-type line is
+// bold and one point larger than the estimated-time line, which is normal
+// weight. Keep in sync with the PDF banner (.c-lesson-banner__type / __time in
+// app/assets/stylesheets/gdoc.scss).
+var HEADER_LESSON_TYPE_SIZE = 12;
+var HEADER_ESTIMATED_TIME_SIZE = 11;
+// Footer typography (see footerLineStyles): the copyright line is normal weight; the
+// course and unit/lesson lines are bold and one point larger. Sizes are set for
+// the Gdoc footer per the styling spec (larger than the PDF footer in
+// app/assets/stylesheets/pdf_plain.scss).
+var FOOTER_COPYRIGHT_SIZE = 11;
+var FOOTER_BOLD_SIZE = 12;
 // tags
 var RE_SIZE = /\[(?:\d+)\]/;
 
@@ -154,7 +170,7 @@ function updateParagraphStyles(elementFrom, elementTo) {
         styles[DocumentApp.Attribute.FONT_SIZE] = fontSize || DEFAULT_FONT_SIZE;
         styles[DocumentApp.Attribute.LINE_SPACING] = attrs[DocumentApp.Attribute.LINE_SPACING];
         styles[DocumentApp.Attribute.FONT_FAMILY] =
-          attrs[DocumentApp.Attribute.FONT_FAMILY] || 'Montserrat';
+          attrs[DocumentApp.Attribute.FONT_FAMILY] || BRAND_FONT;
         documentParagraph.setAttributes(styles);
       }
     });
@@ -245,7 +261,62 @@ function copyFooter(document, template, isLandscape, patterns, replaceTexts) {
   var tmplFooter = template.getFooter();
   if (!tmplFooter || !tmplFooter.getTables()) return;
   var footer = document.getFooter() || document.addFooter();
+
+  // Capture which template paragraph holds each footer placeholder BEFORE
+  // substitution. Matching by placeholder (not by scanning non-blank lines)
+  // keeps each line's style correct even when a value is empty — otherwise a
+  // blank {copyright}/{course} would shift the styles onto the wrong line.
+  var lineStyles = footerLineStyles(tmplFooter);
+
   copyContentTo(document, template, isLandscape, tmplFooter, footer, patterns, replaceTexts);
+  styleFooterLines(footer, lineStyles);
+}
+
+/**
+ * Maps each footer placeholder to its paragraph index within the template
+ * footer and the brand style to apply there. copyContentTo copies the template
+ * structure and updateParagraphStyles re-aligns doc paragraphs 1:1 with the
+ * template, so the same index identifies the line in the generated footer.
+ *   {copyright}   -> Lexend, FOOTER_COPYRIGHT_SIZE, normal weight
+ *   {course}      -> Lexend, FOOTER_BOLD_SIZE, bold
+ *   {unit_lesson} -> Lexend, FOOTER_BOLD_SIZE, bold
+ * Placeholders absent from the template (e.g. the material footer's
+ * {attribution}) simply contribute nothing.
+ */
+function footerLineStyles(tmplFooter) {
+  var specs = [
+    { placeholder: '{copyright}', size: FOOTER_COPYRIGHT_SIZE, bold: false },
+    { placeholder: '{course}', size: FOOTER_BOLD_SIZE, bold: true },
+    { placeholder: '{unit_lesson}', size: FOOTER_BOLD_SIZE, bold: true }
+  ];
+
+  var paragraphs = tmplFooter.getParagraphs();
+  var lines = [];
+  specs.forEach(function (spec) {
+    for (var i = 0; i < paragraphs.length; i++) {
+      if (paragraphs[i].getText().indexOf(spec.placeholder) !== -1) {
+        lines.push({ index: i, size: spec.size, bold: spec.bold });
+        break;
+      }
+    }
+  });
+  return lines;
+}
+
+/**
+ * Applies the captured per-line footer styles to the generated footer. Runs
+ * AFTER copyContentTo (whose updateParagraphStyles pass resets FONT_SIZE/
+ * FONT_FAMILY from the template), so it is the final word on size and weight.
+ */
+function styleFooterLines(footer, lineStyles) {
+  if (!footer || !lineStyles.length) return;
+
+  var paragraphs = footer.getParagraphs();
+  lineStyles.forEach(function (line) {
+    if (line.index < paragraphs.length) {
+      styleParagraphFont(paragraphs[line.index], line.size, line.bold);
+    }
+  });
 }
 
 /**
@@ -265,6 +336,63 @@ function copyHeader(document, template, isLandscape, patterns, replaceTexts, gra
     replaceTexts,
     gradeColors
   );
+  styleHeaderRight(header);
+}
+
+/**
+ * Applies brand typography to the header's right-side lines. Runs AFTER
+ * copyContentTo (whose updateParagraphStyles pass resets FONT_SIZE/FONT_FAMILY
+ * from the template), so this is the final word on size and weight:
+ *   "Estimated Time: …" -> Lexend, HEADER_ESTIMATED_TIME_SIZE, normal weight
+ *   Lesson Type line     -> Lexend, HEADER_LESSON_TYPE_SIZE, bold
+ * Keyed on the static "Estimated Time" label; the lesson-type line is the other
+ * non-empty paragraph in the same header cell. No-op if the label is absent.
+ */
+function styleHeaderRight(header) {
+  if (!header) return;
+  var found = header.findText('Estimated Time');
+  if (!found) return;
+
+  var estimatedParagraph = found.getElement().getParent().asParagraph();
+  styleParagraphFont(estimatedParagraph, HEADER_ESTIMATED_TIME_SIZE, false);
+
+  var cell = parentTableCell(estimatedParagraph);
+  if (!cell) return;
+  for (var i = 0; i < cell.getNumChildren(); i++) {
+    var child = cell.getChild(i);
+    if (child.getType() !== DocumentApp.ElementType.PARAGRAPH) continue;
+
+    var paragraph = child.asParagraph();
+    var text = paragraph.getText();
+    if (text.replace(/\s/g, '') === '' || text.indexOf('Estimated Time') !== -1) continue;
+
+    styleParagraphFont(paragraph, HEADER_LESSON_TYPE_SIZE, true); // lesson type
+  }
+}
+
+/**
+ * Sets Lexend + the given size and weight across a whole paragraph, leaving
+ * alignment, colour and spacing untouched.
+ */
+function styleParagraphFont(paragraph, size, bold) {
+  var text = paragraph.editAsText();
+  var length = text.getText().length;
+  if (length === 0) return;
+  text.setFontFamily(0, length - 1, BRAND_FONT);
+  text.setFontSize(0, length - 1, size);
+  text.setBold(0, length - 1, bold);
+}
+
+/**
+ * Walks up from an element to its containing TableCell, or null if none.
+ */
+function parentTableCell(element) {
+  var el = element;
+  while (el) {
+    if (el.getType() === DocumentApp.ElementType.TABLE_CELL) return el.asTableCell();
+    el = el.getParent();
+  }
+  return null;
 }
 
 /**
@@ -331,6 +459,76 @@ function processPageBreaks(document) {
 }
 
 /**
+ * Replaces the {brandmark_url} placeholder in the running header with the client
+ * logo. Rails passes the logo inline as a base64 data URI (Settings brandmark),
+ * so the image is decoded here — no UrlFetchApp, hence no script.external_request
+ * scope and no dependency on the source URL being publicly fetchable by Google.
+ * No-op when the data is blank, the placeholder is absent, or decoding fails, so
+ * a missing/broken logo never breaks the export — it just leaves the header
+ * without an image.
+ *
+ * Must run AFTER copyHeader, which replaces the header with a fresh copy of the
+ * template header (where the {brandmark_url} placeholder lives).
+ */
+function insertHeaderBrandmark(document, brandmarkData) {
+  Logger.log('brandmark: ' + brandmarkInsert(document, brandmarkData));
+}
+
+function brandmarkInsert(document, brandmarkData) {
+  if (!brandmarkData) return 'skipped — blank data from Rails';
+  var header = document.getHeader();
+  if (!header) return 'skipped — document has no header';
+  var found = header.findText('{brandmark_url}');
+  if (!found) return 'skipped — {brandmark_url} not found in header';
+
+  // Expect a base64 data URI: data:<mime>;base64,<payload>
+  var match = brandmarkData.match(/^data:([^;]+);base64,(.*)$/);
+  if (!match) return 'skipped — brandmark is not a base64 data URI';
+
+  var textEl = found.getElement().asText();
+  var paragraph = textEl.getParent();
+
+  try {
+    var blob = Utilities.newBlob(Utilities.base64Decode(match[2]), match[1], 'brandmark');
+    // Drop the placeholder text, then insert the logo in its place.
+    textEl.setText('');
+    var image = paragraph.appendInlineImage(blob);
+    // Scale down to a header-sized height, preserving aspect ratio.
+    var maxHeight = 48;
+    if (image.getHeight() > maxHeight) {
+      var ratio = maxHeight / image.getHeight();
+      image.setWidth(Math.round(image.getWidth() * ratio));
+      image.setHeight(maxHeight);
+    }
+    return 'inserted OK (' + match[1] + ', ' + match[2].length + ' b64 chars)';
+  } catch (err) {
+    return 'insert failed: ' + err;
+  }
+}
+
+/**
+ * Google Docs' default Heading styles carry a large "space above" (~16-18pt)
+ * that HTML import cannot override — it shows up as an empty line above every
+ * sub-heading (e.g. "Before teaching Class Session 1" under "Lesson
+ * Preparation") and over-spaces the flat activity list. Bring heading spacing
+ * down to the brand gap so headings sit tight to their content, matching the
+ * PDF. The flat layout relies on this space to separate activities, so it is
+ * REDUCED, not zeroed. Tune HEADING_SPACE_BEFORE / _AFTER to taste (points).
+ */
+var HEADING_SPACE_BEFORE = 6;
+var HEADING_SPACE_AFTER = 4;
+function tightenHeadings(document) {
+  var paragraphs = document.getBody().getParagraphs();
+  for (var i = 0; i < paragraphs.length; i++) {
+    var paragraph = paragraphs[i];
+    if (paragraph.getHeading() !== DocumentApp.ParagraphHeading.NORMAL) {
+      paragraph.setSpacingBefore(HEADING_SPACE_BEFORE);
+      paragraph.setSpacingAfter(HEADING_SPACE_AFTER);
+    }
+  }
+}
+
+/**
  * Main function to call after uploading document
  */
 function postProcessing(
@@ -341,14 +539,17 @@ function postProcessing(
   footerReplaceTexts = [],
   headerPatterns = [],
   headerReplaceTexts = [],
-  gradeColors = []
+  gradeColors = [],
+  brandmarkData = ''
 ) {
   var document = DocumentApp.openById(documentId);
   var template = DocumentApp.openById(templateId);
   processPageBreaks(document);
+  tightenHeadings(document);
   setMargins(document, template, isLandscape);
   if (footerPatterns.length && footerReplaceTexts.length)
     copyFooter(document, template, isLandscape, footerPatterns, footerReplaceTexts);
   if (headerPatterns.length && headerReplaceTexts.length)
     copyHeader(document, template, isLandscape, headerPatterns, headerReplaceTexts, gradeColors);
+  insertHeaderBrandmark(document, brandmarkData);
 }

--- a/config/scripts/Code.gs
+++ b/config/scripts/Code.gs
@@ -344,9 +344,10 @@ function copyHeader(document, template, isLandscape, patterns, replaceTexts, gra
  * copyContentTo (whose updateParagraphStyles pass resets FONT_SIZE/FONT_FAMILY
  * from the template), so this is the final word on size and weight:
  *   "Estimated Time: …" -> Lexend, HEADER_ESTIMATED_TIME_SIZE, normal weight
- *   Lesson Type line     -> Lexend, HEADER_LESSON_TYPE_SIZE, bold
- * Keyed on the static "Estimated Time" label; the lesson-type line is the other
- * non-empty paragraph in the same header cell. No-op if the label is absent.
+ *   every other line     -> Lexend, HEADER_LESSON_TYPE_SIZE, bold
+ * Keyed on the static "Estimated Time" label; the remaining non-empty
+ * paragraphs in the same header cell are the title, unit title and lesson type
+ * lines, which share one bold treatment. No-op if the label is absent.
  */
 function styleHeaderRight(header) {
   if (!header) return;
@@ -366,7 +367,7 @@ function styleHeaderRight(header) {
     var text = paragraph.getText();
     if (text.replace(/\s/g, '') === '' || text.indexOf('Estimated Time') !== -1) continue;
 
-    styleParagraphFont(paragraph, HEADER_LESSON_TYPE_SIZE, true); // lesson type
+    styleParagraphFont(paragraph, HEADER_LESSON_TYPE_SIZE, true); // title / unit title / lesson type
   }
 }
 
@@ -459,6 +460,55 @@ function processPageBreaks(document) {
 }
 
 /**
+ * Replaces the {page_number} placeholder in the running footer with a LIVE page
+ * number.
+ *
+ * This cannot go through the footerPatterns/replaceText path Rails drives: a
+ * page number is not text but its own PageNumber element, so replaceText could
+ * only ever write a fixed string (every page would read the same number). The
+ * placeholder is therefore left untouched by the substitution pass and swapped
+ * here for a real element.
+ *
+ * appendPageNumber() appends at the END of the paragraph, which is where a page
+ * number belongs (the template puts {page_number} last on its line, after the
+ * right-tab). No-op when the placeholder is absent, so a template without one
+ * simply gets no page number.
+ *
+ * Must run AFTER copyFooter, which replaces the footer with a fresh copy of the
+ * template footer (where the {page_number} placeholder lives).
+ */
+function insertFooterPageNumber(document) {
+  Logger.log('page number: ' + pageNumberInsert(document));
+}
+
+function pageNumberInsert(document) {
+  var footer = document.getFooter();
+  if (!footer) return 'skipped — document has no footer';
+  var found = footer.findText('{page_number}');
+  if (!found) return 'skipped — {page_number} not found in footer';
+
+  var textEl = found.getElement().asText();
+  // asParagraph(): getParent() returns a generic ContainerElement, which has no
+  // appendPageNumber (same cast as brandmarkInsert / styleHeaderRight).
+  var paragraph = textEl.getParent().asParagraph();
+
+  try {
+    // Insert the live element BEFORE deleting the placeholder text: if this
+    // throws, the footer keeps its {page_number} marker instead of losing both
+    // (this catch only reaches Logger).
+    var pageNumber = paragraph.appendPageNumber();
+    // styleFooterLines already ran (inside copyFooter), so this element is not
+    // covered by it — style it directly to match the bold breadcrumb line it
+    // shares.
+    pageNumber.setFontFamily(BRAND_FONT).setFontSize(FOOTER_BOLD_SIZE).setBold(true);
+    textEl.deleteText(found.getStartOffset(), found.getEndOffsetInclusive());
+    return 'inserted OK';
+  } catch (err) {
+    return 'insert failed: ' + err;
+  }
+}
+
+/**
  * Replaces the {brandmark_url} placeholder in the running header with the client
  * logo. Rails passes the logo inline as a base64 data URI (Settings brandmark),
  * so the image is decoded here — no UrlFetchApp, hence no script.external_request
@@ -486,13 +536,21 @@ function brandmarkInsert(document, brandmarkData) {
   if (!match) return 'skipped — brandmark is not a base64 data URI';
 
   var textEl = found.getElement().asText();
-  var paragraph = textEl.getParent();
+  // asParagraph(): getParent() returns a generic ContainerElement, which has no
+  // appendInlineImage — calling it there throws (see styleHeaderRight, which
+  // casts the same way).
+  var paragraph = textEl.getParent().asParagraph();
 
   try {
     var blob = Utilities.newBlob(Utilities.base64Decode(match[2]), match[1], 'brandmark');
-    // Drop the placeholder text, then insert the logo in its place.
-    textEl.setText('');
+    // Insert the logo BEFORE dropping the placeholder text: if the insert
+    // throws, the header keeps its {brandmark_url} marker instead of losing
+    // both the logo and the placeholder (this catch only reaches Logger).
     var image = paragraph.appendInlineImage(blob);
+    // Delete only the placeholder's own range. setText('') would wipe the whole
+    // text run, taking any other placeholder or label authored beside it in the
+    // same run (e.g. "{brandmark_url}  {unit_title}") with it.
+    textEl.deleteText(found.getStartOffset(), found.getEndOffsetInclusive());
     // Scale down to a header-sized height, preserving aspect ratio.
     var maxHeight = 48;
     if (image.getHeight() > maxHeight) {
@@ -529,6 +587,38 @@ function tightenHeadings(document) {
 }
 
 /**
+ * Removes the blank paragraph that sits directly after a heading.
+ *
+ * The exported HTML deliberately puts a near-invisible paragraph at the top of
+ * a section body (`.c-gdoc-heading-break`, 1pt, in documents/gdoc/_header.html.erb):
+ * Google Docs' import demotes a heading that is the FIRST child of a container
+ * to Normal text, so that paragraph keeps the authored sub-heading from being
+ * first. Drive honours the trick but NOT the 1pt size — the imported paragraph
+ * comes back at full Normal height, leaving a visible gap under headings like
+ * "Lesson Preparation".
+ *
+ * By the time this runs the import is done and the spacer has served its
+ * purpose, so it can be dropped. Only whitespace-only paragraphs immediately
+ * following a heading are removed, and never the last paragraph of the body
+ * (Apps Script requires a document to keep at least one).
+ */
+function removeBlankParagraphsAfterHeadings(document) {
+  var body = document.getBody();
+  var paragraphs = body.getParagraphs();
+
+  for (var i = paragraphs.length - 1; i > 0; i--) {
+    var paragraph = paragraphs[i];
+    if (paragraph.getText().replace(/[\s ]/g, '') !== '') continue;
+    // Keep a blank that carries content of its own (an inline image spacer).
+    if (paragraph.getNumChildren() > 1) continue;
+    if (paragraphs[i - 1].getHeading() === DocumentApp.ParagraphHeading.NORMAL) continue;
+    if (body.getNumChildren() <= 1) break;
+
+    paragraph.removeFromParent();
+  }
+}
+
+/**
  * Main function to call after uploading document
  */
 function postProcessing(
@@ -545,6 +635,7 @@ function postProcessing(
   var document = DocumentApp.openById(documentId);
   var template = DocumentApp.openById(templateId);
   processPageBreaks(document);
+  removeBlankParagraphsAfterHeadings(document);
   tightenHeadings(document);
   setMargins(document, template, isLandscape);
   if (footerPatterns.length && footerReplaceTexts.length)
@@ -552,4 +643,5 @@ function postProcessing(
   if (headerPatterns.length && headerReplaceTexts.length)
     copyHeader(document, template, isLandscape, headerPatterns, headerReplaceTexts, gradeColors);
   insertHeaderBrandmark(document, brandmarkData);
+  insertFooterPageNumber(document);
 }

--- a/db/migrate/20260603000000_seed_pdf_settings.rb
+++ b/db/migrate/20260603000000_seed_pdf_settings.rb
@@ -4,14 +4,25 @@
 # are visible and editable in the admin UI. The structure is seeded from the
 # canonical defaults (Settings::DEFAULTS[:pdf]); operators edit the values
 # from there. Guarded so re-runs never clobber existing (edited) values.
+#
+# This migration runs BEFORE `CreateSolidCacheEntries` (20260605000000), so it
+# must not touch the Settings cache: both `Settings.get` (a `cache.fetch`) and
+# `Settings.set` (via `Setting`'s `after_commit` cache invalidation) read/write
+# the Solid Cache table, which does not exist yet at this point. Operating on
+# the `settings` table directly through a callback-free local model keeps the
+# seed independent of the cache backend.
 class SeedPdfSettings < ActiveRecord::Migration[8.1]
-  def up
-    return if Settings.get(:pdf).present?
+  class MigrationSetting < ActiveRecord::Base
+    self.table_name = "settings"
+  end
 
-    Settings.set(:pdf, Settings::DEFAULTS[:pdf].deep_stringify_keys)
+  def up
+    return if MigrationSetting.exists?(key: "pdf")
+
+    MigrationSetting.create!(key: "pdf", value: Settings::DEFAULTS[:pdf].deep_stringify_keys)
   end
 
   def down
-    Settings.unset(:pdf)
+    MigrationSetting.where(key: "pdf").delete_all
   end
 end

--- a/db/migrate/20260810000000_realign_seeded_pdf_right_margin.rb
+++ b/db/migrate/20260810000000_realign_seeded_pdf_right_margin.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# `SeedPdfSettings` (20260603000000) persisted the whole `Settings::DEFAULTS[:pdf]`
+# hash into the `settings` table, and `Settings.merge_with_defaults` lets a stored
+# value win over the shipped default. So lowering the default right margin from
+# 1in to 0.5in — which the lesson banner and materials table widths are tuned for —
+# has no effect on any environment seeded before that change: the stored 1in keeps
+# shadowing it, and those PDFs render differently from a fresh install.
+#
+# Only the exact old shipped value is rewritten, so an operator who deliberately
+# chose a different margin (or already runs 0.5in) is left alone. Idempotent.
+class RealignSeededPdfRightMargin < ActiveRecord::Migration[8.1]
+  OLD_DEFAULT = "1in"
+  NEW_DEFAULT = "0.5in"
+
+  def up
+    migrate_right_margin(from: OLD_DEFAULT, to: NEW_DEFAULT)
+  end
+
+  def down
+    migrate_right_margin(from: NEW_DEFAULT, to: OLD_DEFAULT)
+  end
+
+  private
+
+  def migrate_right_margin(from:, to:)
+    pdf = Settings.get(:pdf)
+    return unless pdf.is_a?(Hash)
+    return unless pdf.dig("default", "margin", "right") == from
+
+    updated = pdf.deep_dup
+    updated["default"]["margin"]["right"] = to
+    Settings.set(:pdf, updated)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_06_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"

--- a/docs/core/lesson-metadata-specs.md
+++ b/docs/core/lesson-metadata-specs.md
@@ -51,7 +51,7 @@
 | activity-materials-pair | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
 | activity-materials-group | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
 | activity-materials-class | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
-| activity-metadata-teacher | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
+| activity-materials-teacher | text, comma separated list; use the \[material\] tag for LCMS-generated materials; can be blank |
 | vocabulary | text, comma separated list; can be blank |
 
 | \[lms-materials\] |  |

--- a/docs/core/styling-defaults-needs-clarification.md
+++ b/docs/core/styling-defaults-needs-clarification.md
@@ -187,29 +187,35 @@ rewritten to the R2 layout:
   the footer block styles. Grover renders the footer template via a
   separate Chromium document, so styles must live there, not in
   `pdf.scss`.
-- **Gdoc**: `DocumentPresenter#gdoc_footer` still returns the original
-  2-row shape (`{attribution}` placeholder + value). The value now
-  merges `copyright_text` with `cc_attribution` (joined by ` — `) so
-  the publisher copyright shows up in the Gdoc footer; the breadcrumb
-  line does **not** land in Gdocs yet.
+- **Gdoc**: `DocumentPresenter#gdoc_footer` and `#gdoc_header` now carry
+  the full R2 payload. Each returns **two parallel arrays** —
+  `[patterns, values]`: footer `["{copyright}", "{course}", "{unit_lesson}"]`,
+  header `["{title}", "{lesson_type}", "{estimated_time}"]`. The post-
+  processing Apps Script (`config/scripts/Code.gs#postProcessing`) copies the
+  Drive template doc's header/footer, then loops
+  `replaceText(patterns[i], values[i])` — so the matching placeholders must
+  exist in the **template** header/footer for substitution to happen.
 
-  **Why not the expanded 6-row payload?** Initial implementation passed
-  three placeholders (`{attribution}`, `{copyright}`, `{breadcrumb}`).
-  Deployed to staging, this caused `DocumentGdocJob` to hang during
-  Apps Script post-processing — the external Apps Script function
-  expects the original argument arity and chokes on the extra rows,
-  combined with `Retriable.retriable(base_interval: 5, tries: 10)` in
-  `app/services/google/script_service.rb` it appears as a multi-minute
-  job hang. Until the Apps Script template doc in Drive is updated to
-  use new placeholders AND the script can accept the extra args, the
-  Ruby side must keep the 2-row shape.
+  **Earlier "hang" — corrected root cause.** A prior attempt was recorded
+  here as the Apps Script "choking on extra rows / expecting the original
+  arity." That was a misdiagnosis. `postProcessing` handles any number of
+  patterns variadically (it's a `for` loop over `patterns`). The real bug was
+  the Ruby **shape**: returning a flat list of `[["{ph}"], [val]]` pairs
+  instead of two parallel `[patterns, values]` arrays. Once
+  `ScriptService#parameters` splats it, the mis-shaped payload mis-aligns the
+  positional args — header patterns get dropped and a placeholder string
+  leaks into `gradeColors` (→ `setBackgroundColor("{unit_lesson}")`), which
+  surfaces as the multi-minute hang under
+  `Retriable.retriable(base_interval: 5, tries: 10)`.
 
-  **Path to full Gdoc parity**: (1) update the Apps Script function
-  outside this repo to accept additional `[placeholder, value]` pairs
-  variadically and to map `{copyright}` / `{breadcrumb}` into the
-  footer template, (2) update the Drive template doc with the new
-  placeholders, (3) extend `gdoc_footer` again. Until then, treat the
-  Gdoc footer as a PDF-only feature.
+  **Status**: with the correct `[patterns, values]` shape plus matching
+  Drive-template placeholders, the Gdoc header (title / lesson type /
+  estimated time) and footer (copyright / course / unit • lesson) substitute
+  correctly. Logo/type/time were also removed from the Gdoc **body** banner
+  (`documents/gdoc/_header.html.erb`) to avoid duplicating the running header;
+  the PDF banner keeps them (no running header there). Remaining manual
+  template steps: insert the brandmark image in the header and add the footer
+  placeholders to the Drive template.
 
 A new `_text.html.erb` partial under `app/views/admin/settings/show/`
 backs the new `:text` Settings field type so admins can edit
@@ -228,7 +234,7 @@ buckets the spec mockup shows:
 | Pair Materials | `activity-materials-pair` |
 | Small Group Materials | `activity-materials-group` |
 | Class Materials | `activity-materials-class` |
-| Teacher Materials | `activity-metadata-teacher` |
+| Teacher Materials | `activity-materials-teacher` |
 
 Each row dedupes within its bucket and joins with `, `. Empty rows
 render as **None** (matching the mockup). The whole block is skipped if
@@ -368,7 +374,7 @@ authors to hand-author a `<table>` in the Google Doc. The
 activity-metadata schema already has the source fields:
 `activity-materials-student`, `activity-materials-pair`,
 `activity-materials-group`, `activity-materials-class`, and
-`activity-metadata-teacher`.
+`activity-materials-teacher`.
 
 **Decision required**: should the LCMS aggregate those activity-level
 fields into a per-lesson Materials table, rendering it automatically? If
@@ -438,9 +444,17 @@ The default body font (Lexend) is not a Chromium built-in. Choose one:
   needs network at PDF-render time and may not coexist with
   `ENABLE_BASE64_CACHING`.
 
-Same question applies to the allowlisted alternates (Arial, Nunito, Roboto,
-Tahoma, Verdana) — Arial/Tahoma/Verdana are typically system fonts and may
-not be present in the Chromium PDF environment.
+Same question applies to the allowlisted alternates — system fonts may not be
+present in the Chromium PDF environment.
+
+**Resolved (2026-06-23): Google Fonts CDN.** Keep the existing
+`@import url("https://fonts.googleapis.com/css2?family=Lexend…")` in
+`pdf.scss` / `pdf_plain.scss`. Trade-off accepted: PDF rendering needs network
+access at render time. The approved client allowlist is **Lexend, Arial,
+Calibri, Helvetica, Verdana** (note: supersedes the earlier
+"Arial, Nunito, Roboto, Tahoma, Verdana" wording); the body fallback stack in
+`app/assets/stylesheets/_tokens.scss` is
+`"Lexend", Arial, Calibri, Helvetica, Verdana, sans-serif`.
 
 ### Q6. Scope of the source-doc CSS normalization pass
 The spec requires that exports **override** color and size from source docs,
@@ -478,6 +492,15 @@ specifications:
 For each unspecified tag: need a visual design or "use sensible default and
 review later" sign-off.
 
+### Q7b. Authored table rendering limitations
+The styling spec does not cover how author-drawn content tables survive the
+sanitization/rendering pipeline. The known constraints (text color stripped,
+`<th>` inline styles dropped, no house table styling, pinned-header repetition
+not guaranteed, etc.) are documented separately in
+[table-rendering-limitations.md](table-rendering-limitations.md). Decide which,
+if any, need a fix (text-color preservation and a default table house style are
+the highest-impact).
+
 ### Q8. Initiative-level scoping
 The spec text mixes engineering work with non-engineering items
 (cost model, IP ownership in the "To Discuss" section). For the engineering
@@ -494,8 +517,19 @@ and shipped independently:
 
 Confirm whether to ship as a single PR or split per above.
 
+**Resolved (2026-06-23): single PR.** All styling work lands on branch
+`76-styling-lessons-materials`; do not split into separate PRs.
+
 ### Q9. `config/pdf.yml` `handout` profile
 The spec mandates 0.5" margins as the default. The current `handout` profile
 in `config/pdf.yml` uses 1.25" margins, which contradicts the spec. Is the
 `handout` profile being retired, kept as a customization escape hatch, or
 should it be updated to the new defaults?
+
+**Resolved (2026-06-23):**
+- The `default` profile right margin was a defect (1in while the other three
+  sides were 0.5in); corrected to **0.5in** all sides (no gutter).
+- The `handout` profile is **left as-is** for now. The whole `config/pdf.yml`
+  is slated to migrate from YAML to **DB settings** in a separate branch;
+  `handout`'s fate (retire / keep / update) is deferred to that migration.
+  Keep margin values correct in YAML meanwhile — they carry into the DB move.

--- a/docs/core/styling-defaults-needs-clarification.md
+++ b/docs/core/styling-defaults-needs-clarification.md
@@ -141,8 +141,10 @@ Decisions captured from user Q&A on 2026-05-27:
 - **Slice 1 — Lesson header banner.** New Settings setting for brandmark;
   new `estimated-time` and `vocabulary` fields parsed off lesson-metadata;
   rewrite `_header.html.erb` (PDF + Gdoc) to emit the
-  brandmark+lesson-type+estimated-time strip → `<hr>` → `<h1>` → bare
-  comma standards. New SCSS for the banner.
+  brandmark+unit-title+lesson-type+estimated-time strip → `<hr>` → `<h1>` →
+  bare comma standards. New SCSS for the banner. The `<h1>` is
+  `DocumentPresenter#banner_title` — the lesson title prefixed with its number
+  ("Lesson 5: …"); the Gdoc running header's `{title}` stays unprefixed.
 - **Slice 2 — Standards header rendering.** Bare comma list (no
   "Standards:" prefix, no dropdown). Splits cleanly from slice 1 only if
   we want to ship the banner first.
@@ -173,28 +175,49 @@ rewritten to the R2 layout:
 
 ```
 © <copyright_text>
+<cc-attribution>                                             (only if authored)
 ─────────────────────────────────
-<Grade N/Course • Unit Title • Lesson N>          <page#>   (bold)
+<Course • Lesson N>                               <page#>   (bold)
 ```
 
 - **`copyright_text`** is a new free-form `Setting` (Documents group) —
-  authors type the full line, e.g. `© Acme Corp, Spring 2026`.
-- **Breadcrumb** is computed by `DocumentPresenter#footer_breadcrumb`:
-  `Grade {N}/Course • {unit title} • Lesson {N}`. Unit title comes from
-  `document.resource.ancestors.find(&:unit?).title`, falling back to
-  `Unit {unit_id}` if the resource graph isn't populated.
+  authors type the full line, e.g. `© Acme Corp, Spring 2026`. The unit
+  version is appended when unit-metadata carries one.
+- **cc-attribution** is the per-lesson licence line from lesson-metadata
+  (`DocumentPresenter#footer_attribution`), rendered only when a lesson
+  authors one — distinct from the site-wide copyright boilerplate.
+- **Breadcrumb** is `DocumentPresenter#footer_course_lesson`:
+  `{course} • Lesson {N}`, with the course from unit-metadata. It leads with
+  the COURSE, not the unit title: a unit created implicitly by the lesson
+  import has no authored unit title, and the old fallback chain printed the
+  importer's generated resource label (e.g. `Science G10 gg`) into every
+  exported footer. Blank parts drop out of the join, so a lesson whose unit
+  has no metadata at all degrades to a bare `Lesson 7` rather than inventing
+  a placeholder.
 - **PDF**: a new `pdf_plain.scss` (previously empty) provides Lexend +
   the footer block styles. Grover renders the footer template via a
   separate Chromium document, so styles must live there, not in
   `pdf.scss`.
 - **Gdoc**: `DocumentPresenter#gdoc_footer` and `#gdoc_header` now carry
   the full R2 payload. Each returns **two parallel arrays** —
-  `[patterns, values]`: footer `["{copyright}", "{course}", "{unit_lesson}"]`,
-  header `["{title}", "{lesson_type}", "{estimated_time}"]`. The post-
+  `[patterns, values]`: footer
+  `["{copyright}", "{attribution}", "{course}", "{unit_lesson}"]` — where
+  `{course}` is now blanked and `{unit_lesson}` carries `Course • Lesson N`
+  (both placeholder NAMES kept as-is so the existing Drive template keeps
+  substituting; renaming would strand the old literal text in every footer) —
+  header `["{title}", "{unit_title}", "{lesson_type}", "{estimated_time}"]`. The post-
   processing Apps Script (`config/scripts/Code.gs#postProcessing`) copies the
   Drive template doc's header/footer, then loops
   `replaceText(patterns[i], values[i])` — so the matching placeholders must
   exist in the **template** header/footer for substitution to happen.
+
+  Two template placeholders are handled OUTSIDE that substitution pass,
+  because neither is text: `{brandmark_url}` becomes an inline image
+  (`insertHeaderBrandmark`) and `{page_number}` becomes a live PageNumber
+  element (`insertFooterPageNumber`). Routing either through `replaceText`
+  would only ever write a static string — in the page number's case, the same
+  number on every page. Both run after the header/footer copy, and both no-op
+  when their placeholder is absent from the template.
 
   **Earlier "hang" — corrected root cause.** A prior attempt was recorded
   here as the Apps Script "choking on extra rows / expecting the original
@@ -209,13 +232,15 @@ rewritten to the R2 layout:
   `Retriable.retriable(base_interval: 5, tries: 10)`.
 
   **Status**: with the correct `[patterns, values]` shape plus matching
-  Drive-template placeholders, the Gdoc header (title / lesson type /
-  estimated time) and footer (copyright / course / unit • lesson) substitute
-  correctly. Logo/type/time were also removed from the Gdoc **body** banner
-  (`documents/gdoc/_header.html.erb`) to avoid duplicating the running header;
-  the PDF banner keeps them (no running header there). Remaining manual
-  template steps: insert the brandmark image in the header and add the footer
-  placeholders to the Drive template.
+  Drive-template placeholders, the Gdoc header (title / unit title / lesson
+  type / estimated time) and footer (copyright / course / unit • lesson)
+  substitute correctly. Logo/type/time were also removed from the Gdoc **body**
+  banner (`documents/gdoc/_header.html.erb`) to avoid duplicating the running
+  header; the PDF banner keeps them (no running header there) and shows the
+  same four lines. Remaining manual template steps: insert the brandmark image
+  in the header, add `{unit_title}` to the template header (a missing
+  placeholder is a harmless no-op — the line simply doesn't appear), and add
+  the footer placeholders to the Drive template.
 
 A new `_text.html.erb` partial under `app/views/admin/settings/show/`
 backs the new `:text` Settings field type so admins can edit

--- a/docs/core/table-rendering-limitations.md
+++ b/docs/core/table-rendering-limitations.md
@@ -1,0 +1,133 @@
+# Authored Table Rendering — Known Limitations
+
+How author-authored content tables (the tables an author draws inside a Google
+Doc lesson/material, *not* the metadata tables like `material-metadata`) are
+processed before they reach the PDF and Gdoc outputs, and what is lost along
+the way.
+
+The pipeline: Google Doc HTML → `HtmlSanitizer` (allow-list of elements,
+attributes, and CSS properties + a few transformers) → per-context
+post-processing → rendered by `pdf.scss` / `gdoc.scss`. A style survives only
+if it is on an allowed element, is an allowed attribute, is an allowed CSS
+property, and is not overridden by an `!important` app rule.
+
+Verified against the code on branch `76-styling-lessons-materials`
+(2026-06-26). See [styling-defaults-needs-clarification.md](styling-defaults-needs-clarification.md)
+Q7 for related open tag-styling questions.
+
+**Status (2026-06-26):** L1, L2, L3, and L4 have been addressed for material
+content (each section below notes the fix). L5 and L6 remain open.
+
+## Limitations
+
+### L1. Authored text color is stripped
+Cell text keeps no authored color — colored text (e.g. red numbers) renders in
+the default near-black body color. Two layers remove it:
+
+- `color` is **not** in the sanitizer's allowed CSS `properties` list
+  (`app/services/html_sanitizer.rb:128-130`), so every `color:` declaration is
+  dropped. `remove_meanless_styles` additionally strips `color:#000000`
+  explicitly (`html_sanitizer.rb:169`).
+- `pdf.scss` / `gdoc.scss` then force `td, th { color: $color-text !important }`
+  (`app/assets/stylesheets/pdf.scss:36-41`), which would override any inline
+  color even if it survived the sanitizer.
+
+**Impact:** authored emphasis-by-color in tables is lost. (Background
+*highlight* is intentionally stripped per spec; text color is a separate case
+and currently shares the same fate.)
+
+**Addressed (materials, 2026-06-26):** `color` is now an allowed CSS property
+(`html_sanitizer.rb`), and `pdf.scss` no longer force-sets `color !important`
+globally — the brand-color enforcement is re-scoped to the lesson wrapper
+`[class*="o-page--cg-"]`. Material content (`.o-m-content`, which has no lesson
+wrapper) therefore keeps authored text color, while lessons stay normalized.
+Gdoc material color rides on the now-preserved inline style into the Google Doc
+import (the gdoc stylesheet is unchanged). Caveat: lesson content rendered
+without the `o-page--cg-` wrapper (e.g. some bundle paths) would no longer be
+force-normalized — verify if those paths matter.
+
+### L2. `<th>` header cells lose all inline styling; `<td>` does not
+The sanitizer attribute allow-list (`html_sanitizer.rb:119-120`) permits
+`style` on `td` (`colspan rowspan style`) but **not** on `th`
+(`colspan rowspan` only). So a header cell authored as `<th>` drops its
+background, borders, alignment, width, and height, while the identical content
+in a `<td>` keeps them.
+
+**Impact:** header-row styling is reliable only when Google Docs exports the
+cells as `<td>`. A real `<th>` header flattens.
+
+**Addressed (2026-06-26):** `style` was added to the `th` attribute allow-list
+(`html_sanitizer.rb`), so header cells now keep their inline
+background/border/alignment like `td`. Global change (lessons benefit too).
+
+### L3. Content tables have no house styling
+The sanitizer tags content tables `.c-ld-table` (and adds
+`o-native-table` / `u-table-padding` in the Gdoc context), but **none of those
+classes have any SCSS** — confirmed no rules in `pdf.scss`, `gdoc.scss`, or
+`pdf_plain.scss`. See `post_processing_tables` / `post_processing_tables_gdoc`
+(`html_sanitizer.rb:357-368`).
+
+**Impact:** an arbitrary content table gets borders, cell padding, and header
+background **only** from authored inline styles. There is no fallback border,
+no default cell padding, and no wide-table overflow handling.
+
+**Addressed (materials, 2026-06-26):** `pdf.scss` now gives
+`.o-m-content .c-ld-table` a baseline border + cell padding. Every declaration
+is non-`!important`, so authored inline borders/padding/alignment still win;
+only un-styled tables fall back to the house default. (Still no wide-table
+overflow handling — see L5.)
+
+### L4. Pinned header row is not guaranteed to repeat across page breaks
+There is no `thead { display: table-header-group }` rule and no logic that
+promotes the first row to a repeating header. Repetition depends entirely on
+Google Docs exporting a real `<thead>` and Chromium's (Grover's) default
+behavior. A header authored as a plain `<tr>` will not reappear at the top of a
+continued page.
+
+**Impact:** "pinned header row" tables that span a page break may show the
+header only on the first page.
+
+**Addressed (materials, 2026-06-26):** `pdf.scss` adds
+`.o-m-content thead { display: table-header-group }`, which makes Chromium/Grover
+repeat the header on each page. Caveat: this only helps when Google Docs exports
+the pinned row inside a `<thead>`; a header authored as a plain `<tr>` would
+still need post-processing promotion (not done).
+
+### L5. Material/handout tables skip the table wrapper
+`post_processing_tables` wraps tables in `.c-ld-table__wrap`
+**`unless @options[:material]`** (`html_sanitizer.rb:357-362`), so material
+(handout) tables never receive the wrapper.
+
+**Impact:** harmless today because `.c-ld-table__wrap` is unstyled (L3), but any
+future wrapper-based fix (e.g. overflow/scroll for wide tables) will not reach
+materials unless this is revisited.
+
+### L6. Border zero-width normalization skips `th` and `thead`
+`replace_table_border_styles` only iterates `tbody/tr/td`
+(`html_sanitizer.rb:387+`) when collapsing authored zero-width borders to
+`border-*:0`. Borders on `th` cells or rows directly under `thead` are not
+normalized.
+
+**Impact:** minor; inconsistent border cleanup between body and header cells.
+Now slightly more reachable since L2 lets `th` carry inline borders — a
+zero-width border on a header cell won't be normalized. Still low priority.
+
+## What is preserved (works today)
+
+- **Merged cells** — `colspan` / `rowspan` are kept on both `td` and `th`.
+- **Borders** — `border-bottom/left/right/top` (width, color, style) are
+  allowed CSS properties, so a custom or colored cell border survives on `<td>`.
+- **Cell background** — `background-color` is allowed, so a gray header
+  background survives on `<td>`.
+- **Text alignment** — `text-align` is an allowed property and the
+  `[table-preserve-alignment]` tag also promotes inline alignment to classes.
+- **Row height / cell width / vertical-align** — allowed properties.
+- **Inline italics / bold** — `font-style` / `font-weight` are allowed.
+
+## Caveat: source vs. rendered output
+
+Several limitations (L1 especially, and the read on L4) only become visible in
+the **rendered** PDF/Gdoc, not in the authored Google Doc. A screenshot of the
+source doc will still show red text and native pinned headers; the loss happens
+during sanitization/rendering. Confirm behavior against an actual export, not
+the source document.

--- a/docs/unit-metadata-spec.md
+++ b/docs/unit-metadata-spec.md
@@ -13,6 +13,7 @@ This document defines the `unit-metadata` table expected in Google Docs sources.
 | `subject` | text | Required |
 | `grade` | number | Required |
 | `course` | text | Optional, can be blank |
+| `version` | text | Optional, can be blank; shown in the lesson footer (e.g., "v1.0") |
 | `unit-id` | unique alphanumeric id | Required |
 | `unit-title` | text | Required |
 | `unit-title-Spanish` | text | Optional, can be blank |

--- a/lib/doc_template/document.rb
+++ b/lib/doc_template/document.rb
@@ -41,8 +41,17 @@ module DocTemplate
       self
     end
 
+    # Rendered HTML for this (sub)document.
+    #
+    # html_safe is marked HERE, at the point of production, rather than at each
+    # `<%= @tmpl[:content] %>` in the ~20 tag templates that consume it. Tag
+    # templates escape by default (BaseTag#parse_template), and this value is
+    # HTML by construction — serialized Nokogiri nodes whose source already
+    # passed HtmlSanitizer's allowlist in Template#parse. Marking it at the
+    # producer means adding a template or a nested-content field cannot
+    # accidentally double-escape the document body.
     def render
-      @nodes.to_html
+      @nodes.to_html.html_safe # rubocop:disable Rails/OutputSafety
     end
 
     private

--- a/lib/doc_template/objects/activity.rb
+++ b/lib/doc_template/objects/activity.rb
@@ -21,7 +21,7 @@ module DocTemplate
         attribute :activity_materials_pair, :string
         attribute :activity_materials_group, :string
         attribute :activity_materials_class, :string
-        attribute :activity_metadata_teacher, :string
+        attribute :activity_materials_teacher, :string
         attribute :activity_standard, :string
         attribute :activity_mathematical_practice, :string
         attribute :activity_metacognition, :string

--- a/lib/doc_template/objects/activity.rb
+++ b/lib/doc_template/objects/activity.rb
@@ -92,6 +92,16 @@ module DocTemplate
       end
 
       def self.apply_defaults(data)
+        # Legacy key. Teacher materials were authored as `activity-metadata-teacher`
+        # before the field was renamed to `activity-materials-teacher`
+        # (DocTemplate::Tables::Activity::MATERIALS_KEYS). Stored activity_metadata
+        # is never rewritten, so every document parsed before the rename still
+        # carries the old key — which Item#initialize would drop as unknown,
+        # silently emptying the activity "Materials:" line.
+        if data["activity_materials_teacher"].blank? && data["activity_metadata_teacher"].present?
+          data["activity_materials_teacher"] = data["activity_metadata_teacher"]
+        end
+
         # lms-title: if blank, use activity-title
         data["lms_title"] = data["activity_title"] if data["lms_title"].blank?
         data["lms_title_spanish"] = data["activity_title_spanish"] if data["lms_title_spanish"].blank?

--- a/lib/doc_template/objects/unit.rb
+++ b/lib/doc_template/objects/unit.rb
@@ -16,6 +16,7 @@ module DocTemplate
       attribute :unit_title_spanish, :string, default: ""
       attribute :unit_topic, :string, default: ""
       attribute :unit_topic_spanish, :string, default: ""
+      attribute :version, :string, default: ""
     end
   end
 end

--- a/lib/doc_template/tables/activity.rb
+++ b/lib/doc_template/tables/activity.rb
@@ -7,7 +7,7 @@ module DocTemplate
       HTML_VALUE_FIELDS = %w(activity-description).freeze
       MATERIALS_KEYS = %w(activity-materials-student activity-materials-pair
                           activity-materials-group activity-materials-class
-                          activity-metadata-teacher).freeze
+                          activity-materials-teacher).freeze
       GROUPING_OPTIONS = ["individual", "partners", "small group", "class"].freeze
       LMS_TYPE_OPTIONS = %w(assignment discussion assessment reference).freeze
       LMS_FIELDS = %w(lms-title lms-title-spanish lms-instructions

--- a/lib/doc_template/tables/activity.rb
+++ b/lib/doc_template/tables/activity.rb
@@ -5,9 +5,17 @@ module DocTemplate
     class Activity < Base
       HEADER_LABEL = "activity-metadata"
       HTML_VALUE_FIELDS = %w(activity-description).freeze
+      # Cells scanned for `[material: id]` tokens when collecting an activity's
+      # material_ids. `activity-metadata-teacher` is the pre-rename key: source
+      # docs still authored against it must keep contributing their teacher
+      # material ids, or a re-import silently drops those materials from the
+      # lesson's MaterialsContainer and from the unit bundle — even though the
+      # activity "Materials:" line still names them (DocTemplate::Objects::
+      # Activity.apply_defaults and DocumentPresenter::LEGACY_MATERIALS_KEYS
+      # carry the same fallback for the display paths).
       MATERIALS_KEYS = %w(activity-materials-student activity-materials-pair
                           activity-materials-group activity-materials-class
-                          activity-materials-teacher).freeze
+                          activity-materials-teacher activity-metadata-teacher).freeze
       GROUPING_OPTIONS = ["individual", "partners", "small group", "class"].freeze
       LMS_TYPE_OPTIONS = %w(assignment discussion assessment reference).freeze
       LMS_FIELDS = %w(lms-title lms-title-spanish lms-instructions

--- a/lib/doc_template/tables/lesson_prep.rb
+++ b/lib/doc_template/tables/lesson_prep.rb
@@ -4,7 +4,9 @@ module DocTemplate
   module Tables
     class LessonPrep < Base
       HEADER_LABEL = "lesson-prep"
-      HTML_VALUE_FIELDS = [].freeze # steep:ignore
+      # Directions carry rich formatting (sub-headings + nested lists) that the
+      # Lesson Preparation section renders verbatim, so capture them as HTML.
+      HTML_VALUE_FIELDS = %w(lesson-prep-directions).freeze
     end
   end
 end

--- a/lib/doc_template/tags/base_tag.rb
+++ b/lib/doc_template/tags/base_tag.rb
@@ -172,6 +172,63 @@ module DocTemplate
         node.replace replacement
       end
 
+      #
+      # Substitute only the tag markup inside `node`, leaving the element and
+      # the text around the tag intact. For inline tags this is what you want:
+      # `node` is the *enclosing* element (see DocTemplate::Document#parse_node,
+      # which hands a tag its `node.parent`), so #replace_tag would throw away
+      # the authored sentence the tag sits in. Inside a list that is worse than
+      # losing text: dropping the `<li>` leaves its `<ol>` one item short, while
+      # the next `<ol start="N">` chunk Google Docs emits still carries the
+      # original absolute number — so the visible numbering skips.
+      #
+      # Falls back to #replace_tag when the tag markup cannot be located in the
+      # element's HTML (e.g. an export mangled beyond FULL_TAG's reach).
+      #
+      def replace_tag_inline(node)
+        # Locate the tag across the element's TEXT nodes, never in its
+        # serialized HTML: inner_html also carries attribute values, so a
+        # bracketed literal in an attribute (e.g. <img alt="Figure [1]">)
+        # matches FULL_TAG first and the substitution lands there — corrupting
+        # the attribute and leaving the real tag behind for the parse loop to
+        # hit again. Matching the concatenated text mirrors how
+        # DocTemplate::Document#parse_node identifies the tag (`node.text`), and
+        # still spans a tag that a broken export split across several elements.
+        text_nodes = node.xpath(".//text()").to_a
+        match = DocTemplate::FULL_TAG.match(text_nodes.map(&:content).join)
+        return replace_tag(node) unless match
+
+        replacement = @opts&.[](:explicit_render) ? content.to_s : placeholder
+        splice_tag(text_nodes, match, replacement)
+        @result = node
+      end
+
+      #
+      # Rewrites the text nodes the tag covers: the first one keeps the text
+      # before the tag and receives the replacement markup; the rest lose the
+      # covered slice, keeping only whatever text follows the tag. Text either
+      # side is re-escaped, since only the replacement is markup.
+      #
+      def splice_tag(text_nodes, match, replacement)
+        cursor = 0
+        inserted = false
+
+        text_nodes.each do |text_node|
+          body = text_node.content
+          starts_at = cursor
+          cursor += body.length
+          # Untouched: entirely before the tag starts, or entirely after it ends.
+          next if cursor <= match.begin(0) || starts_at >= match.end(0)
+
+          prefix = body[0, [match.begin(0) - starts_at, 0].max].to_s
+          suffix = body[(match.end(0) - starts_at)..].to_s
+          html = "#{ERB::Util.html_escape(prefix)}#{inserted ? '' : replacement}#{ERB::Util.html_escape(suffix)}"
+          inserted = true
+
+          html.empty? ? text_node.remove : text_node.replace(Nokogiri::HTML.fragment(html))
+        end
+      end
+
       def tag_data
         {}
       end

--- a/lib/doc_template/tags/base_tag.rb
+++ b/lib/doc_template/tags/base_tag.rb
@@ -145,10 +145,33 @@ module DocTemplate
         parsed.render
       end
 
+      # Renders a tag template with `<%= %>` HTML-escaping ON by default.
+      #
+      # This used to be `ERB.new(template).result(binding)`. Plain ERB does no
+      # escaping — Rails' auto-escaping lives in ActionView's ERB handler, not
+      # in ERB itself — and HtmlSanitizer's allowlist pass runs only over the
+      # SOURCE Google Doc HTML (Template#parse), never over rendered template
+      # output. So every `<%= %>` here was a hole through which authored text
+      # reached stored, publicly served HTML verbatim: a caption of
+      # `x" onerror="alert(1)` closed an attribute and injected a live handler.
+      #
+      # Escaping by DEFAULT (rather than escaping at each tag's params) means a
+      # new template or a new field is safe unless someone opts out, and every
+      # opt-out is greppable as `raw` / `.html_safe`.
+      #
+      # escapefunc matters: Erubi's own default is CGI.escapeHTML, which is not
+      # html_safe-aware and would double-escape the values that are deliberately
+      # raw HTML (nested rendered content, style fragments). ActiveSupport's
+      # ERB::Util.html_escape passes an html_safe String through untouched.
+      ESCAPE_FUNC = "::ERB::Util.html_escape"
+
       def parse_template(context, template_name)
         @tmpl = context
         template = File.read template_path(template_name)
-        ERB.new(template).result(binding)
+        src = Erubi::Engine.new(template, escape: true, escapefunc: ESCAPE_FUNC).src
+        # to_s: template_path returns a Pathname, and Binding#eval wants a String
+        # filename. Passing it keeps backtraces pointing at the .erb, not at this line.
+        binding.eval(src, template_path(template_name).to_s) # rubocop:disable Security/Eval
       end
 
       def placeholder

--- a/lib/doc_template/tags/callout_tag.rb
+++ b/lib/doc_template/tags/callout_tag.rb
@@ -76,6 +76,8 @@ module DocTemplate
         rows.each_with_object({}) do |row, hash|
           row = row.to_h.symbolize_keys
           key = row[:type].to_s.strip.downcase
+          # Title is plain text; BaseTag#parse_template escapes it at render
+          # time (it reaches both element content and an `alt=""` attribute).
           hash[key] = { title: row[:title].to_s, image: row[:image] } if key.present?
         end
       end

--- a/lib/doc_template/tags/callout_tag.rb
+++ b/lib/doc_template/tags/callout_tag.rb
@@ -152,9 +152,17 @@ module DocTemplate
         html.gsub(/\[\s*#{Regexp.escape(self.class::TAG_NAME)}[^\]]*\]/i, "")
       end
 
+      # Template for the inline visual every callout now renders with.
+      #
+      # Keeps BaseTag#template_name's two behaviours, which a bare
+      # INLINE_TEMPLATES lookup dropped: a per-context override configured in
+      # config/lcms.yml (`tags.callout.templates.<context>`) still wins, and an
+      # unmapped context falls back to :default instead of handing nil to
+      # File.read — which raised TypeError and aborted the whole render.
       def inline_template_name
         context = @opts.fetch(:context_type, :default).to_s
-        INLINE_TEMPLATES[context.to_sym]
+        override = ::DocTemplate::Tags.config.dig(TAG_NAME, "templates", context)
+        override.presence || INLINE_TEMPLATES[context.to_sym] || INLINE_TEMPLATES[:default]
       end
 
       def previous_non_empty(node)

--- a/lib/doc_template/tags/callout_tag.rb
+++ b/lib/doc_template/tags/callout_tag.rb
@@ -18,15 +18,31 @@ module DocTemplate
       def parse_table(table)
         inline = inline_shape?(table)
         header, content = fetch_content(table, inline:)
+        # The keyword in `[callout: <type>]` selects the canonical type; nil
+        # when absent or not a client-configured callout type (see
+        # #configured_callout_types).
+        type = callout_type(table)
+        callout = configured_callout_types[type]
+        title = callout&.fetch(:title, nil)
         params = {
           content:,
           header:,
+          # Canonical type keyword and display title, present only for a
+          # recognized `[callout: <type>]`. The template renders the title
+          # (and a per-type icon) instead of the authored label.
+          type: (callout ? type : nil),
+          title:,
+          # Configured icon URL (or a gdoc-inlined data URI — see
+          # #callout_icon_url), nil when unconfigured/no upload: the
+          # template falls back to a plain "+" in that case.
+          image: callout_icon_url(callout&.fetch(:image, nil)),
           subject: @opts[:metadata].subject,
           # Tells the inline template whether the author supplied an
           # icon/label as authored HTML (1-row 2-col shape) or just a
           # plain category label (3-row shapes — renderer adds a default
-          # decoration).
-          authored_label: inline
+          # decoration). A canonical title supersedes the authored label,
+          # so this is only honored for untyped callouts.
+          authored_label: inline && title.nil?
         }
         # All callouts render with the inline horizontal visual per the
         # LCMS Core spec, regardless of how the author structured the
@@ -46,8 +62,54 @@ module DocTemplate
 
       private
 
+      # Client-configurable callout type => {title:, image:} map (see admin
+      # Settings > Documents > Callout Types, DocTemplate::Tags::CalloutTag's
+      # counterpart in FlatGroup). Ships with 4 default types (see
+      # Settings::DEFAULTS[:documents][:callout_types]) that resolve even
+      # before an operator ever opens the settings screen. Row hashes come
+      # back deep_symbolize_keys'd by Settings.merge_with_defaults, but are
+      # normalized defensively here in case a caller ever stubs Settings with
+      # string-keyed rows. Type is folded to a lowercase key to match
+      # #callout_type's marker parsing.
+      def configured_callout_types
+        rows = Settings.get(:documents, include_defaults: true)&.dig(:callout_types) || []
+        rows.each_with_object({}) do |row, hash|
+          row = row.to_h.symbolize_keys
+          key = row[:type].to_s.strip.downcase
+          hash[key] = { title: row[:title].to_s, image: row[:image] } if key.present?
+        end
+      end
+
+      # Resolves the icon URL for the current output context. Gdoc output is
+      # routed through Drive at import time, which drops external image
+      # references, so the icon is inlined as a data URI there — mirrors
+      # ContentPresenter#brandmark_url. PDF/default output (Grover/Chromium)
+      # fetches a plain URL fine.
+      def callout_icon_url(raw_url)
+        return nil if raw_url.blank?
+        return raw_url unless @opts.fetch(:context_type, :default).to_s == "gdoc"
+
+        AssetHelper.inline_data_uri(raw_url, cache: ViewHelper::ENABLE_BASE64_CACHING) || raw_url
+      end
+
       def inline_shape?(node)
-        node.xpath(".//tr").size == 1
+        direct_rows(node).size == 1
+      end
+
+      # Rows that belong directly to this callout table, excluding rows of any
+      # nested table in a body cell. Using `.//tr` here would count nested rows
+      # too and misclassify a 1-row/2-col callout whose body cell contains a
+      # table as the legacy 3-row shape.
+      def direct_rows(node)
+        node.xpath("./tr | ./tbody/tr | ./thead/tr | ./tfoot/tr")
+      end
+
+      # Extracts the keyword from the `[callout: <type>]` marker anywhere in
+      # the table, normalized to a lowercase key. nil when the marker has no
+      # argument (`[callout]`).
+      def callout_type(node)
+        marker = node.inner_html[/\[\s*#{Regexp.escape(self.class::TAG_NAME)}\s*:?\s*([^\]]*)\]/i, 1]
+        marker.to_s.strip.downcase.presence
       end
 
       def fetch_content(node, inline:)

--- a/lib/doc_template/tags/helpers.rb
+++ b/lib/doc_template/tags/helpers.rb
@@ -5,10 +5,62 @@ module DocTemplate
     module Helpers
       include ActionView::Helpers::TagHelper
 
+      # English cardinal words for the system-generated activity ordinal
+      # ("Activity One", "Activity Two", ...). The activity index is 1-based.
+      NUMBER_WORDS = %w(Zero One Two Three Four Five Six Seven Eight Nine Ten
+                        Eleven Twelve Thirteen Fourteen Fifteen Sixteen Seventeen
+                        Eighteen Nineteen Twenty).freeze
+
+      # Per-grouping material fields aggregated into the activity "Materials:"
+      # line. Mirrors the lesson-level Materials table (DocumentPresenter).
+      ACTIVITY_MATERIALS_FIELDS = %i(activity_materials_student activity_materials_pair
+                                     activity_materials_group activity_materials_class
+                                     activity_materials_teacher).freeze
+
       def materials_container(props)
         return if props.nil?
 
         content_tag(:div, nil, data: { react_class: "MaterialsContainer", react_props: props }) { _1 }
+      end
+
+      # English cardinal word for a 1-based number, e.g. 1 => "One". Falls back
+      # to the numeral past the lookup table; blank for nil.
+      def number_to_word(num)
+        return "" if num.blank?
+
+        NUMBER_WORDS[num.to_i] || num.to_s
+      end
+
+      # Compiles an activity's per-grouping material fields into a single
+      # de-duplicated, comma-joined string for the "Materials:" line.
+      def activity_materials_list(activity)
+        ACTIVITY_MATERIALS_FIELDS
+          .flat_map { |field| activity.public_send(field).to_s.split(",") }
+          .map(&:strip)
+          .reject(&:blank?)
+          .uniq
+          .join(", ")
+      end
+
+      # Converts a stored `student-grouping` value (e.g. "small group") into its
+      # client-configurable display label, using the Settings student_groupings
+      # map (see admin Settings > Documents). Unlike lesson_types, the map's
+      # keys are the fixed, validated GROUPING_OPTIONS vocabulary — no
+      # case-folding needed — so the lookup is by exact key, falling back to
+      # titleizing the raw value when it isn't configured (mirrors
+      # DocumentPresenter#lesson_type_label's fallback).
+      def student_grouping_label(value)
+        Settings.map_label(:student_groupings, value)
+      end
+
+      # Converts a stored `activity-type` value (e.g. "warm-up") into its
+      # client-configurable display label, using the Settings activity_types map
+      # (see admin Settings > Documents). Like lesson_types, the operator defines
+      # the abbr => label pairs, so the lookup is case-insensitive and falls back
+      # to titleizing the raw value when it isn't configured (mirrors
+      # DocumentPresenter#lesson_type_label).
+      def activity_type_label(value)
+        Settings.map_label(:activity_types, value)
       end
 
       def priority_description(activity)
@@ -19,23 +71,11 @@ module DocTemplate
         Array.wrap(config["priority_descriptions"])[priority - 1]
       end
 
-      # Replaces `[material: id]` tokens in plain text with the italicized
-      # identifier markup that MaterialTag emits inline. Used in the
-      # activity Materials line so authored tokens render the same as in
-      # the body. Unknown identifiers fall through to bare identifier text.
-      MATERIAL_TOKEN_RE = /\[material:\s*([^\]]+)\]/i
-
+      # Replaces `[material: id]` tokens in the activity Materials line with the
+      # same inline link markup MaterialTag emits, batch-loading the referenced
+      # materials in a single query. Unknown identifiers fall through to bare text.
       def resolve_material_tokens(text)
-        text.to_s.gsub(MATERIAL_TOKEN_RE) do
-          identifier = ::Regexp.last_match(1).to_s.strip
-          next identifier if identifier.blank?
-
-          if ::Material.exists?(identifier: identifier.downcase)
-            %(<a class="o-ld-material">#{identifier}</a>)
-          else
-            identifier
-          end
-        end
+        MaterialTokens.resolve(text)
       end
     end
   end

--- a/lib/doc_template/tags/helpers.rb
+++ b/lib/doc_template/tags/helpers.rb
@@ -33,9 +33,12 @@ module DocTemplate
 
       # Compiles an activity's per-grouping material fields into a single
       # de-duplicated, comma-joined string for the "Materials:" line.
+      # Splits on the same separators as Tables::Base#fetch_materials, which
+      # resolves `[material: id]` tokens from these very cells — a
+      # semicolon-separated cell would otherwise render as one run-on entry.
       def activity_materials_list(activity)
         ACTIVITY_MATERIALS_FIELDS
-          .flat_map { |field| activity.public_send(field).to_s.split(",") }
+          .flat_map { |field| activity.public_send(field).to_s.split(DocTemplate::Tables::Base::SPLIT_REGEX) }
           .map(&:strip)
           .reject(&:blank?)
           .uniq
@@ -74,8 +77,17 @@ module DocTemplate
       # Replaces `[material: id]` tokens in the activity Materials line with the
       # same inline link markup MaterialTag emits, batch-loading the referenced
       # materials in a single query. Unknown identifiers fall through to bare text.
+      #
+      # The source cells hold DECODED PLAIN TEXT (activity-materials-* is not in
+      # Tables::Activity::HTML_VALUE_FIELDS) but both activity templates emit the
+      # result with `raw`, so the authored text is escaped first — otherwise an
+      # entry like "Beaker <250 ml>" is parsed as a tag and silently disappears
+      # from the rendered line. `[material: id]` tokens survive escaping
+      # untouched, so resolution still works. Mirrors
+      # DocumentPresenter#materials_summary, which escapes the same values for
+      # the lesson-level Materials table.
       def resolve_material_tokens(text)
-        MaterialTokens.resolve(text)
+        MaterialTokens.resolve(ERB::Util.html_escape(text))
       end
     end
   end

--- a/lib/doc_template/tags/image_tag.rb
+++ b/lib/doc_template/tags/image_tag.rb
@@ -7,10 +7,25 @@ module DocTemplate
       TEMPLATES = { default: "image.html.erb",
                     gdoc: "gdoc/image.html.erb" }.freeze
 
+      # Authored as `[image: <id> align=<a> size=<s>]`. Alignment drives text
+      # wrapping (only `left`/`right` float and wrap); size maps to a width
+      # preset in the stylesheet. Unrecognized values fall back to defaults.
+      ALIGNMENTS = %w(center left right).freeze
+      SIZES = %w(small medium large).freeze
+      DEFAULT_ALIGNMENT = "center"
+      DEFAULT_SIZE = "large"
+
       def parse_table(table)
+        id, align, size = parse_args(@opts[:value])
+        # Per spec, captions and credits appear only on centered images;
+        # left/right images wrap surrounding text and show neither.
+        show_meta = align == "center"
         params = {
-          caption: table.at_xpath(".//tr[2]/td").text,
-          image_src:,
+          image_src: image_src(id),
+          align:,
+          size:,
+          caption: (show_meta ? cell_text(table, 2) : ""),
+          credit: (show_meta ? cell_text(table, 3) : ""),
           subject: @opts[:metadata].try(:[], "subject")
         }
         @content = parse_template(params, template_name(@opts))
@@ -19,8 +34,36 @@ module DocTemplate
 
       private
 
-      def image_src
-        filename = "#{@opts[:value]}.jpg"
+      # Splits the tag value "<id> align=<a> size=<s>" into [id, align, size],
+      # applying defaults and ignoring unrecognized keys/values. Only `align=`
+      # and `size=` tokens are treated as options; every other token is part of
+      # the id and rejoined with spaces, so a legacy id that contains spaces
+      # (e.g. "[image: some id]") still resolves to the original filename rather
+      # than being truncated at the first space.
+      def parse_args(value)
+        opts = {}
+        id_tokens = value.to_s.strip.split(/\s+/).reject do |token|
+          key, val = token.split("=", 2)
+          next false if val.nil?
+
+          key = key.downcase
+          next false unless %w(align size).include?(key)
+
+          opts[key] = val.downcase
+          true
+        end
+        id = id_tokens.join(" ")
+        align = ALIGNMENTS.include?(opts["align"]) ? opts["align"] : DEFAULT_ALIGNMENT
+        size = SIZES.include?(opts["size"]) ? opts["size"] : DEFAULT_SIZE
+        [id, align, size]
+      end
+
+      def cell_text(table, row)
+        table.at_xpath(".//tr[#{row}]/td").try(:text).to_s
+      end
+
+      def image_src(id)
+        filename = "#{id}.jpg"
         grade = @opts[:metadata]["grade"]
         unit = @opts[:metadata]["unit"]
         "https://unbounded-uploads-development.s3.amazonaws.com/ela-images/G#{grade}/#{unit}/#{filename}"

--- a/lib/doc_template/tags/image_tag.rb
+++ b/lib/doc_template/tags/image_tag.rb
@@ -20,11 +20,18 @@ module DocTemplate
         # Per spec, captions and credits appear only on centered images;
         # left/right images wrap surrounding text and show neither.
         show_meta = align == "center"
+        caption = cell_text(table, 2)
         params = {
           image_src: image_src(id),
           align:,
           size:,
-          caption: (show_meta ? cell_text(table, 2) : ""),
+          # The authored caption doubles as alt text and is emitted for EVERY
+          # alignment, unlike the visible caption below: a left/right image is
+          # still an image a screen reader has to describe, and this is the only
+          # description the author gives us. Matters for the prince_pdf plugin,
+          # which targets PDF/UA-1.
+          alt: caption,
+          caption: (show_meta ? caption : ""),
           credit: (show_meta ? cell_text(table, 3) : ""),
           subject: @opts[:metadata].try(:[], "subject")
         }
@@ -58,6 +65,11 @@ module DocTemplate
         [id, align, size]
       end
 
+      # Author-supplied TEXT from the tag table (`.text`, so entities are already
+      # decoded and a caption may legitimately contain a quote or an angle
+      # bracket). Deliberately not escaped here: BaseTag#parse_template escapes
+      # every `<%= %>` by default, so escaping again would be a second, silent
+      # authority on the same value.
       def cell_text(table, row)
         table.at_xpath(".//tr[#{row}]/td").try(:text).to_s
       end

--- a/lib/doc_template/tags/material_tag.rb
+++ b/lib/doc_template/tags/material_tag.rb
@@ -2,6 +2,11 @@
 
 module DocTemplate
   module Tags
+    # `[material: id]` is an inline reference: it is authored mid-sentence
+    # ("provide students with copies of [material: …]."), so only the tag markup
+    # is substituted — the surrounding text and its element stay put. Same
+    # treatment DefTag and StandardTag give their inline tags, and the same
+    # markup MaterialTokens emits for the identical reference in metadata text.
     class MaterialTag < BaseTag
       TAG_NAME = "material"
 
@@ -17,7 +22,7 @@ module DocTemplate
             %(<span class="badge text-bg-danger">Unknown material: #{identifier}</span>)
           end
 
-        replace_tag node
+        replace_tag_inline node
         self
       end
     end

--- a/lib/doc_template/tags/material_tag.rb
+++ b/lib/doc_template/tags/material_tag.rb
@@ -12,8 +12,7 @@ module DocTemplate
 
         @content =
           if material
-            %(<a href="/materials/#{material.id}" class="o-ld-material" target="_blank" rel="noopener">) \
-              "#{identifier}</a>"
+            MaterialTokens.label_for(material, identifier)
           else
             %(<span class="badge text-bg-danger">Unknown material: #{identifier}</span>)
           end

--- a/lib/doc_template/tags/material_tokens.rb
+++ b/lib/doc_template/tags/material_tokens.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module DocTemplate
+  module Tags
+    # Shared resolution of `[material: id]` tokens found in raw metadata text
+    # (lesson Materials summary, activity Materials line). Emits the same inline
+    # markup as MaterialTag so a reference renders identically wherever it
+    # appears. Unknown identifiers fall through to bare identifier text.
+    module MaterialTokens
+      MATERIAL_TOKEN_RE = /\[material:\s*([^\]]+)\]/i
+
+      module_function
+
+      # Downcased identifiers referenced by every `[material: id]` token in text.
+      def identifiers_in(text)
+        text.to_s.scan(MATERIAL_TOKEN_RE).flatten.map { |id| id.to_s.strip.downcase }.reject(&:blank?)
+      end
+
+      # Loads the referenced materials keyed by identifier, so token resolution
+      # does not issue a query per token. Resolved identifiers (hits AND misses)
+      # are memoized per request/job in Current, so a lesson whose N activities
+      # each resolve their own Materials line reuses one cache instead of firing
+      # one query per activity (the former N+1). Only identifiers not already
+      # cached hit the database.
+      #
+      # @return [Hash{String => Material}] downcased identifier => material
+      #   (misses omitted, matching the previous return shape).
+      def lookup(identifiers)
+        ids = Array(identifiers).map { |id| id.to_s.downcase }.reject(&:blank?).uniq
+        return {} if ids.empty?
+
+        cache = (Current.material_tokens ||= {})
+        missing = ids.reject { |id| cache.key?(id) }
+        if missing.any?
+          found = ::Material.where(identifier: missing).index_by(&:identifier)
+          missing.each { |id| cache[id] = found[id] } # nil for a miss, so it is not re-queried
+        end
+
+        ids.each_with_object({}) { |id, result| (m = cache[id]) && result[id] = m }
+      end
+
+      # Replaces `[material: id]` tokens with MaterialTag-style links. Pass a
+      # preloaded `known` map (from .lookup) to resolve many strings against a
+      # single query; when omitted, the tokens in `text` are batched-loaded once.
+      def resolve(text, known: nil)
+        str = text.to_s
+        known ||= lookup(identifiers_in(str))
+        str.gsub(MATERIAL_TOKEN_RE) do
+          identifier = ::Regexp.last_match(1).to_s.strip
+          next identifier if identifier.blank?
+
+          material = known[identifier.downcase]
+          material ? label_for(material, identifier) : identifier
+        end
+      end
+
+      # Inline markup for a resolved material, shared with MaterialTag. A
+      # reference is plain (italicized) text, not a link: a material is only
+      # navigable from a unit bundle, where the material sits alongside the
+      # lesson as its own file, so a per-instance /materials/:id URL would be
+      # wrong in every context this markup actually renders in (preview, PDF,
+      # Google Doc). The visible text is the material's authored title (e.g.
+      # "Lesson 7 Slides"), falling back to the identifier when the material has
+      # no title. The label is HTML-escaped since a title is authored text.
+      def label_for(material, identifier)
+        label = title_for(material).presence || identifier.downcase
+        %(<span class="o-ld-material">#{ERB::Util.html_escape(label)}</span>)
+      end
+
+      # The material's authored title from its metadata (same derivation as
+      # MaterialPresenter#title), or "" when it defines none.
+      def title_for(material)
+        DocTemplate::Objects::Material.build_from(material.metadata).material_title.to_s
+      end
+    end
+  end
+end

--- a/lib/doc_template/templates/activity.html.erb
+++ b/lib/doc_template/templates/activity.html.erb
@@ -1,14 +1,8 @@
 <%
   activity = @tmpl[:activity]
-  type_label = activity.activity_type.to_s.strip
-  group_label = activity.student_grouping.to_s.strip
-  materials_list = [
-    activity.activity_materials,
-    activity.activity_materials_student,
-    activity.activity_materials_pair,
-    activity.activity_materials_group,
-    activity.activity_materials_class
-  ].compact.map(&:to_s).reject(&:blank?).join(", ")
+  type_label = activity_type_label(activity.activity_type)
+  group_label = student_grouping_label(activity.student_grouping)
+  materials_list = activity_materials_list(activity)
 %>
 <div class="o-ld-activity"
   id="<%= activity.anchor %>"
@@ -16,24 +10,26 @@
   data-tag="<%= @tmpl[:placeholder] %>"
   <%= "data-optional" if activity.optional %>>
 
-  <hr class="o-ld-activity__divider">
-
   <% if activity.alert.present? %>
     <p class="o-ld-activity__alert"><%= activity.alert %></p>
   <% end %>
 
   <h3 class="o-ld-activity__heading">
-    <%= "Optional: " if activity.optional %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %>
+    <% if activity.idx.present? %>Activity <%= number_to_word(activity.idx) %>: <% end %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %><% if activity.activity_label.present? %> <%= activity.activity_label.upcase %><% end %><% if activity.activity_priority.to_i.positive? %><% priority_id = "o-ld-p_#{SecureRandom.hex(4)}" %> <span class="o-ld-icon__wrapper" data-toggle="<%= priority_id %>"><span class="o-ld-icon o-ld-icon--base o-ld-icon--priority<%= activity.activity_priority %>"></span></span><span class="dropdown-pane o-ld-dropdown bottom" data-dropdown data-hover="true" data-hover-delay="0" data-hover-pane="true" data-v-offset="8" id="<%= priority_id %>"><%= @tmpl[:priority_description] %></span><% end %>
   </h3>
 
   <% if type_label.present? || group_label.present? %>
     <p class="o-ld-activity__meta">
-      <%= type_label %><% if type_label.present? && group_label.present? %> <% end %><% if group_label.present? %>(<%= group_label %>)<% end %>
+      <% if type_label.present? %><strong><%= type_label %></strong><% end %><% if type_label.present? && group_label.present? %> <% end %><% if group_label.present? %>(<%= group_label %>)<% end %>
     </p>
   <% end %>
 
   <% if materials_list.present? %>
     <p class="o-ld-activity__materials">Materials: <%= raw resolve_material_tokens(materials_list) %></p>
+  <% end %>
+
+  <% if activity.activity_description.present? %>
+    <div class="o-ld-activity__description"><%= raw activity.activity_description %></div>
   <% end %>
 
   <% if activity.activity_metacognition.present? %>

--- a/lib/doc_template/templates/activity.html.erb
+++ b/lib/doc_template/templates/activity.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 
   <h3 class="o-ld-activity__heading">
-    <% if activity.idx.present? %>Activity <%= number_to_word(activity.idx) %>: <% end %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %><% if activity.activity_label.present? %> <%= activity.activity_label.upcase %><% end %><% if activity.activity_priority.to_i.positive? %><% priority_id = "o-ld-p_#{SecureRandom.hex(4)}" %> <span class="o-ld-icon__wrapper" data-toggle="<%= priority_id %>"><span class="o-ld-icon o-ld-icon--base o-ld-icon--priority<%= activity.activity_priority %>"></span></span><span class="dropdown-pane o-ld-dropdown bottom" data-dropdown data-hover="true" data-hover-delay="0" data-hover-pane="true" data-v-offset="8" id="<%= priority_id %>"><%= @tmpl[:priority_description] %></span><% end %>
+    <% if activity.idx.present? %>Activity <%= activity.idx %>: <% end %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %><% if activity.activity_label.present? %> <%= activity.activity_label.upcase %><% end %><% if activity.activity_priority.to_i.positive? %><% priority_id = "o-ld-p_#{SecureRandom.hex(4)}" %> <span class="o-ld-icon__wrapper" data-toggle="<%= priority_id %>"><span class="o-ld-icon o-ld-icon--base o-ld-icon--priority<%= activity.activity_priority %>"></span></span><span class="dropdown-pane o-ld-dropdown bottom" data-dropdown data-hover="true" data-hover-delay="0" data-hover-pane="true" data-v-offset="8" id="<%= priority_id %>"><%= @tmpl[:priority_description] %></span><% end %>
   </h3>
 
   <% if type_label.present? || group_label.present? %>

--- a/lib/doc_template/templates/callout_inline.html.erb
+++ b/lib/doc_template/templates/callout_inline.html.erb
@@ -1,8 +1,17 @@
-<div class="o-ld-callout o-ld-callout--inline o-ld-callout--<%= @tmpl[:subject] %>">
+<div class="o-ld-callout o-ld-callout--inline o-ld-callout--<%= @tmpl[:subject] %><%= " o-ld-callout--#{@tmpl[:type]}" if @tmpl[:type] %>">
   <table class="o-ld-callout__layout">
     <tr>
       <td class="o-ld-callout__label">
-        <% if @tmpl[:authored_label] %>
+        <% if @tmpl[:title].present? %>
+          <div class="o-ld-callout__icon o-ld-callout__icon--<%= @tmpl[:type] %>">
+            <% if @tmpl[:image].present? %>
+              <img class="o-ld-callout__icon-img" src="<%= @tmpl[:image] %>" alt="<%= @tmpl[:title] %>">
+            <% else %>
+              +
+            <% end %>
+          </div>
+          <div class="o-ld-callout__type"><%= @tmpl[:title] %></div>
+        <% elsif @tmpl[:authored_label] %>
           <%= @tmpl[:header].html_safe %>
         <% else %>
           <div class="o-ld-callout__icon">+</div>

--- a/lib/doc_template/templates/columns.html.erb
+++ b/lib/doc_template/templates/columns.html.erb
@@ -4,7 +4,14 @@
       <% @tmpl[:rows].each do |row| %>
         <tr>
           <% row.each do |cell| %>
-            <td class="<%= cell[:css_class] %>"><%= cell[:content] %></td>
+            <%# html_safe: cell[:content] is rendered cell HTML — it carries <img>
+                tags reinstated by ColumnsTag#substitute_images and nested parsed
+                tags from #substitute_tags, so it must not be escaped. It comes
+                from source markup that already passed HtmlSanitizer's allowlist.
+                (.html_safe rather than `raw`: `raw` comes from Tags::Helpers,
+                which ColumnsTag does not include.) css_class is a computed
+                literal and stays escaped. %>
+            <td class="<%= cell[:css_class] %>"><%= cell[:content].to_s.html_safe %></td>
           <% end %>
         </tr>
       <% end %>

--- a/lib/doc_template/templates/def.html.erb
+++ b/lib/doc_template/templates/def.html.erb
@@ -1,5 +1,11 @@
+<%# html_safe on prepend/append/preserved_style: DefTag splits the tag's own
+    node.inner_html around the [def: ...] marker, so these are RAW HTML
+    FRAGMENTS of the surrounding markup (often an unbalanced "<span>" /
+    "</span>" pair that only closes once both are emitted), not text.
+    preserved_style is likewise a bare attribute fragment (style="...").
+    definition/description stay escaped — they come from the tag's text value. %>
 <% if @tmpl[:prepend] %>
-  <span><%= @tmpl[:prepend] %></span>
+  <span><%= @tmpl[:prepend].to_s.html_safe %></span>
 <% end %>
 <% id = "cg-k_#{SecureRandom.hex(4)}" %>
 <span class="c-ld-keyword c-ld-keyword--<%= @tmpl[:subject] %>" data-toggle="<%= id %>"><%= @tmpl[:definition] %></span>
@@ -15,5 +21,5 @@
   </span>
 <% end %>
 <% if @tmpl[:append] %>
-  <span <%= @tmpl[:preserved_style] %>><%= @tmpl[:append] %></span>
+  <span <%= @tmpl[:preserved_style].to_s.html_safe %>><%= @tmpl[:append].to_s.html_safe %></span>
 <% end %>

--- a/lib/doc_template/templates/dialogue.html.erb
+++ b/lib/doc_template/templates/dialogue.html.erb
@@ -1,5 +1,8 @@
+<%# html_safe: DialogueTag#format_phrases builds each phrase from
+    nodes.map(&:to_html) and injects <strong> speaker labels, so a phrase is
+    HTML by construction, not text. %>
 <div class="o-ld-dialogue">
   <% @tmpl[:phrases].each do |phrase| %>
-    <p><%= phrase %></p>
+    <p><%= phrase.to_s.html_safe %></p>
   <% end %>
 </div>

--- a/lib/doc_template/templates/gdoc/activity.html.erb
+++ b/lib/doc_template/templates/gdoc/activity.html.erb
@@ -20,7 +20,7 @@
   <p class="o-ld-activity__alert"><%= activity.alert %></p>
 <% end %>
 
-<h3><span class="o-gdoc-h3"><% if activity.idx.present? %>Activity <%= number_to_word(activity.idx) %>: <% end %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %><% if activity.activity_label.present? %> <%= activity.activity_label.upcase %><% end %></span></h3>
+<h3><span class="o-gdoc-h3"><% if activity.idx.present? %>Activity <%= activity.idx %>: <% end %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %><% if activity.activity_label.present? %> <%= activity.activity_label.upcase %><% end %></span></h3>
 
 <% if type_label.present? || group_label.present? %>
   <p class="o-ld-activity__meta">

--- a/lib/doc_template/templates/gdoc/activity.html.erb
+++ b/lib/doc_template/templates/gdoc/activity.html.erb
@@ -1,49 +1,54 @@
 <%
   activity = @tmpl[:activity]
-  type_label = activity.activity_type.to_s.strip
-  group_label = activity.student_grouping.to_s.strip
-  materials_list = [
-    activity.activity_materials,
-    activity.activity_materials_student,
-    activity.activity_materials_pair,
-    activity.activity_materials_group,
-    activity.activity_materials_class
-  ].compact.map(&:to_s).reject(&:blank?).join(", ")
+  type_label = activity_type_label(activity.activity_type)
+  group_label = student_grouping_label(activity.student_grouping)
+  materials_list = activity_materials_list(activity)
 %>
-<div class="o-ld-activity" id="<%= activity.anchor %>" data-id="<%= activity.anchor %>" data-tag="<%= @tmpl[:placeholder] %>">
+<%# The activity is rendered FLAT (no wrapping <div>) for the Gdoc: Google Docs'
+    HTML import promotes a heading to its Heading 3 style only when the heading
+    is a direct child of <body> — a heading nested inside a <div> is imported as
+    Normal text (which is why the wrapped <h3>/<p> never became a real heading).
+    Flattened, the <h3> below maps natively, the same way the top-level Lesson
+    Content / Lesson Preparation <h2>s do, so no font-size workaround is needed.
+    The inline font-family is required because a paragraph mapped to a named
+    Heading style imports with that style's default font (Arial) and ignores our
+    CSS font — every Gdoc heading carries it for the same reason. The wrapper's
+    other roles are inert here (its anchor/data-tag are unused in the Gdoc path
+    and its margin is dropped on import). The PDF keeps its wrapping div +
+    <h3 class> (default activity.html.erb). %>
+<% if activity.alert.present? %>
+  <p class="o-ld-activity__alert"><%= activity.alert %></p>
+<% end %>
 
-  <% if activity.alert.present? %>
-    <p class="o-ld-activity__alert"><%= activity.alert %></p>
-  <% end %>
+<h3><span class="o-gdoc-h3"><% if activity.idx.present? %>Activity <%= number_to_word(activity.idx) %>: <% end %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %><% if activity.activity_label.present? %> <%= activity.activity_label.upcase %><% end %></span></h3>
 
-  <h3 class="o-ld-activity__heading" style="font-family:'Lexend',Arial,sans-serif;font-size:14pt;font-weight:bold;color:#434343;line-height:1.15;margin:0 0 4pt 0;padding:0;">
-    <%= "Optional: " if activity.optional %><%= activity.activity_title %><% if activity.time.to_i.positive? %> (<%= activity.time %> minutes)<% end %>
-  </h3>
+<% if type_label.present? || group_label.present? %>
+  <p class="o-ld-activity__meta">
+    <% if type_label.present? %><strong><%= type_label %></strong><% end %><% if type_label.present? && group_label.present? %> <% end %><% if group_label.present? %>(<%= group_label %>)<% end %>
+  </p>
+<% end %>
 
-  <% if type_label.present? || group_label.present? %>
-    <p class="o-ld-activity__meta">
-      <%= type_label %><% if type_label.present? && group_label.present? %> <% end %><% if group_label.present? %>(<%= group_label %>)<% end %>
-    </p>
-  <% end %>
+<% if materials_list.present? %>
+  <p class="o-ld-activity__materials">Materials: <%= raw resolve_material_tokens(materials_list) %></p>
+<% end %>
 
-  <% if materials_list.present? %>
-    <p class="o-ld-activity__materials">Materials: <%= raw resolve_material_tokens(materials_list) %></p>
-  <% end %>
+<% if activity.activity_description.present? %>
+  <div class="o-ld-activity__description"><%= raw activity.activity_description %></div>
+<% end %>
 
-  <% if activity.activity_metacognition.present? %>
-    <p class="o-ld-activity__metacognition"><%= raw activity.activity_metacognition %></p>
-  <% end %>
+<% if activity.activity_metacognition.present? %>
+  <p class="o-ld-activity__metacognition"><%= raw activity.activity_metacognition %></p>
+<% end %>
 
-  <% if activity.activity_guidance.present? %>
-    <div class="o-ld-activity__guidance">
-      <p><strong>Guidance:</strong></p>
-      <%= raw activity.activity_guidance %>
-    </div>
-  <% end %>
+<% if activity.activity_guidance.present? %>
+  <div class="o-ld-activity__guidance">
+    <p><strong>Guidance:</strong></p>
+    <%= raw activity.activity_guidance %>
+  </div>
+<% end %>
 
-  <% if activity.activity_standard.present? %>
-    <p class="o-ld-activity__standard"><strong>Standards:</strong> <%= activity.activity_standard %></p>
-  <% end %>
+<% if activity.activity_standard.present? %>
+  <p class="o-ld-activity__standard"><strong>Standards:</strong> <%= activity.activity_standard %></p>
+<% end %>
 
-  <%= @tmpl[:content] %>
-</div>
+<%= @tmpl[:content] %>

--- a/lib/doc_template/templates/gdoc/callout.html.erb
+++ b/lib/doc_template/templates/gdoc/callout.html.erb
@@ -2,7 +2,7 @@
   <table class="o-simple-table">
     <tr>
       <td class="cs-border-left--<%= @tmpl[:subject] %> o-ld-callout__wrap">
-        <h4 class="u-txt--ld-callout-header cs-txt--<%= @tmpl[:subject] %>-base"><%= @tmpl[:header] %></h4>
+        <h4><span class="o-gdoc-h4 cs-txt--<%= @tmpl[:subject] %>-base"><%= @tmpl[:header] %></span></h4>
         <span class="o-ld-callout__content--<%= @tmpl[:subject] %>">
           <%= @tmpl[:content].html_safe %>
         </span>

--- a/lib/doc_template/templates/gdoc/callout_inline.html.erb
+++ b/lib/doc_template/templates/gdoc/callout_inline.html.erb
@@ -1,8 +1,17 @@
-<div class="o-ld-callout o-ld-callout--inline">
+<div class="o-ld-callout o-ld-callout--inline<%= " o-ld-callout--#{@tmpl[:type]}" if @tmpl[:type] %>">
   <table class="o-simple-table o-ld-callout__layout">
     <tr>
       <td class="o-ld-callout__label cs-border-left--<%= @tmpl[:subject] %>">
-        <% if @tmpl[:authored_label] %>
+        <% if @tmpl[:title].present? %>
+          <div class="o-ld-callout__icon o-ld-callout__icon--<%= @tmpl[:type] %>">
+            <% if @tmpl[:image].present? %>
+              <img class="o-ld-callout__icon-img" src="<%= @tmpl[:image] %>" alt="<%= @tmpl[:title] %>">
+            <% else %>
+              +
+            <% end %>
+          </div>
+          <div class="o-ld-callout__type"><%= @tmpl[:title] %></div>
+        <% elsif @tmpl[:authored_label] %>
           <%= @tmpl[:header].html_safe %>
         <% else %>
           <div class="o-ld-callout__icon">+</div>

--- a/lib/doc_template/templates/gdoc/callout_inline.html.erb
+++ b/lib/doc_template/templates/gdoc/callout_inline.html.erb
@@ -4,8 +4,14 @@
       <td class="o-ld-callout__label cs-border-left--<%= @tmpl[:subject] %>">
         <% if @tmpl[:title].present? %>
           <div class="o-ld-callout__icon o-ld-callout__icon--<%= @tmpl[:type] %>">
+            <%# width attribute, not just the max-width in gdoc.scss: Google
+                Docs' HTML import sizes images from the width/height attributes
+                and ignores max-width, so without this the icon lands at its
+                natural resolution. 32px == the 24pt cap the PDF renders at.
+                Width only (no height) so a non-square icon scales
+                proportionally instead of being squashed to a square. %>
             <% if @tmpl[:image].present? %>
-              <img class="o-ld-callout__icon-img" src="<%= @tmpl[:image] %>" alt="<%= @tmpl[:title] %>">
+              <img class="o-ld-callout__icon-img" src="<%= @tmpl[:image] %>" alt="<%= @tmpl[:title] %>" width="32">
             <% else %>
               +
             <% end %>

--- a/lib/doc_template/templates/gdoc/def.html.erb
+++ b/lib/doc_template/templates/gdoc/def.html.erb
@@ -1,7 +1,11 @@
+<%# html_safe on prepend/append/preserved_style: DefTag splits the tag's own
+    node.inner_html around the [def: ...] marker, so these are raw HTML fragments
+    of the surrounding markup, and preserved_style is a bare attribute fragment
+    (style="..."). Mirrors ../def.html.erb. definition stays escaped. %>
 <% if @tmpl[:prepend] %>
-  <span><%= @tmpl[:prepend] %></span>
+  <span><%= @tmpl[:prepend].to_s.html_safe %></span>
 <% end %>
 <span class="c-ld-keyword c-ld-keyword--<%= @tmpl[:subject] %>"><%= h @tmpl[:definition] %></span>
 <% if @tmpl[:append] %>
-  <span <%= @tmpl[:preserved_style] %>><%= @tmpl[:append] %></span>
+  <span <%= @tmpl[:preserved_style].to_s.html_safe %>><%= @tmpl[:append].to_s.html_safe %></span>
 <% end %>

--- a/lib/doc_template/templates/gdoc/dialogue.html.erb
+++ b/lib/doc_template/templates/gdoc/dialogue.html.erb
@@ -1,3 +1,6 @@
+<%# html_safe: DialogueTag#format_phrases builds each phrase from
+    nodes.map(&:to_html) and injects <strong> speaker labels, so a phrase is
+    HTML by construction, not text. Mirrors ../dialogue.html.erb. %>
 <% @tmpl[:phrases].each do |phrase| %>
-  <%= phrase %>
+  <%= phrase.to_s.html_safe %>
 <% end %>

--- a/lib/doc_template/templates/gdoc/group-math.html.erb
+++ b/lib/doc_template/templates/gdoc/group-math.html.erb
@@ -7,7 +7,7 @@
   <table class="o-simple-table u-pdf-nobreak--around">
     <tr>
       <td class="o-ld-title__title">
-        <h2 class="o-ld-title__title--h2"><%= @tmpl[:section].title %></h2>
+        <h2><span class="o-gdoc-h2"><%= @tmpl[:section].title %></span></h2>
       </td>
       <td class="o-ld-title__time o-ld-title__time--h2 u-text--right"><%= @tmpl[:section].time.zero? ? '&mdash;' : "#{@tmpl[:section].time} mins" %></td>
     </tr>
@@ -18,7 +18,7 @@
   <% end %>
 
   <% if @tmpl[:section].try(:lesson_objective).present? %>
-    <h3>Lesson Summary:</h3>
+    <h3><span class="o-gdoc-h3">Lesson Summary:</span></h3>
     <p><%= @tmpl[:section].lesson_objective %></p>
   <% end %>
 

--- a/lib/doc_template/templates/gdoc/group-math.html.erb
+++ b/lib/doc_template/templates/gdoc/group-math.html.erb
@@ -9,7 +9,7 @@
       <td class="o-ld-title__title">
         <h2><span class="o-gdoc-h2"><%= @tmpl[:section].title %></span></h2>
       </td>
-      <td class="o-ld-title__time o-ld-title__time--h2 u-text--right"><%= @tmpl[:section].time.zero? ? '&mdash;' : "#{@tmpl[:section].time} mins" %></td>
+      <td class="o-ld-title__time o-ld-title__time--h2 u-text--right"><%= @tmpl[:section].time.zero? ? "—" : "#{@tmpl[:section].time} mins" %></td>
     </tr>
   </table>
 

--- a/lib/doc_template/templates/gdoc/image.html.erb
+++ b/lib/doc_template/templates/gdoc/image.html.erb
@@ -4,7 +4,12 @@
       <img src="<%= @tmpl[:image_src] %>"/>
     </td>
     <td class="o-ld-image__caption">
-      <strong><%= @tmpl[:caption] %></strong>
+      <% if @tmpl[:caption].present? %>
+        <strong><%= @tmpl[:caption] %></strong>
+      <% end %>
+      <% if @tmpl[:credit].present? %>
+        <p class="o-ld-image__credit"><%= @tmpl[:credit] %></p>
+      <% end %>
     </td>
   </tr>
 </table>

--- a/lib/doc_template/templates/gdoc/image.html.erb
+++ b/lib/doc_template/templates/gdoc/image.html.erb
@@ -1,15 +1,36 @@
-<table class="o-simple-table u-pdf-nobreak--around cs-bg--<%= @tmpl[:subject] %>-image-bg">
+<%#
+  Single-column layout — image, then caption, then credit stacked beneath it —
+  mirroring the PDF figure in ../image.html.erb so both exports render the same
+  design. (This was previously a two-column table with caption/credit beside the
+  image, which left a wide empty gutter and diverged from the PDF.)
+
+  Google Docs' HTML import styles text RUNS, not cells: a class on the <td>
+  is dropped, so the typography classes sit on the inner <p> elements. The one
+  exception is the credit's hairline rule — a cell border is the only border
+  form that survives the import, so it lives on the <td> instead.
+
+  `o-simple-table` is not decorative: HtmlSanitizer#post_processing_tables_gdoc
+  keys off `table:not(.o-simple-table)` to skip the generic border/padding
+  treatment applied to authored tables.
+%>
+<table class="o-simple-table">
   <tr>
     <td class="o-ld-image__img">
-      <img src="<%= @tmpl[:image_src] %>"/>
-    </td>
-    <td class="o-ld-image__caption">
-      <% if @tmpl[:caption].present? %>
-        <strong><%= @tmpl[:caption] %></strong>
-      <% end %>
-      <% if @tmpl[:credit].present? %>
-        <p class="o-ld-image__credit"><%= @tmpl[:credit] %></p>
-      <% end %>
+      <img src="<%= @tmpl[:image_src] %>" alt="<%= @tmpl[:alt] %>"/>
     </td>
   </tr>
+  <% if @tmpl[:caption].present? %>
+    <tr>
+      <td>
+        <p class="o-ld-image__caption"><%= @tmpl[:caption] %></p>
+      </td>
+    </tr>
+  <% end %>
+  <% if @tmpl[:credit].present? %>
+    <tr>
+      <td class="o-ld-image__credit-cell">
+        <p class="o-ld-image__credit"><%= @tmpl[:credit] %></p>
+      </td>
+    </tr>
+  <% end %>
 </table>

--- a/lib/doc_template/templates/gdoc/section.html.erb
+++ b/lib/doc_template/templates/gdoc/section.html.erb
@@ -17,9 +17,7 @@
         <table class="o-simple-table">
           <tr>
             <td class="o-ld-title__title">
-              <h3 class="o-ld-title__title--h3">
-                <%= @tmpl[:section].title %>
-              </h3>
+              <h3><span class="o-gdoc-h3"><%= @tmpl[:section].title %></span></h3>
             </td>
             <td class="o-ld-title__time o-ld-title__time--h3 u-text--right"><%= @tmpl[:section].time.zero? ? '&mdash;' : "#{@tmpl[:section].time} mins" %></td>
           </tr>

--- a/lib/doc_template/templates/gdoc/section.html.erb
+++ b/lib/doc_template/templates/gdoc/section.html.erb
@@ -19,7 +19,7 @@
             <td class="o-ld-title__title">
               <h3><span class="o-gdoc-h3"><%= @tmpl[:section].title %></span></h3>
             </td>
-            <td class="o-ld-title__time o-ld-title__time--h3 u-text--right"><%= @tmpl[:section].time.zero? ? '&mdash;' : "#{@tmpl[:section].time} mins" %></td>
+            <td class="o-ld-title__time o-ld-title__time--h3 u-text--right"><%= @tmpl[:section].time.zero? ? "—" : "#{@tmpl[:section].time} mins" %></td>
           </tr>
         </table>
 

--- a/lib/doc_template/templates/gdoc/standard.html.erb
+++ b/lib/doc_template/templates/gdoc/standard.html.erb
@@ -1,7 +1,11 @@
+<%# html_safe on prepend/append/preserved_style: StandardTag splits the source
+    node HTML around the standard marker, so these are raw fragments of the
+    surrounding markup, and preserved_style is a bare attribute fragment
+    (style="..."). Mirrors ../standard.html.erb. @standard_shortcut stays escaped. %>
 <% if @data[:prepend] %>
-  <span><%= @data[:prepend] %></span>
+  <span><%= @data[:prepend].to_s.html_safe %></span>
 <% end %>
-<span class="c-ld-keyword" <%= @preserved_style %>>(<%= @standard_shortcut %>)</span>
+<span class="c-ld-keyword" <%= @preserved_style.to_s.html_safe %>>(<%= @standard_shortcut %>)</span>
 <% if @data[:append] %>
-  <span <%= @preserved_style %>><%= @data[:append] %></span>
+  <span <%= @preserved_style.to_s.html_safe %>><%= @data[:append].to_s.html_safe %></span>
 <% end %>

--- a/lib/doc_template/templates/group-math.html.erb
+++ b/lib/doc_template/templates/group-math.html.erb
@@ -4,7 +4,7 @@
   <h2 id="<%= @tmpl[:section].anchor %>" class="o-ld-title c-ld-toc">
     <div class="o-ld-title__title o-ld-title__title--h2"><%= @tmpl[:section].title %></div>
     <div class="o-ld-title__time o-ld-title__time--h2">
-      <%= @tmpl[:section].time.zero? ? '&mdash;' : "#{@tmpl[:section].time} mins" %>
+      <%= @tmpl[:section].time.zero? ? "—" : "#{@tmpl[:section].time} mins" %>
     </div>
   </h2>
 

--- a/lib/doc_template/templates/image.html.erb
+++ b/lib/doc_template/templates/image.html.erb
@@ -1,9 +1,14 @@
-<div class="o-ld-image">
+<div class="o-ld-image o-ld-image--<%= @tmpl[:align] %> o-ld-image--<%= @tmpl[:size] %>">
   <div class="o-ld-image--clearfix"></div>
   <div class="o-ld-image__container o-ld-image__container--<%= @tmpl[:subject] %>">
     <figure>
       <img src="<%= @tmpl[:image_src] %>"/>
-      <figcaption><%= @tmpl[:caption] %></figcaption>
+      <% if @tmpl[:caption].present? %>
+        <figcaption><%= @tmpl[:caption] %></figcaption>
+      <% end %>
+      <% if @tmpl[:credit].present? %>
+        <p class="o-ld-image__credit"><%= @tmpl[:credit] %></p>
+      <% end %>
     </figure>
   </div>
 </div>

--- a/lib/doc_template/templates/image.html.erb
+++ b/lib/doc_template/templates/image.html.erb
@@ -2,7 +2,7 @@
   <div class="o-ld-image--clearfix"></div>
   <div class="o-ld-image__container o-ld-image__container--<%= @tmpl[:subject] %>">
     <figure>
-      <img src="<%= @tmpl[:image_src] %>"/>
+      <img src="<%= @tmpl[:image_src] %>" alt="<%= @tmpl[:alt] %>"/>
       <% if @tmpl[:caption].present? %>
         <figcaption><%= @tmpl[:caption] %></figcaption>
       <% end %>

--- a/lib/doc_template/templates/section.html.erb
+++ b/lib/doc_template/templates/section.html.erb
@@ -35,7 +35,7 @@
           </span>
         <% end %>
       </div>
-      <div class="o-ld-title__time o-ld-title__time--h3"><%= @tmpl[:section].time.zero? ? '&mdash;' : "#{@tmpl[:section].time} mins" %></div>
+      <div class="o-ld-title__time o-ld-title__time--h3"><%= @tmpl[:section].time.zero? ? "—" : "#{@tmpl[:section].time} mins" %></div>
     </h3>
 
     <% if (metacog = @tmpl[:section].metacognition.content) %>

--- a/lib/doc_template/templates/standard.html.erb
+++ b/lib/doc_template/templates/standard.html.erb
@@ -1,8 +1,12 @@
 <% id = "cg-k_#{SecureRandom.hex(4)}" %>
+<%# html_safe on prepend/append/preserved_style: StandardTag splits the source
+    node HTML around the standard marker, so these are raw fragments of the
+    surrounding markup, and preserved_style is a bare attribute fragment
+    (style="..."). @standard_shortcut and @description stay escaped. %>
 <% if @data[:prepend] %>
-  <span><%= @data[:prepend] %></span>
+  <span><%= @data[:prepend].to_s.html_safe %></span>
 <% end %>
-<span class="c-ld-keyword" data-toggle="<%= id %>" <%= @preserved_style %>>(<%= @standard_shortcut %>)</span>
+<span class="c-ld-keyword" data-toggle="<%= id %>" <%= @preserved_style.to_s.html_safe %>>(<%= @standard_shortcut %>)</span>
 <% if @description.present? %>
   <span class="dropdown-pane o-ld-dropdown"
   data-dropdown
@@ -16,5 +20,5 @@
   </span>
 <% end %>
 <% if @data[:append] %>
-  <span <%= @preserved_style %>><%= @data[:append] %></span>
+  <span <%= @preserved_style.to_s.html_safe %>><%= @data[:append].to_s.html_safe %></span>
 <% end %>

--- a/lib/exporters/gdoc/base.rb
+++ b/lib/exporters/gdoc/base.rb
@@ -116,7 +116,28 @@ module Exporters
       end
 
       def content
-        render_template template_path("show"), layout: "gdoc"
+        inline_css render_template(template_path("show"), layout: "gdoc")
+      end
+
+      # Google Docs' HTML import ignores <style> blocks and global/container CSS,
+      # so the export must carry every element's styling inline. Premailer reads
+      # the inlined gdoc.css <style> block and rewrites its rules as per-element
+      # style="" attributes. Heading tags are deliberately left without CSS rules
+      # (their typography lives on an inner <span>) so they stay pure and Google
+      # maps them to real Heading styles — see the gdoc templates.
+      def inline_css(html)
+        Premailer.new(
+          html,
+          with_html_string: true,
+          warn_level: Premailer::Warnings::SAFE,
+          remove_comments: true
+        ).to_inline_css
+      rescue StandardError => e
+        # CSS inlining sits on the critical path of every Gdoc export, so a
+        # premailer/nokogiri failure must not abort generation. Fall back to the
+        # un-inlined HTML (Google still imports it, just without inline styling).
+        Rails.logger.warn "[Gdoc] CSS inlining failed, using un-inlined HTML: #{e.class}: #{e.message}"
+        html
       end
 
       #

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -43,6 +43,21 @@ module Settings
       sections: ["/admin/sections#section_:id"],
       units: ["/admin/units#unit_:id"]
     },
+    # Ship-default callout types (see DocTemplate::Tags::CalloutTag), so
+    # `[callout: tip]` etc. still resolve a canonical title before an operator
+    # ever opens admin Settings > Documents > Callout Types. No `image` key:
+    # the shipped defaults have no icon until one is uploaded (an absent key
+    # renders the same as `nil`). An operator override REPLACES this array
+    # wholesale (Settings.merge_with_defaults only deep-merges Hash values,
+    # not Array elements), matching the admin widget which edits the full list.
+    documents: {
+      callout_types: [
+        { type: "tip", title: "Teaching Tip" },
+        { type: "assessment", title: "Assessment" },
+        { type: "support", title: "Student Support" },
+        { type: "home", title: "Home Connection" }
+      ]
+    },
     # Admin chrome. `layout` names a layout template that must exist in the
     # deployed code, so this is a code-level setting (not exposed in the admin
     # UI) — a fork overrides it by shipping a different DEFAULTS or setting the
@@ -62,7 +77,7 @@ module Settings
         name_date: false,
         margin: {
           top: "0.5in",
-          right: "1in",
+          right: "0.5in",
           # 0.5in margin within 8pt footer + 7pt gap from footer to page content
           bottom: "0.5in",
           left: "0.5in"
@@ -113,6 +128,21 @@ module Settings
         db_settings = merge_with_defaults(key, db_settings) if include_defaults
         db_settings
       end
+    end
+
+    # Display label for a value against one of the editable `:documents` maps
+    # (`:lesson_types`, `:activity_types`, `:student_groupings`). The map is
+    # folded to downcased keys for a case-insensitive lookup, so a stored "AP"
+    # matches an authored "ap"/"Ap"; an unmapped (or blank-labelled) value
+    # falls back to titleizing the raw value. Shared by DocumentPresenter and
+    # DocTemplate::Tags::Helpers so the three labels stay consistent.
+    def map_label(sub_key, value)
+      key = value.to_s.strip
+      return "" if key.blank?
+
+      map = (get(:documents, include_defaults: true)&.dig(sub_key) || {})
+            .transform_keys { |abbr| abbr.to_s.strip.downcase }
+      map[key.downcase].presence || key.titleize
     end
 
     # N cached reads. At the current call sites N is 1, so a true batch

--- a/spec/fixtures/tables/lesson-prep.html
+++ b/spec/fixtures/tables/lesson-prep.html
@@ -14,7 +14,12 @@
       </tr>
       <tr>
         <td><span>lesson-prep-directions</span></td>
-        <td><span>Review student notebooks and prepare materials for lab activity.</span></td>
+        <td>
+          <h3><span>Before teaching Class Session 1</span></h3>
+          <ol>
+            <li><span>Review student notebooks and prepare materials for lab activity.</span></li>
+          </ol>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/spec/forms/settings_form_spec.rb
+++ b/spec/forms/settings_form_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe SettingsForm do
       expect(Setting.find_by(key: "appearance")).to be_nil
     end
 
+    # The submitted list/map values are string-keyed while the defaults come
+    # back symbolized, so a naive == treats an unchanged list as a change and
+    # pins the shipped defaults into the DB as an explicit override.
+    it "does not persist a resubmitted list field equal to the shipped default" do
+      defaults = Settings::DEFAULTS[:documents][:callout_types]
+      submitted = defaults.map { |type| type.deep_stringify_keys }
+
+      expect(form(callout_types_submitted: "1", callout_types: submitted).save).to be(true)
+      expect(Setting.find_by(key: "documents")).to be_nil
+    end
+
     it "persists a form-group change (casting the textarea to a list)" do
       expect(form(admin_view_links: { documents: "/x/:id\n/y/:id" }).save).to be(true)
       expect(Settings.get(:admin_view_links)["documents"]).to eq(["/x/:id", "/y/:id"])

--- a/spec/forms/settings_form_spec.rb
+++ b/spec/forms/settings_form_spec.rb
@@ -39,6 +39,195 @@ RSpec.describe SettingsForm do
     end
   end
 
+  describe "#save with a :key_value_list field" do
+    it "persists submitted rows as an ordered abbr => label Hash" do
+      expect(form(lesson_types_submitted: "1", lesson_types: [
+        { abbr: "AP", label: "Anchoring Phenomenon" },
+        { abbr: "CMB", label: "Class Model Building" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["lesson_types"]).to eq(
+        "AP" => "Anchoring Phenomenon",
+        "CMB" => "Class Model Building"
+      )
+    end
+
+    it "strips whitespace and drops rows with a blank abbreviation or label" do
+      expect(form(lesson_types_submitted: "1", lesson_types: [
+        { abbr: " AP ", label: " Anchoring Phenomenon " },
+        { abbr: "  ", label: "Missing abbr" },
+        { abbr: "NL", label: "  " }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["lesson_types"]).to eq("AP" => "Anchoring Phenomenon")
+    end
+
+    it "lets a later duplicate abbreviation overwrite an earlier one" do
+      expect(form(lesson_types_submitted: "1", lesson_types: [
+        { abbr: "AP", label: "First" },
+        { abbr: "AP", label: "Second" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["lesson_types"]).to eq("AP" => "Second")
+    end
+
+    it "collapses abbreviations that differ only in case (later row wins)" do
+      expect(form(lesson_types_submitted: "1", lesson_types: [
+        { abbr: "AP", label: "Anchoring Phenomenon" },
+        { abbr: "ap", label: "Applied Practice" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["lesson_types"]).to eq("ap" => "Applied Practice")
+    end
+
+    it "clears the map when the widget is submitted with no rows" do
+      Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" })
+
+      expect(form(lesson_types_submitted: "1").save).to be(true)
+
+      expect(Settings.get(:documents)["lesson_types"]).to eq({})
+    end
+
+    it "leaves the stored map untouched when the field is omitted entirely" do
+      Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" })
+
+      expect(form(copyright_text: "unchanged").save).to be(true)
+
+      expect(Settings.get(:documents)["lesson_types"]).to eq("AP" => "Anchoring Phenomenon")
+    end
+  end
+
+  describe "#save with a :label_map field" do
+    it "persists submitted labels as a key => label Hash" do
+      expect(form(student_groupings: { "class" => "Whole Class", "small group" => "Small Groups" }).save).to be(true)
+
+      expect(Settings.get(:documents)["student_groupings"]).to eq(
+        "class" => "Whole Class",
+        "small group" => "Small Groups"
+      )
+    end
+
+    it "strips whitespace and drops blank labels, leaving unconfigured keys absent" do
+      expect(form(student_groupings: { "class" => " Whole Class ", "individual" => "  " }).save).to be(true)
+
+      expect(Settings.get(:documents)["student_groupings"]).to eq("class" => "Whole Class")
+    end
+
+    it "ignores a key outside the fixed GROUPING_OPTIONS vocabulary" do
+      expect(form(student_groupings: { "class" => "Whole Class", "bogus" => "Nope" }).save).to be(true)
+
+      expect(Settings.get(:documents)["student_groupings"]).to eq("class" => "Whole Class")
+    end
+
+    it "leaves the stored map untouched when the field is omitted entirely" do
+      Settings.set(:documents, "student_groupings" => { "class" => "Whole Class" })
+
+      expect(form(copyright_text: "unchanged").save).to be(true)
+
+      expect(Settings.get(:documents)["student_groupings"]).to eq("class" => "Whole Class")
+    end
+  end
+
+  describe "#save with a :callout_list field" do
+    it "persists submitted rows as an ordered Array of type/title/image Hashes" do
+      expect(form(callout_types_submitted: "1", callout_types: [
+        { type: "tip", title: "Teaching Tip" },
+        { type: "custom", title: "Custom Type" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["callout_types"]).to eq(
+        [
+          { "type" => "tip", "title" => "Teaching Tip", "image" => nil },
+          { "type" => "custom", "title" => "Custom Type", "image" => nil }
+        ]
+      )
+    end
+
+    it "uploads a new icon file for a row and stores its URL" do
+      uploader = instance_double(ImageUploader, store!: true, url: "/uploads/settings/tip.png")
+      allow(ImageUploader).to receive(:new).and_return(uploader)
+      image_file = Tempfile.new(["tip_icon", ".png"]).tap do |f|
+        f.binmode
+        f.write("\x89PNG\r\n\x1a\n")
+        f.rewind
+      end
+      uploaded_file = Rack::Test::UploadedFile.new(image_file.path, "image/png")
+
+      expect(form(callout_types_submitted: "1", callout_types: [
+        { type: "tip", title: "Teaching Tip", image: uploaded_file }
+      ]).save).to be(true)
+
+      expect(uploader).to have_received(:store!).with(uploaded_file)
+      expect(Settings.get(:documents)["callout_types"]).to eq(
+        [{ "type" => "tip", "title" => "Teaching Tip", "image" => "/uploads/settings/tip.png" }]
+      )
+    ensure
+      image_file&.close!
+    end
+
+    it "keeps the existing icon (looked up by type) when no new file is uploaded" do
+      Settings.set(:documents, "callout_types" => [
+        { "type" => "tip", "title" => "Teaching Tip", "image" => "/uploads/settings/old.png" }
+      ])
+
+      expect(form(callout_types_submitted: "1", callout_types: [
+        { type: "tip", title: "Renamed Tip" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["callout_types"]).to eq(
+        [{ "type" => "tip", "title" => "Renamed Tip", "image" => "/uploads/settings/old.png" }]
+      )
+    end
+
+    it "never persists a client-supplied image URL string" do
+      expect(form(callout_types_submitted: "1", callout_types: [
+        { type: "tip", title: "Teaching Tip", image: "https://evil.example.com/x.png" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["callout_types"]).to eq(
+        [{ "type" => "tip", "title" => "Teaching Tip", "image" => nil }]
+      )
+    end
+
+    it "downcases the type and drops rows with a blank type" do
+      expect(form(callout_types_submitted: "1", callout_types: [
+        { type: " TIP ", title: " Teaching Tip " },
+        { type: "  ", title: "Missing type" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["callout_types"]).to eq(
+        [{ "type" => "tip", "title" => "Teaching Tip", "image" => nil }]
+      )
+    end
+
+    it "lets a later duplicate type overwrite an earlier one" do
+      expect(form(callout_types_submitted: "1", callout_types: [
+        { type: "tip", title: "First" },
+        { type: "tip", title: "Second" }
+      ]).save).to be(true)
+
+      expect(Settings.get(:documents)["callout_types"]).to eq(
+        [{ "type" => "tip", "title" => "Second", "image" => nil }]
+      )
+    end
+
+    it "clears the list when the widget is submitted with no rows" do
+      Settings.set(:documents, "callout_types" => [{ "type" => "tip", "title" => "Teaching Tip" }])
+
+      expect(form(callout_types_submitted: "1").save).to be(true)
+
+      expect(Settings.get(:documents)["callout_types"]).to eq([])
+    end
+
+    it "leaves the stored list untouched when the field is omitted entirely" do
+      Settings.set(:documents, "callout_types" => [{ "type" => "tip", "title" => "Teaching Tip" }])
+
+      expect(form(copyright_text: "unchanged").save).to be(true)
+
+      expect(Settings.get(:documents)["callout_types"]).to eq([{ "type" => "tip", "title" => "Teaching Tip" }])
+    end
+  end
+
   describe "groups" do
     it "exposes one group per SETTINGS entry, each rendered by its own partial" do
       by_key = form({}).groups.index_by(&:key)

--- a/spec/forms/settings_form_spec.rb
+++ b/spec/forms/settings_form_spec.rb
@@ -155,8 +155,11 @@ RSpec.describe SettingsForm do
     end
 
     it "uploads a new icon file for a row and stores its URL" do
-      uploader = instance_double(ImageUploader, store!: true, url: "/uploads/settings/tip.png")
-      allow(ImageUploader).to receive(:new).and_return(uploader)
+      # CalloutIconUploader, not ImageUploader: callout icons go through the
+      # downscaling subclass. Stubbing the parent would still pass (Ruby looks
+      # up the inherited singleton `new`), but would not say what the code does.
+      uploader = instance_double(CalloutIconUploader, store!: true, url: "/uploads/settings/tip.png")
+      allow(CalloutIconUploader).to receive(:new).and_return(uploader)
       image_file = Tempfile.new(["tip_icon", ".png"]).tap do |f|
         f.binmode
         f.write("\x89PNG\r\n\x1a\n")

--- a/spec/helpers/asset_helper_spec.rb
+++ b/spec/helpers/asset_helper_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssetHelper do
+  describe ".inline_data_uri" do
+    it "returns nil for a blank url" do
+      expect(described_class.inline_data_uri("")).to be_nil
+    end
+
+    context "when the URL has no recognizable extension" do
+      let(:url) { "https://cdn.example.com/logo" }
+
+      it "derives the MIME from the server Content-Type" do
+        allow(described_class).to receive(:fetch_remote).with(url).and_return(["binarydata", "image/png"])
+
+        expect(described_class.inline_data_uri(url)).to start_with("data:image/png;base64,")
+      end
+
+      it "falls back to application/octet-stream when no Content-Type is available" do
+        allow(described_class).to receive(:fetch_remote).with(url).and_return(["binarydata", nil])
+
+        expect(described_class.inline_data_uri(url)).to start_with("data:application/octet-stream;base64,")
+      end
+
+      it "strips parameters from the Content-Type" do
+        allow(described_class).to receive(:fetch_remote).with(url).and_return(["binarydata", "image/jpeg; charset=binary"])
+
+        expect(described_class.inline_data_uri(url)).to start_with("data:image/jpeg;base64,")
+      end
+    end
+
+    it "prefers the URL extension over the Content-Type" do
+      url = "https://cdn.example.com/logo.png"
+      allow(described_class).to receive(:fetch_remote).with(url).and_return(["binarydata", "application/octet-stream"])
+
+      expect(described_class.inline_data_uri(url)).to start_with("data:image/png;base64,")
+    end
+
+    it "detects SVG by content sniffing regardless of Content-Type" do
+      url = "https://cdn.example.com/logo"
+      allow(described_class).to receive(:fetch_remote).with(url).and_return(["<svg xmlns='...'></svg>", "text/plain"])
+
+      expect(described_class.inline_data_uri(url)).to start_with("data:image/svg+xml;base64,")
+    end
+  end
+end

--- a/spec/helpers/asset_helper_spec.rb
+++ b/spec/helpers/asset_helper_spec.rb
@@ -44,4 +44,24 @@ RSpec.describe AssetHelper do
       expect(described_class.inline_data_uri(url)).to start_with("data:image/svg+xml;base64,")
     end
   end
+
+  # open-uri calls this with the running transfer total, including for chunked
+  # responses that carry no Content-Length (where content_length_proc never
+  # fires), so the cap holds mid-stream rather than after the whole body landed.
+  describe "the fetch size guard" do
+    subject(:guard) { described_class.send(:fetch_limit_guard) }
+
+    it "aborts once the transfer passes the limit" do
+      expect { guard.call(described_class::DATA_URI_FETCH_LIMIT + 1) }
+        .to raise_error(/exceeds/)
+    end
+
+    it "allows a transfer at the limit" do
+      expect { guard.call(described_class::DATA_URI_FETCH_LIMIT) }.not_to raise_error
+    end
+
+    it "allows an ordinary asset" do
+      expect { guard.call(120.kilobytes) }.not_to raise_error
+    end
+  end
 end

--- a/spec/lib/doc_template/objects/activity_spec.rb
+++ b/spec/lib/doc_template/objects/activity_spec.rb
@@ -15,6 +15,28 @@ describe DocTemplate::Objects::Activity do
       end
     end
 
+    describe "teacher materials authored under the pre-rename key" do
+      let(:activity_table) do
+        [{ "activity-title" => "Wrap up", "activity-metadata-teacher" => "Answer key" }]
+      end
+
+      it "reads the legacy key into activity_materials_teacher" do
+        expect(subject.children.first.activity_materials_teacher).to eq("Answer key")
+      end
+
+      context "when the current key is also present" do
+        let(:activity_table) do
+          [{ "activity-title" => "Wrap up",
+             "activity-metadata-teacher" => "Old key",
+             "activity-materials-teacher" => "Current key" }]
+        end
+
+        it "prefers the current key" do
+          expect(subject.children.first.activity_materials_teacher).to eq("Current key")
+        end
+      end
+    end
+
     describe "correct data" do
       describe "with single section" do
         let(:activity_table) do

--- a/spec/lib/doc_template/tables/lesson_prep_spec.rb
+++ b/spec/lib/doc_template/tables/lesson_prep_spec.rb
@@ -23,6 +23,10 @@ describe DocTemplate::Tables::LessonPrep do
       it "extracts lesson-prep-directions" do
         expect(subject.data["lesson-prep-directions"]).to include("Review student notebooks")
       end
+
+      it "preserves the rich HTML formatting of lesson-prep-directions" do
+        expect(subject.data["lesson-prep-directions"]).to include("<li")
+      end
     end
 
     context "when lesson-prep table is absent" do

--- a/spec/lib/doc_template/tags/callout_tag_spec.rb
+++ b/spec/lib/doc_template/tags/callout_tag_spec.rb
@@ -273,5 +273,35 @@ describe DocTemplate::Tags::CalloutTag do
       expect(subject).to include('src="data:image/png;base64,ZmFrZQ=="')
       expect(subject).not_to include("https://cdn.example.com/tip.png")
     end
+
+    # Google Docs' import ignores max-width and sizes images from the width
+    # attribute, so the 24pt cap in gdoc.scss alone leaves the icon at its
+    # natural resolution. The attribute has to survive to the rendered output.
+    it "constrains the icon with a width attribute" do
+      expect(subject).to include('width="32"')
+    end
+
+    it "sets no height, so a non-square icon is not squashed" do
+      icon = Nokogiri::HTML.fragment(subject).at_css("img.o-ld-callout__icon-img")
+      expect(icon["width"]).to eq("32")
+      expect(icon["height"]).to be_nil
+    end
+
+    context "when the configured title contains markup characters" do
+      before do
+        Settings.set(:documents, "callout_types" => [
+          { "type" => "tip", "title" => 'Tip" onerror="alert(1)', "image" => "https://cdn.example.com/tip.png" }
+        ])
+      end
+
+      # Plain ERB, no auto-escaping — an admin-set title must not be able to
+      # close the alt attribute and add live markup.
+      it "escapes the title in the icon alt attribute" do
+        icon = Nokogiri::HTML.fragment(subject).at_css("img.o-ld-callout__icon-img")
+
+        expect(icon["onerror"]).to be_nil
+        expect(icon["alt"]).to eq('Tip" onerror="alert(1)')
+      end
+    end
   end
 end

--- a/spec/lib/doc_template/tags/callout_tag_spec.rb
+++ b/spec/lib/doc_template/tags/callout_tag_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe DocTemplate::Tags::CalloutTag do
+  before { Rails.cache.clear }
+
   let(:metadata) { instance_double(DocTemplate::Objects::Lesson, subject: "math") }
   let(:opts) { { metadata:, context_type: :default } }
   let(:tag) { described_class.new }
@@ -93,6 +95,183 @@ describe DocTemplate::Tags::CalloutTag do
 
     it "preserves the body cell HTML" do
       expect(subject).to include("Body content goes here")
+    end
+  end
+
+  describe "1-row 2-col inline shape with a nested table in the body cell" do
+    let(:original_content) do
+      <<-HTML
+        <table>
+          <tr>
+            <td><p>[#{described_class::TAG_NAME}: tip]</p></td>
+            <td>
+              <p>Intro text</p>
+              <table>
+                <tr><td>Nested cell A</td><td>Nested cell B</td></tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      HTML
+    end
+
+    it "is classified as inline (nested rows do not inflate the row count)" do
+      expect(subject).to include("o-ld-callout--inline")
+      expect(subject).to include("o-ld-callout--tip")
+    end
+
+    it "keeps the body cell content, including the nested table" do
+      expect(subject).to include("Intro text")
+      expect(subject).to include("Nested cell A")
+      expect(subject).to include("Nested cell B")
+    end
+  end
+
+  describe "ship-default callout types ([callout: <type>] -> canonical title, no Settings override)" do
+    {
+      "tip" => "Teaching Tip",
+      "assessment" => "Assessment",
+      "support" => "Student Support",
+      "home" => "Home Connection"
+    }.each do |type, title|
+      context "when the callout type is #{type}" do
+        let(:original_content) do
+          <<-HTML
+            <table>
+              <tr>
+                <td><p>[#{described_class::TAG_NAME}: #{type}]</p></td>
+                <td><p>Body content for #{type}.</p></td>
+              </tr>
+            </table>
+          HTML
+        end
+
+        it "renders the canonical #{title.inspect} title, resolved from Settings::DEFAULTS" do
+          expect(subject).to include(title)
+          expect(subject).to include("o-ld-callout__type")
+        end
+
+        it "adds the o-ld-callout--#{type} modifier and falls back to the + icon (no icon shipped by default)" do
+          expect(subject).to include("o-ld-callout--#{type}")
+          expect(subject).to include("o-ld-callout__icon--#{type}")
+          expect(subject).not_to include("o-ld-callout__icon-img")
+        end
+
+        it "preserves the body content and strips the marker" do
+          expect(subject).to include("Body content for #{type}.")
+          expect(subject).not_to include("[#{described_class::TAG_NAME}: #{type}]")
+        end
+      end
+    end
+
+    context "when the type is unknown" do
+      let(:original_content) do
+        <<-HTML
+          <table>
+            <tr><td>[#{described_class::TAG_NAME}: nonsense]</td></tr>
+            <tr><td>Authored Header</td></tr>
+            <tr><td>Body text</td></tr>
+          </table>
+        HTML
+      end
+
+      it "falls back to the authored label without a type modifier" do
+        expect(subject).to include("Authored Header")
+        expect(subject).not_to include("o-ld-callout--nonsense")
+      end
+    end
+  end
+
+  describe "client-configured callout types (admin Settings > Documents > Callout Types)" do
+    before do
+      Settings.set(:documents, "callout_types" => [
+        { "type" => "tip", "title" => "Custom Tip Title", "image" => "/uploads/settings/tip-icon.png" },
+        { "type" => "custom", "title" => "Fully Custom Type" }
+      ])
+    end
+
+    context "when the configured type has an uploaded icon" do
+      let(:original_content) do
+        <<-HTML
+          <table>
+            <tr>
+              <td><p>[#{described_class::TAG_NAME}: tip]</p></td>
+              <td><p>Body content.</p></td>
+            </tr>
+          </table>
+        HTML
+      end
+
+      it "resolves the configured title and renders the icon image" do
+        expect(subject).to include("Custom Tip Title")
+        expect(subject).to include("o-ld-callout--tip")
+        expect(subject).to include('src="/uploads/settings/tip-icon.png"')
+        expect(subject).to include('alt="Custom Tip Title"')
+      end
+    end
+
+    context "when a client-defined type has no uploaded icon" do
+      let(:original_content) do
+        <<-HTML
+          <table>
+            <tr>
+              <td><p>[#{described_class::TAG_NAME}: custom]</p></td>
+              <td><p>Body content.</p></td>
+            </tr>
+          </table>
+        HTML
+      end
+
+      it "resolves the configured title and falls back to the + icon" do
+        expect(subject).to include("Fully Custom Type")
+        expect(subject).to include("o-ld-callout--custom")
+        expect(subject).not_to include("o-ld-callout__icon-img")
+      end
+    end
+
+    context "when the type is unknown to the configured list" do
+      let(:original_content) do
+        <<-HTML
+          <table>
+            <tr><td>[#{described_class::TAG_NAME}: nonsense]</td></tr>
+            <tr><td>Authored Header</td></tr>
+            <tr><td>Body text</td></tr>
+          </table>
+        HTML
+      end
+
+      it "falls back to the authored label without a type modifier" do
+        expect(subject).to include("Authored Header")
+        expect(subject).not_to include("o-ld-callout--nonsense")
+      end
+    end
+  end
+
+  describe "gdoc output inlines the configured icon as a data URI" do
+    let(:opts) { { metadata:, context_type: :gdoc } }
+    let(:original_content) do
+      <<-HTML
+        <table>
+          <tr>
+            <td><p>[#{described_class::TAG_NAME}: tip]</p></td>
+            <td><p>Body content.</p></td>
+          </tr>
+        </table>
+      HTML
+    end
+
+    before do
+      Settings.set(:documents, "callout_types" => [
+        { "type" => "tip", "title" => "Teaching Tip", "image" => "https://cdn.example.com/tip.png" }
+      ])
+      allow(AssetHelper).to receive(:inline_data_uri)
+        .with("https://cdn.example.com/tip.png", cache: anything)
+        .and_return("data:image/png;base64,ZmFrZQ==")
+    end
+
+    it "renders the data URI instead of the raw URL" do
+      expect(subject).to include('src="data:image/png;base64,ZmFrZQ=="')
+      expect(subject).not_to include("https://cdn.example.com/tip.png")
     end
   end
 end

--- a/spec/lib/doc_template/tags/helpers_spec.rb
+++ b/spec/lib/doc_template/tags/helpers_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DocTemplate::Tags::Helpers do
+  let(:helper) { Class.new { include DocTemplate::Tags::Helpers }.new }
+
+  describe "#number_to_word" do
+    it "returns the cardinal word for a 1-based number" do
+      expect(helper.number_to_word(1)).to eq("One")
+      expect(helper.number_to_word(3)).to eq("Three")
+    end
+
+    it "falls back to the numeral beyond the lookup table" do
+      expect(helper.number_to_word(42)).to eq("42")
+    end
+
+    it "is blank for nil" do
+      expect(helper.number_to_word(nil)).to eq("")
+    end
+  end
+
+  describe "#activity_materials_list" do
+    let(:activity) do
+      Struct.new(:activity_materials_student, :activity_materials_pair,
+                 :activity_materials_group, :activity_materials_class,
+                 :activity_materials_teacher, keyword_init: true).new(
+                   activity_materials_student: "Notebook, Ruler",
+                   activity_materials_pair: "Ruler",
+                   activity_materials_group: nil,
+                   activity_materials_class: "Lesson 7 Slides",
+                   activity_materials_teacher: "Answer Key"
+                 )
+    end
+
+    it "compiles, dedupes, and comma-joins across all grouping fields" do
+      expect(helper.activity_materials_list(activity))
+        .to eq("Notebook, Ruler, Lesson 7 Slides, Answer Key")
+    end
+
+    it "is blank when no grouping field has materials" do
+      blank = Struct.new(:activity_materials_student, :activity_materials_pair,
+                         :activity_materials_group, :activity_materials_class,
+                         :activity_materials_teacher, keyword_init: true).new
+      expect(helper.activity_materials_list(blank)).to eq("")
+    end
+  end
+
+  describe "#student_grouping_label" do
+    context "when the key is configured in Settings" do
+      before { Settings.set(:documents, "student_groupings" => { "class" => "Whole Class" }) }
+
+      it "returns the configured label" do
+        expect(helper.student_grouping_label("class")).to eq("Whole Class")
+      end
+    end
+
+    context "when the key is not configured" do
+      before { Settings.set(:documents, "student_groupings" => { "class" => "Whole Class" }) }
+
+      it "falls back to titleizing the raw key" do
+        expect(helper.student_grouping_label("small group")).to eq("Small Group")
+      end
+    end
+
+    it "is blank for a blank value" do
+      expect(helper.student_grouping_label("")).to eq("")
+      expect(helper.student_grouping_label(nil)).to eq("")
+    end
+  end
+
+  describe "#activity_type_label" do
+    before { Settings.set(:documents, "activity_types" => { "WU" => "Warm-Up" }) }
+
+    it "returns the configured label" do
+      expect(helper.activity_type_label("WU")).to eq("Warm-Up")
+    end
+
+    it "looks up case-insensitively" do
+      expect(helper.activity_type_label("wu")).to eq("Warm-Up")
+    end
+
+    it "falls back to titleizing the raw value when unconfigured" do
+      expect(helper.activity_type_label("investigation")).to eq("Investigation")
+    end
+
+    it "is blank for a blank value" do
+      expect(helper.activity_type_label("")).to eq("")
+      expect(helper.activity_type_label(nil)).to eq("")
+    end
+  end
+end

--- a/spec/lib/doc_template/tags/helpers_spec.rb
+++ b/spec/lib/doc_template/tags/helpers_spec.rb
@@ -44,6 +44,40 @@ describe DocTemplate::Tags::Helpers do
                          :activity_materials_teacher, keyword_init: true).new
       expect(helper.activity_materials_list(blank)).to eq("")
     end
+
+    # Tables::Base#fetch_materials resolves [material: id] tokens from these
+    # same cells on SPLIT_REGEX, so an author may separate entries with
+    # semicolons or newlines.
+    it "splits on semicolons and newlines too, so entries still dedupe" do
+      mixed = Struct.new(:activity_materials_student, :activity_materials_pair,
+                         :activity_materials_group, :activity_materials_class,
+                         :activity_materials_teacher, keyword_init: true).new(
+                           activity_materials_student: "Beakers; Tongs",
+                           activity_materials_pair: "Tongs",
+                           activity_materials_group: "Ring stand\nClamp",
+                           activity_materials_class: nil,
+                           activity_materials_teacher: nil
+                         )
+
+      expect(helper.activity_materials_list(mixed))
+        .to eq("Beakers, Tongs, Ring stand, Clamp")
+    end
+  end
+
+  describe "#resolve_material_tokens" do
+    # Both activity templates emit this with `raw`, and the source cells are
+    # decoded plain text — so markup characters must not reach the renderer.
+    it "escapes authored text that contains markup characters" do
+      expect(helper.resolve_material_tokens("Beaker <250 ml> & tongs"))
+        .to eq("Beaker &lt;250 ml&gt; &amp; tongs")
+    end
+
+    it "still resolves material tokens in escaped text" do
+      create(:material, identifier: "esc.01", metadata: { "material-title" => "Slides 01" })
+
+      expect(helper.resolve_material_tokens("Use [material: esc.01]"))
+        .to include(%(<span class="o-ld-material">Slides 01</span>))
+    end
   end
 
   describe "#student_grouping_label" do

--- a/spec/lib/doc_template/tags/image_tag_spec.rb
+++ b/spec/lib/doc_template/tags/image_tag_spec.rb
@@ -8,13 +8,15 @@ describe DocTemplate::Tags::ImageTag do
     html.at_xpath("*//table/thead/tr[1]/td[1]")
   end
   let(:metadata) { { "grade" => "5", "unit" => "1", "subject" => "Math" } }
-  let(:opts) { { value: "example_image", metadata: } }
+  let(:value) { "example_image" }
+  let(:opts) { { value:, metadata: } }
   let(:original_content) do
     <<-HTML
       <table>
         <thead>
           <tr><td>[#{described_class::TAG_NAME}]</td></tr>
           <tr><td>Caption text</td></tr>
+          <tr><td>Credit text</td></tr>
         </thead>
       </table>
     HTML
@@ -29,6 +31,72 @@ describe DocTemplate::Tags::ImageTag do
 
     it "substitues tag with image with caption" do
       expect(subject.content).to include("figcaption>Caption text</figcaption>")
+    end
+
+    it "defaults to centered, large layout" do
+      expect(subject.content).to include("o-ld-image--center")
+      expect(subject.content).to include("o-ld-image--large")
+    end
+
+    it "renders the credit row for centered images" do
+      expect(subject.content).to include('class="o-ld-image__credit">Credit text')
+    end
+
+    it "builds the image src from the first token only" do
+      expect(subject.content).to include("example_image.jpg")
+    end
+  end
+
+  describe "alignment and size args" do
+    context "when size is specified" do
+      let(:value) { "example_image size=medium" }
+
+      it "applies the size modifier" do
+        expect(subject.content).to include("o-ld-image--medium")
+      end
+
+      it "still builds the src from the id only (ignores args)" do
+        expect(subject.content).to include("example_image.jpg")
+        expect(subject.content).not_to include("size=medium.jpg")
+      end
+    end
+
+    %w(left right).each do |align|
+      context "when aligned #{align}" do
+        let(:value) { "example_image align=#{align}" }
+
+        it "applies the #{align} float modifier" do
+          expect(subject.content).to include("o-ld-image--#{align}")
+        end
+
+        it "suppresses the caption and credit (text wraps instead)" do
+          expect(subject.content).not_to include("figcaption")
+          expect(subject.content).not_to include("o-ld-image__credit")
+        end
+      end
+    end
+
+    context "when align is centered explicitly" do
+      let(:value) { "example_image align=center size=small" }
+
+      it "keeps the caption and credit" do
+        expect(subject.content).to include("figcaption>Caption text</figcaption>")
+        expect(subject.content).to include("o-ld-image__credit")
+      end
+
+      it "applies center and small modifiers" do
+        expect(subject.content).to include("o-ld-image--center")
+        expect(subject.content).to include("o-ld-image--small")
+      end
+    end
+
+    context "when an unrecognized value is given" do
+      let(:value) { "example_image align=sideways size=huge" }
+
+      it "falls back to center/large defaults" do
+        expect(subject.content).to include("o-ld-image--center")
+        expect(subject.content).to include("o-ld-image--large")
+      end
     end
   end
 end

--- a/spec/lib/doc_template/tags/image_tag_spec.rb
+++ b/spec/lib/doc_template/tags/image_tag_spec.rb
@@ -45,6 +45,46 @@ describe DocTemplate::Tags::ImageTag do
     it "builds the image src from the first token only" do
       expect(subject.content).to include("example_image.jpg")
     end
+
+    it "uses the caption as alt text" do
+      expect(subject.content).to include('alt="Caption text"')
+    end
+  end
+
+  # BaseTag#parse_template uses plain ERB (no auto-escaping), and HtmlSanitizer's
+  # allowlist pass only runs over the SOURCE doc, never over rendered template
+  # output — so authored text has to be neutralised here or it reaches stored,
+  # publicly served HTML intact.
+  describe "escaping of authored caption/credit text" do
+    # The credit cell is entity-encoded in the source so that cell_text's
+    # `.text` DECODES it into real angle brackets — that is the shape that
+    # actually injects. A literal <script> in the fixture would be parsed as an
+    # element by Nokogiri and stripped by `.text` before it ever reached us.
+    let(:original_content) do
+      <<-HTML
+        <table>
+          <thead>
+            <tr><td>[#{described_class::TAG_NAME}]</td></tr>
+            <tr><td>x" onerror="alert(1)</td></tr>
+            <tr><td>Ben &amp; Co &lt;script&gt;alert(2)&lt;/script&gt;</td></tr>
+          </thead>
+        </table>
+      HTML
+    end
+
+    it "does not let a caption break out of the alt attribute" do
+      img = Nokogiri::HTML.fragment(subject.content).at_css("img")
+
+      expect(img["onerror"]).to be_nil
+      expect(img["alt"]).to eq('x" onerror="alert(1)')
+    end
+
+    it "does not let a credit inject markup into the document body" do
+      doc = Nokogiri::HTML.fragment(subject.content)
+
+      expect(doc.at_css("script")).to be_nil
+      expect(doc.at_css("p.o-ld-image__credit").text).to eq("Ben & Co <script>alert(2)</script>")
+    end
   end
 
   describe "alignment and size args" do
@@ -73,6 +113,10 @@ describe DocTemplate::Tags::ImageTag do
           expect(subject.content).not_to include("figcaption")
           expect(subject.content).not_to include("o-ld-image__credit")
         end
+
+        it "still emits alt text from the caption" do
+          expect(subject.content).to include('alt="Caption text"')
+        end
       end
     end
 
@@ -96,6 +140,75 @@ describe DocTemplate::Tags::ImageTag do
       it "falls back to center/large defaults" do
         expect(subject.content).to include("o-ld-image--center")
         expect(subject.content).to include("o-ld-image--large")
+      end
+    end
+  end
+
+  describe "gdoc template" do
+    let(:opts) { { value:, metadata:, context_type: :gdoc } }
+    let(:doc) { Nokogiri::HTML.fragment subject.content }
+
+    it "keeps the o-simple-table marker" do
+      # HtmlSanitizer#post_processing_tables_gdoc keys off
+      # `table:not(.o-simple-table)` to skip the generic border/padding pass.
+      expect(doc.at_css("table")["class"]).to include("o-simple-table")
+    end
+
+    it "stacks image, caption and credit in one column" do
+      rows = doc.css("tr")
+      expect(rows.size).to eq(3)
+      expect(rows.map { |row| row.css("td").size }).to all(eq(1))
+      expect(rows[0].at_css("img")).to be_present
+      expect(rows[1].at_css("p.o-ld-image__caption").text).to eq("Caption text")
+      expect(rows[2].at_css("p.o-ld-image__credit").text).to eq("Credit text")
+    end
+
+    it "puts the typography class on the paragraph, not the cell" do
+      # Google Docs' import drops cell-level text formatting, so a class on the
+      # <td> would lose the caption's size and alignment.
+      expect(doc.at_css("td.o-ld-image__caption")).to be_nil
+      expect(doc.at_css("p.o-ld-image__caption")).to be_present
+    end
+
+    it "puts the credit rule on the cell, which survives the import" do
+      expect(doc.at_css("td.o-ld-image__credit-cell")).to be_present
+    end
+
+    it "emits alt text" do
+      expect(doc.at_css("img")["alt"]).to eq("Caption text")
+    end
+
+    context "when the caption and credit cells are empty" do
+      let(:original_content) do
+        <<-HTML
+          <table>
+            <thead>
+              <tr><td>[#{described_class::TAG_NAME}]</td></tr>
+              <tr><td></td></tr>
+              <tr><td></td></tr>
+            </thead>
+          </table>
+        HTML
+      end
+
+      it "renders only the image row" do
+        expect(doc.css("tr").size).to eq(1)
+        expect(doc.at_css("p.o-ld-image__caption")).to be_nil
+        expect(doc.at_css("td.o-ld-image__credit-cell")).to be_nil
+      end
+    end
+
+    context "when the image is not centered" do
+      let(:value) { "example_image align=left" }
+
+      it "renders only the image row" do
+        expect(doc.css("tr").size).to eq(1)
+        expect(doc.at_css("p.o-ld-image__caption")).to be_nil
+        expect(doc.at_css("p.o-ld-image__credit")).to be_nil
+      end
+
+      it "still emits alt text" do
+        expect(doc.at_css("img")["alt"]).to eq("Caption text")
       end
     end
   end

--- a/spec/lib/doc_template/tags/material_tag_spec.rb
+++ b/spec/lib/doc_template/tags/material_tag_spec.rb
@@ -47,5 +47,89 @@ describe DocTemplate::Tags::MaterialTag do
         expect(parsed.errors).to be_empty
       end
     end
+
+    # `[material: id]` is authored mid-sentence, and DocTemplate::Document hands
+    # a tag its `node.parent` — so substituting the enclosing element would take
+    # the sentence with it.
+    describe "inline substitution" do
+      it "replaces only the tag, keeping the text around it" do
+        parsed
+        expect(node.to_html).to eq(%(<p>provide copies of <span>#{parsed.placeholder}</span>.</p>))
+      end
+
+      it "keeps the enclosing element itself" do
+        parsed
+        expect(fragment.at_xpath(".//p")).to be_present
+      end
+
+      context "when the tag is the element's only content" do
+        let(:html) { %(<p><span>[material: #{identifier}]</span></p>) }
+
+        it "still substitutes in place" do
+          parsed
+          expect(node.to_html).to eq(%(<p><span>#{parsed.placeholder}</span></p>))
+        end
+      end
+
+      # An attribute can hold brackets of its own (Google Docs carries authored
+      # image alt text through the sanitizer). Matching serialized HTML would
+      # hit that literal first and rewrite the attribute instead of the tag.
+      context "when an attribute contains a bracketed literal" do
+        let(:html) { %(<p><img alt="Figure [1]"> copies of [material: #{identifier}] now.</p>) }
+
+        it "substitutes the tag, not the attribute" do
+          parsed
+          expect(node.at_xpath(".//img")["alt"]).to eq("Figure [1]")
+          expect(node.text).to eq(" copies of #{parsed.placeholder} now.")
+        end
+      end
+
+      context "when the surrounding text contains markup characters" do
+        let(:html) { %(<p>use &lt;250ml&gt; beakers &amp; [material: #{identifier}] now.</p>) }
+
+        it "keeps that text escaped" do
+          parsed
+          expect(node.to_html).to include("use &lt;250ml&gt; beakers &amp; #{parsed.placeholder} now.")
+        end
+      end
+
+      context "when a broken export splits the tag across spans" do
+        let(:html) { %(<p>copies of <span>[mat</span><span>erial: #{identifier}]</span> now.</p>) }
+
+        it "substitutes the whole tag and keeps the surrounding text" do
+          parsed
+          expect(node.text).to eq("copies of #{parsed.placeholder} now.")
+        end
+      end
+    end
+  end
+
+  # Google Docs splits one logical list into several `<ol>` chunks and carries
+  # the running count in `start="N"`. Dropping an `<li>` leaves its chunk short
+  # while the next chunk keeps its original absolute number, so the numbering
+  # visibly skips. See the regression this guards in HtmlSanitizer's pipeline.
+  describe "numbering across split lists" do
+    let(:html) do
+      <<~HTML.strip
+        <ol start="1"><li><span>First.</span></li></ol>
+        <ol start="2"><li><span>Display </span><span>Slide 4. Hand out </span><span>[material: mat.01]</span><span>.</span></li></ol>
+        <ol start="3"><li><span>Third.</span></li></ol>
+      HTML
+    end
+    let(:document) { DocTemplate::Document.parse(Nokogiri::HTML.fragment(html), context_type: "default") }
+
+    def rendered
+      index = document.parts.to_h { |p| [p[:placeholder], { content: p[:content], optional: p[:optional] }] }
+      DocumentRenderer::Part.call(document.render, parts_index: index, with_optional: true)
+    end
+
+    it "leaves every list chunk with its item, so `start` stays in step" do
+      counts = Nokogiri::HTML.fragment(rendered).css("ol").map { |ol| [ol["start"], ol.xpath("./li").size] }
+      expect(counts).to eq([["1", 1], ["2", 1], ["3", 1]])
+    end
+
+    it "keeps the text authored alongside the tag" do
+      expect(Nokogiri::HTML.fragment(rendered).text).to include("Display Slide 4. Hand out")
+    end
   end
 end

--- a/spec/lib/doc_template/tags/material_tag_spec.rb
+++ b/spec/lib/doc_template/tags/material_tag_spec.rb
@@ -16,13 +16,24 @@ describe DocTemplate::Tags::MaterialTag do
     context "when the material exists" do
       let!(:material) { create(:material, identifier: identifier) }
 
-      it "renders an anchor pointing to the material" do
-        expect(parsed.content).to include(%(href="/materials/#{material.id}"))
-        expect(parsed.content).to include(identifier)
+      it "renders the material as plain text, not a link" do
+        expect(parsed.content).to include(%(<span class="o-ld-material">#{identifier}</span>))
+        expect(parsed.content).not_to include("href")
       end
 
       it "leaves no errors" do
         expect(parsed.errors).to be_empty
+      end
+    end
+
+    context "when the material has an authored title" do
+      let!(:material) do
+        create(:material, identifier: identifier, metadata: { "material-title" => "Lesson 7 Slides" })
+      end
+
+      it "uses the material title as the visible text" do
+        expect(parsed.content).to include(%(<span class="o-ld-material">Lesson 7 Slides</span>))
+        expect(parsed.content).not_to include("href")
       end
     end
 

--- a/spec/migrations/realign_seeded_pdf_right_margin_spec.rb
+++ b/spec/migrations/realign_seeded_pdf_right_margin_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260810000000_realign_seeded_pdf_right_margin")
+
+RSpec.describe RealignSeededPdfRightMargin do
+  before { Rails.cache.clear }
+
+  def migrate
+    described_class.new.tap { |m| m.verbose = false }.up
+  end
+
+  def stored_right_margin
+    Settings.get(:pdf).dig("default", "margin", "right")
+  end
+
+  def seed(right)
+    Settings.set(:pdf, "default" => { "margin" => { "top" => "0.5in", "right" => right } })
+  end
+
+  it "rewrites a stored right margin still equal to the old shipped default" do
+    seed("1in")
+
+    migrate
+
+    expect(stored_right_margin).to eq("0.5in")
+  end
+
+  it "leaves the rest of the stored :pdf settings untouched" do
+    seed("1in")
+
+    migrate
+
+    expect(Settings.get(:pdf).dig("default", "margin", "top")).to eq("0.5in")
+  end
+
+  it "leaves an operator-chosen margin alone" do
+    seed("1.25in")
+
+    migrate
+
+    expect(stored_right_margin).to eq("1.25in")
+  end
+
+  it "is a no-op when nothing is stored for :pdf" do
+    expect { migrate }.not_to raise_error
+    expect(Settings.get(:pdf)).to be_nil
+  end
+
+  it "is idempotent" do
+    seed("1in")
+
+    migrate
+    migrate
+
+    expect(stored_right_margin).to eq("0.5in")
+  end
+end

--- a/spec/presenters/content_presenter_spec.rb
+++ b/spec/presenters/content_presenter_spec.rb
@@ -77,4 +77,37 @@ RSpec.describe ContentPresenter do
       expect(presenter.footer_margin_styles).to eq("margin-right:0;margin-left:0;")
     end
   end
+
+  describe "#brandmark_data_uri" do
+    let(:record) { double("record", short_breadcrumb: "lesson", version: 1) }
+    let(:presenter) { described_class.new(record, content_type: "default") }
+
+    it "returns an empty string when no brandmark is configured" do
+      allow(presenter).to receive(:brandmark_source_url).and_return(nil)
+
+      expect(presenter.brandmark_data_uri).to eq("")
+    end
+
+    it "returns the inlined base64 data URI for the Settings brandmark" do
+      allow(presenter).to receive(:brandmark_source_url).and_return("https://cdn.example/logo.png")
+      allow(AssetHelper).to receive(:inline_data_uri).and_return("data:image/png;base64,QUJD")
+
+      expect(presenter.brandmark_data_uri).to eq("data:image/png;base64,QUJD")
+    end
+
+    it "returns an empty string when inlining fails" do
+      allow(presenter).to receive(:brandmark_source_url).and_return("https://cdn.example/logo.png")
+      allow(AssetHelper).to receive(:inline_data_uri).and_return(nil)
+
+      expect(presenter.brandmark_data_uri).to eq("")
+    end
+
+    it "drops an oversized image so it can't bloat the scripts.run request" do
+      allow(presenter).to receive(:brandmark_source_url).and_return("https://cdn.example/logo.png")
+      oversized = "data:image/png;base64,#{'A' * (described_class::BRANDMARK_MAX_ENCODED_BYTES + 1)}"
+      allow(AssetHelper).to receive(:inline_data_uri).and_return(oversized)
+
+      expect(presenter.brandmark_data_uri).to eq("")
+    end
+  end
 end

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -16,12 +16,13 @@ describe DocumentPresenter do
   let(:presenter) { described_class.new(document) }
 
   describe "#gdoc_header" do
-    it "returns parallel [patterns, values] arrays for title, lesson type, and estimated time" do
+    it "returns parallel [patterns, values] arrays for title, unit title, lesson type, and estimated time" do
       patterns, values = presenter.gdoc_header
 
-      expect(patterns).to eq(["{title}", "{lesson_type}", "{estimated_time}"])
+      expect(patterns).to eq(["{title}", "{unit_title}", "{lesson_type}", "{estimated_time}"])
       expect(values).to eq([
         presenter.lesson_title,
+        presenter.unit_title,
         presenter.lesson_type_label,
         presenter.estimated_time
       ])
@@ -108,6 +109,63 @@ describe DocumentPresenter do
     end
   end
 
+  describe "#banner_title" do
+    it "prefixes the lesson title with the lesson number" do
+      expect(presenter.banner_title).to eq("Lesson 5: Introduction to Fractions")
+    end
+
+    context "without a lesson number" do
+      let(:document) do
+        create(:document, metadata: {
+          "lesson_title" => "Introduction to Fractions",
+          "grade" => "3",
+          "unit_id" => "1",
+          "section_number" => "1",
+          "subject" => "math"
+        })
+      end
+
+      it "returns the bare title" do
+        expect(presenter.banner_title).to eq("Introduction to Fractions")
+      end
+    end
+
+    context "without a lesson title" do
+      let(:document) do
+        create(:document, metadata: {
+          "lesson_title" => "",
+          "grade" => "3",
+          "unit_id" => "1",
+          "section_number" => "1",
+          "lesson_number" => "5",
+          "subject" => "math"
+        })
+      end
+
+      it "returns the lesson label with no dangling colon" do
+        expect(presenter.banner_title).to eq("Lesson 5")
+      end
+    end
+  end
+
+  describe "#unit_title" do
+    context "without a unit resource ancestor" do
+      it "falls back to the upcased unit_id" do
+        expect(presenter.unit_title).to eq("Unit 1")
+      end
+    end
+
+    context "with a unit resource carrying unit_title metadata" do
+      let(:unit) { create(:resource, :unit, metadata: { "unit_title" => "Expressions and Equations" }) }
+
+      before { document.resource.update!(parent: unit) }
+
+      it "prefers the authored unit-metadata title" do
+        expect(presenter.unit_title).to eq("Expressions and Equations")
+      end
+    end
+  end
+
   describe "integration with Google::ScriptService" do
     it "provides compatible format for ScriptService#parameters" do
       header = presenter.gdoc_header
@@ -121,12 +179,48 @@ describe DocumentPresenter do
     it "returns parallel [patterns, values] arrays mirroring the R2 PDF footer" do
       patterns, values = presenter.gdoc_footer
 
-      expect(patterns).to eq(["{copyright}", "{course}", "{unit_lesson}"])
+      expect(patterns).to eq(["{copyright}", "{attribution}", "{course}", "{unit_lesson}"])
       expect(values).to eq([
         presenter.footer_copyright,
-        presenter.footer_course,
-        presenter.footer_unit_lesson
+        presenter.footer_attribution,
+        nil,
+        presenter.footer_course_lesson
       ])
+    end
+
+    # The template's own {course} paragraph is retired: it must still be
+    # substituted (blank) rather than left as literal text in the exported doc.
+    it "blanks the legacy {course} slot instead of dropping the placeholder" do
+      patterns, values = presenter.gdoc_footer
+
+      expect(patterns).to include("{course}")
+      expect(values[patterns.index("{course}")]).to be_nil
+    end
+
+    context "with an authored cc-attribution" do
+      let(:document) do
+        create(:document, metadata: {
+          "lesson_title" => "Introduction to Fractions",
+          "grade" => "3",
+          "unit_id" => "1",
+          "section_number" => "1",
+          "lesson_number" => "5",
+          "subject" => "math",
+          "cc-attribution" => "Adapted from OpenSciEd, CC BY-NC-SA 4.0"
+        })
+      end
+
+      it "carries the per-lesson attribution into the {attribution} slot" do
+        patterns, values = presenter.gdoc_footer
+
+        expect(values[patterns.index("{attribution}")]).to eq("Adapted from OpenSciEd, CC BY-NC-SA 4.0")
+      end
+    end
+
+    it "leaves the attribution slot blank when the lesson authors none" do
+      patterns, values = presenter.gdoc_footer
+
+      expect(values[patterns.index("{attribution}")]).to be_nil
     end
 
     context "with copyright_text Setting" do
@@ -141,16 +235,69 @@ describe DocumentPresenter do
     end
   end
 
-  describe "#footer_unit_lesson" do
-    it "joins unit title and lesson label with a bullet" do
-      expect(presenter.footer_unit_lesson).to eq("Unit 1 • Lesson 5")
+  describe "#footer_course_lesson" do
+    # No unit-metadata here, so there is no course — the breadcrumb must NOT
+    # invent one from the resource label the lesson importer generated.
+    it "degrades to the bare lesson label when the unit has no metadata" do
+      expect(presenter.footer_course_lesson).to eq("Lesson 5")
     end
 
     context "when unit and lesson are missing" do
       let(:document) { Document.new(metadata: { "subject" => "math" }) }
 
       it "returns nil" do
-        expect(presenter.footer_unit_lesson).to be_nil
+        expect(presenter.footer_course_lesson).to be_nil
+      end
+    end
+
+    context "with every lesson of the unit imported" do
+      before { create(:curriculum) }
+
+      def create_lesson(num)
+        create(:document, metadata: {
+          "subject" => "science", "grade" => "10", "unit-id" => "GG",
+          "section-number" => "1", "lesson-number" => num.to_s, "lesson-title" => "L#{num}"
+        })
+      end
+
+      let!(:lessons) { (1..3).map { |n| create_lesson(n) } }
+
+      before do
+        unit = lessons.first.resource.ancestors.find(&:unit?)
+        unit.update_columns(metadata: unit.metadata.merge("course" => "Biology"))
+      end
+
+      it "counts the unit's lessons into the breadcrumb" do
+        expect(described_class.new(lessons.second).footer_course_lesson)
+          .to eq("Biology • Lesson 2 of 3")
+      end
+
+      it "counts lessons across sections, not just this lesson's own section" do
+        create(:document, metadata: {
+          "subject" => "science", "grade" => "10", "unit-id" => "GG",
+          "section-number" => "2", "lesson-number" => "1", "lesson-title" => "S2 L1"
+        })
+
+        expect(described_class.new(lessons.first).footer_course_lesson)
+          .to eq("Biology • Lesson 1 of 4")
+      end
+    end
+
+    # A lesson doc with a blank section-number lands on a section-typed
+    # resource, so its unit holds no lesson resources — better a short label
+    # than "Lesson 7 of 0".
+    context "when the unit holds fewer lessons than this lesson's number" do
+      before { create(:curriculum) }
+
+      let(:document) do
+        create(:document, metadata: {
+          "subject" => "science", "grade" => "10", "unit-id" => "GG",
+          "section-number" => "", "lesson-number" => "7", "lesson-title" => "L7"
+        })
+      end
+
+      it "omits the total" do
+        expect(presenter.footer_course_lesson).to eq("Lesson 7")
       end
     end
   end
@@ -181,8 +328,8 @@ describe DocumentPresenter do
       expect(described_class.new(document).footer_course).to eq("Biology")
     end
 
-    it "#footer_unit_lesson uses the unit-title from unit-metadata" do
-      expect(described_class.new(document).footer_unit_lesson).to eq("Cells • Lesson 3")
+    it "#footer_course_lesson leads with the course, not the unit title" do
+      expect(described_class.new(document).footer_course_lesson).to eq("Biology • Lesson 3")
     end
 
     it "#footer_copyright appends the unit version to the boilerplate copyright" do
@@ -265,6 +412,32 @@ describe DocumentPresenter do
         ])
       end
     end
+
+    context "when a document was parsed before the teacher-materials rename" do
+      let(:document) do
+        create(:document,
+               metadata: { "subject" => "science", "grade" => "6" },
+               activity_metadata: [{ "activity-metadata-teacher" => "Answer key" }])
+      end
+
+      it "still reads teacher materials from the legacy key" do
+        expect(presenter.materials_summary["Teacher Materials"]).to eq("Answer key")
+      end
+    end
+
+    context "when authored text contains markup-significant characters" do
+      let(:document) do
+        create(:document,
+               metadata: { "subject" => "science", "grade" => "6" },
+               activity_metadata: [{ "activity-materials-class" => "Beakers <250ml> & tongs" }])
+      end
+
+      # Both header views emit these values with `raw`, so anything the author
+      # types must be escaped here or the browser eats it as a tag.
+      it "escapes it instead of letting it be parsed as markup" do
+        expect(presenter.materials_summary["Class Materials"]).to eq("Beakers &lt;250ml&gt; &amp; tongs")
+      end
+    end
   end
 
   describe "#vocabulary" do
@@ -325,6 +498,56 @@ describe DocumentPresenter do
     end
   end
 
+  describe "#lesson_prep_heading" do
+    context "when the lesson-prep table defines a time" do
+      let(:document) do
+        create(:document, metadata: {
+          "subject" => "math",
+          "grade" => "6",
+          "lesson_prep" => { "lesson-prep-time" => "30" }
+        })
+      end
+
+      it "appends it to the heading, like an activity heading" do
+        expect(presenter.lesson_prep_heading).to eq("Lesson Preparation (30 minutes)")
+      end
+    end
+
+    context "when the time is a single minute" do
+      let(:document) do
+        create(:document, metadata: {
+          "subject" => "math",
+          "grade" => "6",
+          "lesson_prep" => { "lesson-prep-time" => "1" }
+        })
+      end
+
+      it "renders the singular unit" do
+        expect(presenter.lesson_prep_heading).to eq("Lesson Preparation (1 minute)")
+      end
+    end
+
+    context "when no prep time is authored" do
+      let(:document) do
+        create(:document, metadata: {
+          "subject" => "math",
+          "grade" => "6",
+          "lesson_prep" => { "lesson-prep-directions" => "<ol><li>Review slides</li></ol>" }
+        })
+      end
+
+      it "returns the bare heading, with no empty parentheses" do
+        expect(presenter.lesson_prep_heading).to eq("Lesson Preparation")
+      end
+    end
+
+    context "when the lesson has no lesson-prep table at all" do
+      it "returns the bare heading" do
+        expect(presenter.lesson_prep_heading).to eq("Lesson Preparation")
+      end
+    end
+  end
+
   describe "#lesson_prep_directions" do
     context "when the lesson defines preparation directions" do
       let(:document) do
@@ -367,48 +590,68 @@ describe DocumentPresenter do
     end
   end
 
-  describe "overview neighbour descriptions" do
-    # A real curriculum tree is built from each document's metadata, so the
-    # presenter can walk to the previous/next lesson within the same unit.
-    before { create(:curriculum) }
-
-    def create_lesson(num, attrs = {})
+  describe "Overview bullets" do
+    # All three bullets come from the lesson's OWN lesson-metadata: the author
+    # writes the recap, the summary and the look-ahead in one table and all
+    # three render in that lesson.
+    let(:document) do
       create(:document, metadata: {
-        "subject" => "math",
-        "grade" => "3",
-        "unit-id" => "1",
-        "section-number" => "1",
-        "lesson-number" => num.to_s,
-        "lesson-title" => "Lesson #{num}"
-      }.merge(attrs))
+        "subject" => "science",
+        "grade" => "10",
+        "unit-id" => "GG",
+        "lesson-number" => "7",
+        "lesson-title" => "How does our stuff impact climate change?",
+        "description" => "In this lesson, we will create a Class Final Explanatory Model.",
+        "description-past" => "In the previous lesson, we created a Class Final Explanatory Model.",
+        "description-future" => "In the next lesson, we will create a Class Final Explanatory Model."
+      })
     end
 
-    # Per the spec: `description-future` is blank for Lesson 1 and
-    # `description-past` is blank for the last lesson of the unit.
-    let!(:lesson1) do
-      create_lesson(1, "description" => "this 1", "description-past" => "past 1", "description-future" => "")
-    end
-    let!(:lesson2) do
-      create_lesson(2, "description" => "this 2", "description-past" => "past 2", "description-future" => "future 2")
-    end
-    let!(:lesson3) do
-      create_lesson(3, "description" => "this 3", "description-past" => "", "description-future" => "future 3")
+    it "reads overview_past from this lesson's own description-past" do
+      expect(presenter.overview_past)
+        .to eq("In the previous lesson, we created a Class Final Explanatory Model.")
     end
 
-    it "reads overview_past from the previous lesson's description-past" do
-      expect(described_class.new(lesson2).overview_past).to eq("past 1")
+    it "reads overview_future from this lesson's own description-future" do
+      expect(presenter.overview_future)
+        .to eq("In the next lesson, we will create a Class Final Explanatory Model.")
     end
 
-    it "reads overview_future from the next lesson's description-future" do
-      expect(described_class.new(lesson2).overview_future).to eq("future 3")
+    it "assembles the three bullets as previous, this, next" do
+      bullets = [presenter.overview_past, presenter.description, presenter.overview_future]
+
+      expect(bullets).to eq([
+        "In the previous lesson, we created a Class Final Explanatory Model.",
+        "In this lesson, we will create a Class Final Explanatory Model.",
+        "In the next lesson, we will create a Class Final Explanatory Model."
+      ])
     end
 
-    it "returns nil overview_past for the first lesson of the unit" do
-      expect(described_class.new(lesson1).overview_past).to be_nil
+    # The lesson's curriculum position is irrelevant now — no neighbour is
+    # consulted, so a lesson with no siblings still renders all three.
+    it "renders all three even when the lesson stands alone in its unit" do
+      expect([presenter.overview_past, presenter.description, presenter.overview_future])
+        .to all(be_present)
     end
 
-    it "returns nil overview_future for the last lesson of the unit" do
-      expect(described_class.new(lesson3).overview_future).to be_nil
+    context "when a description field is blank" do
+      let(:document) do
+        create(:document, metadata: {
+          "subject" => "science",
+          "grade" => "10",
+          "unit-id" => "GG",
+          "lesson-number" => "1",
+          "description" => "In this lesson…",
+          "description-past" => "",
+          "description-future" => ""
+        })
+      end
+
+      it "drops that bullet instead of rendering an empty one" do
+        expect(presenter.overview_past).to be_nil
+        expect(presenter.overview_future).to be_nil
+        expect(presenter.description).to eq("In this lesson…")
+      end
     end
   end
 end

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -16,14 +16,23 @@ describe DocumentPresenter do
   let(:presenter) { described_class.new(document) }
 
   describe "#gdoc_header" do
-    context "when lesson_title is present" do
-      it "returns 2D array with title placeholder and value" do
-        result = presenter.gdoc_header
+    it "returns parallel [patterns, values] arrays for title, lesson type, and estimated time" do
+      patterns, values = presenter.gdoc_header
 
-        expect(result).to eq([
-          ["{title}"],
-          ["Introduction to Fractions"]
-        ])
+      expect(patterns).to eq(["{title}", "{lesson_type}", "{estimated_time}"])
+      expect(values).to eq([
+        presenter.lesson_title,
+        presenter.lesson_type_label,
+        presenter.estimated_time
+      ])
+    end
+
+    context "when lesson_title is present" do
+      it "puts the title first in the values array, aligned with {title}" do
+        patterns, values = presenter.gdoc_header
+
+        expect(patterns.first).to eq("{title}")
+        expect(values.first).to eq("Introduction to Fractions")
       end
     end
 
@@ -39,13 +48,62 @@ describe DocumentPresenter do
         })
       end
 
-      it "returns empty string for title" do
-        result = presenter.gdoc_header
+      it "returns an empty title value" do
+        _patterns, values = presenter.gdoc_header
 
-        expect(result).to eq([
-          ["{title}"],
-          [""]
-        ])
+        expect(values.first).to eq("")
+      end
+    end
+  end
+
+  describe "#lesson_type_label" do
+    let(:document) do
+      create(:document, metadata: {
+        "lesson_title" => "Introduction to Fractions",
+        "grade" => "3",
+        "unit_id" => "1",
+        "section_number" => "1",
+        "lesson_number" => "5",
+        "subject" => "math",
+        "lesson_type" => lesson_type
+      })
+    end
+
+    context "when the abbreviation is mapped in Settings" do
+      let(:lesson_type) { "AP" }
+
+      before { Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" }) }
+
+      it "returns the configured label" do
+        expect(presenter.lesson_type_label).to eq("Anchoring Phenomenon")
+      end
+    end
+
+    context "when the abbreviation matches case-insensitively" do
+      let(:lesson_type) { "ap" }
+
+      before { Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" }) }
+
+      it "returns the configured label" do
+        expect(presenter.lesson_type_label).to eq("Anchoring Phenomenon")
+      end
+    end
+
+    context "when the abbreviation is not in the map" do
+      let(:lesson_type) { "unmapped_type" }
+
+      before { Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" }) }
+
+      it "falls back to titleizing the raw value" do
+        expect(presenter.lesson_type_label).to eq("Unmapped Type")
+      end
+    end
+
+    context "when lesson_type is blank" do
+      let(:lesson_type) { "" }
+
+      it "returns an empty string" do
+        expect(presenter.lesson_type_label).to eq("")
       end
     end
   end
@@ -55,57 +113,95 @@ describe DocumentPresenter do
       header = presenter.gdoc_header
 
       expect(header).to be_an(Array)
-      expect(header.size).to eq(2)
       expect(header.all? { |row| row.is_a?(Array) }).to be true
     end
   end
 
   describe "#gdoc_footer" do
+    it "returns parallel [patterns, values] arrays mirroring the R2 PDF footer" do
+      patterns, values = presenter.gdoc_footer
+
+      expect(patterns).to eq(["{copyright}", "{course}", "{unit_lesson}"])
+      expect(values).to eq([
+        presenter.footer_copyright,
+        presenter.footer_course,
+        presenter.footer_unit_lesson
+      ])
+    end
+
     context "with copyright_text Setting" do
       before { Settings.set(:documents, "copyright_text" => "© Acme, Spring 2026") }
 
-      it "merges copyright_text into the attribution placeholder" do
-        result = presenter.gdoc_footer
+      it "carries the configured copyright into the {copyright} slot" do
+        patterns, values = presenter.gdoc_footer
 
-        expect(result).to eq([
-          ["{attribution}"],
-          ["© Acme, Spring 2026"]
-        ])
-      end
-    end
-
-    context "without any copyright info" do
-      it "falls back to the placeholder default" do
-        result = presenter.gdoc_footer
-
-        expect(result).to eq([
-          ["{attribution}"],
-          ["Copyright attribution here"]
-        ])
+        expect(patterns.first).to eq("{copyright}")
+        expect(values.first).to include("© Acme, Spring 2026")
       end
     end
   end
 
-  describe "#footer_breadcrumb" do
-    it "joins grade label, unit title, and lesson label with bullets" do
-      result = presenter.footer_breadcrumb
-
-      expect(result).to eq("Grade 3/Course • Unit 1 • Lesson 5")
+  describe "#footer_unit_lesson" do
+    it "joins unit title and lesson label with a bullet" do
+      expect(presenter.footer_unit_lesson).to eq("Unit 1 • Lesson 5")
     end
 
-    context "when all parts are missing" do
+    context "when unit and lesson are missing" do
       let(:document) { Document.new(metadata: { "subject" => "math" }) }
 
       it "returns nil" do
-        expect(presenter.footer_breadcrumb).to be_nil
+        expect(presenter.footer_unit_lesson).to be_nil
       end
+    end
+  end
+
+  describe "footer lines from unit-metadata" do
+    before { create(:curriculum) }
+
+    let(:document) do
+      create(:document, metadata: {
+        "subject" => "math",
+        "grade" => "6",
+        "unit-id" => "2",
+        "section-number" => "1",
+        "lesson-number" => "3",
+        "lesson-title" => "L3"
+      })
+    end
+
+    before do
+      # The unit Resource carries unit-metadata (populated by UnitBuildService).
+      unit = document.resource.ancestors.find(&:unit?)
+      unit.update_columns(metadata: unit.metadata.merge(
+        "course" => "Biology", "version" => "v1.0", "unit-title" => "Cells"
+      ))
+    end
+
+    it "#footer_course reads the course from unit-metadata" do
+      expect(described_class.new(document).footer_course).to eq("Biology")
+    end
+
+    it "#footer_unit_lesson uses the unit-title from unit-metadata" do
+      expect(described_class.new(document).footer_unit_lesson).to eq("Cells • Lesson 3")
+    end
+
+    it "#footer_copyright appends the unit version to the boilerplate copyright" do
+      Settings.set(:documents, "copyright_text" => "© Acme")
+
+      expect(described_class.new(document).footer_copyright).to eq("© Acme, v1.0")
     end
   end
 
   describe "#materials_summary" do
     context "when document has no activity metadata" do
-      it "returns an empty hash" do
-        expect(presenter.materials_summary).to eq({})
+      it "renders every category as \"None\"" do
+        expect(presenter.materials_summary).to eq(
+          "Individual Student Materials" => "None",
+          "Pair Materials" => "None",
+          "Small Group Materials" => "None",
+          "Class Materials" => "None",
+          "Teacher Materials" => "None"
+        )
       end
     end
 
@@ -134,13 +230,13 @@ describe DocumentPresenter do
         expect(summary["Class Materials"]).to eq("Lesson 7 Slides")
       end
 
-      it "resolves [material: id] tokens to italic identifier links when the material exists" do
+      it "resolves [material: id] tokens to plain identifier text matching MaterialTag when the material exists" do
         create(:material, identifier: "worksheet01")
 
         summary = presenter.materials_summary
 
         expect(summary["Individual Student Materials"])
-          .to include('<a class="o-ld-material">worksheet01</a>')
+          .to include(%(<span class="o-ld-material">worksheet01</span>))
         expect(summary["Individual Student Materials"])
           .not_to include("[material:")
       end
@@ -168,6 +264,151 @@ describe DocumentPresenter do
           "Teacher Materials"
         ])
       end
+    end
+  end
+
+  describe "#vocabulary" do
+    context "when activities define vocabulary" do
+      let(:document) do
+        create(:document,
+               metadata: { "subject" => "math", "grade" => "6" },
+               activity_metadata: [
+                 { "vocabulary" => "energy, force" },
+                 { "vocabulary" => "force, motion" },
+                 { "vocabulary" => "" }
+               ])
+      end
+
+      it "compiles and dedupes vocabulary across activities" do
+        expect(presenter.vocabulary).to eq("energy, force, motion")
+      end
+    end
+
+    context "when no activity defines vocabulary" do
+      it "returns a blank string" do
+        expect(presenter.vocabulary).to eq("")
+      end
+    end
+  end
+
+  describe "#estimated_time" do
+    def with_activity_times(*times)
+      create(:document,
+             metadata: { "subject" => "math", "grade" => "6" },
+             activity_metadata: times.map { |t| { "activity-time" => t.to_s } })
+    end
+
+    it "rounds total activity time up to whole 45-minute class periods" do
+      # 45 → 1 period
+      expect(described_class.new(with_activity_times(20, 25)).estimated_time)
+        .to eq("1 Class Period")
+      # 60 → 2 periods
+      expect(described_class.new(with_activity_times(30, 30)).estimated_time)
+        .to eq("2 Class Periods")
+      # 135 → 3 periods
+      expect(described_class.new(with_activity_times(45, 45, 45)).estimated_time)
+        .to eq("3 Class Periods")
+    end
+
+    it "falls back to the authored estimated-time when no activity has a time" do
+      document = create(:document, metadata: {
+        "subject" => "math", "grade" => "6", "estimated-time" => "Two weeks"
+      })
+
+      expect(described_class.new(document).estimated_time).to eq("Two weeks")
+    end
+
+    it "is blank when there is neither activity time nor an authored value" do
+      document = create(:document, metadata: { "subject" => "math", "grade" => "6" })
+
+      expect(described_class.new(document).estimated_time).to be_blank
+    end
+  end
+
+  describe "#lesson_prep_directions" do
+    context "when the lesson defines preparation directions" do
+      let(:document) do
+        create(:document, metadata: {
+          "subject" => "math",
+          "grade" => "6",
+          "lesson_prep" => { "lesson-prep-directions" => "<ol><li>Review slides</li></ol>" }
+        })
+      end
+
+      it "returns the directions HTML" do
+        expect(presenter.lesson_prep_directions).to eq("<ol><li>Review slides</li></ol>")
+      end
+    end
+
+    context "when the lesson has no preparation directions" do
+      it "is blank" do
+        expect(presenter.lesson_prep_directions).to be_blank
+      end
+    end
+
+    context "when the directions reference a [material: id] token" do
+      let!(:material) { create(:material, identifier: "10s.10.gg.l7.slides01") }
+      let(:document) do
+        create(:document, metadata: {
+          "subject" => "math",
+          "grade" => "6",
+          "lesson_prep" => {
+            "lesson-prep-directions" => "<ol><li>Review [material: 10S.10.GG.L7.Slides01].</li></ol>"
+          }
+        })
+      end
+
+      it "resolves the token to inline plain material text (case-insensitively)" do
+        result = presenter.lesson_prep_directions
+
+        expect(result).to include(%(<span class="o-ld-material">10s.10.gg.l7.slides01</span>))
+        expect(result).not_to include("[material:")
+      end
+    end
+  end
+
+  describe "overview neighbour descriptions" do
+    # A real curriculum tree is built from each document's metadata, so the
+    # presenter can walk to the previous/next lesson within the same unit.
+    before { create(:curriculum) }
+
+    def create_lesson(num, attrs = {})
+      create(:document, metadata: {
+        "subject" => "math",
+        "grade" => "3",
+        "unit-id" => "1",
+        "section-number" => "1",
+        "lesson-number" => num.to_s,
+        "lesson-title" => "Lesson #{num}"
+      }.merge(attrs))
+    end
+
+    # Per the spec: `description-future` is blank for Lesson 1 and
+    # `description-past` is blank for the last lesson of the unit.
+    let!(:lesson1) do
+      create_lesson(1, "description" => "this 1", "description-past" => "past 1", "description-future" => "")
+    end
+    let!(:lesson2) do
+      create_lesson(2, "description" => "this 2", "description-past" => "past 2", "description-future" => "future 2")
+    end
+    let!(:lesson3) do
+      create_lesson(3, "description" => "this 3", "description-past" => "", "description-future" => "future 3")
+    end
+
+    it "reads overview_past from the previous lesson's description-past" do
+      expect(described_class.new(lesson2).overview_past).to eq("past 1")
+    end
+
+    it "reads overview_future from the next lesson's description-future" do
+      expect(described_class.new(lesson2).overview_future).to eq("future 3")
+    end
+
+    it "returns nil overview_past for the first lesson of the unit" do
+      expect(described_class.new(lesson1).overview_past).to be_nil
+    end
+
+    it "returns nil overview_future for the last lesson of the unit" do
+      expect(described_class.new(lesson3).overview_future).to be_nil
     end
   end
 end

--- a/spec/presenters/material_presenter_spec.rb
+++ b/spec/presenters/material_presenter_spec.rb
@@ -136,6 +136,38 @@ describe MaterialPresenter do
     end
   end
 
+  describe "#external_assets" do
+    context "when the material has external-asset URLs" do
+      let(:material) do
+        create(:material, metadata: {
+          "material_id" => "TEST.MAT.001",
+          "material_title" => "Lesson 7 Slides",
+          "material_type" => "slides",
+          "language" => "English",
+          "external_assets" => {
+            "pdf" => "",
+            "slides" => "https://docs.google.com/presentation/d/abc/edit",
+            "video" => "https://youtu.be/xyz",
+            "webpage" => ""
+          }
+        })
+      end
+
+      it "returns only populated links in EXTERNAL_ASSETS order with labels" do
+        expect(presenter.external_assets).to eq([
+          { label: "Slides", url: "https://docs.google.com/presentation/d/abc/edit" },
+          { label: "Video", url: "https://youtu.be/xyz" }
+        ])
+      end
+    end
+
+    context "when the material has no external assets" do
+      it "returns an empty array" do
+        expect(presenter.external_assets).to eq([])
+      end
+    end
+  end
+
   describe "integration with Google::ScriptService" do
     it "provides compatible format for ScriptService#parameters" do
       footer = presenter.gdoc_footer

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -206,6 +206,241 @@ RSpec.describe "Admin::Settings", type: :request do
     end
   end
 
+  describe "documents lesson_types field (:key_value_list)" do
+    it "renders a row per existing entry, plus the submitted sentinel" do
+      Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" })
+
+      get settings_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('name="lesson_types[][abbr]"')
+      expect(response.body).to include('name="lesson_types[][label]"')
+      expect(response.body).to include('name="lesson_types_submitted"')
+      expect(response.body).to include("Anchoring Phenomenon")
+    end
+
+    it "persists submitted rows as an ordered abbr => label Hash" do
+      patch settings_path, params: {
+        lesson_types_submitted: "1",
+        lesson_types: [
+          { abbr: "AP", label: "Anchoring Phenomenon" },
+          { abbr: "CMB", label: "Class Model Building" }
+        ]
+      }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["lesson_types"]).to eq(
+        "AP" => "Anchoring Phenomenon",
+        "CMB" => "Class Model Building"
+      )
+    end
+
+    it "drops rows with a blank abbreviation or label" do
+      patch settings_path, params: {
+        lesson_types_submitted: "1",
+        lesson_types: [
+          { abbr: "AP", label: "Anchoring Phenomenon" },
+          { abbr: "", label: "Missing abbr" },
+          { abbr: "NL", label: "" }
+        ]
+      }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["lesson_types"]).to eq("AP" => "Anchoring Phenomenon")
+    end
+
+    it "leaves the stored map untouched when the field is omitted" do
+      Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" })
+
+      patch settings_path, params: { copyright_text: "© Acme" }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["lesson_types"]).to eq("AP" => "Anchoring Phenomenon")
+    end
+  end
+
+  describe "documents student_groupings field (:label_map)" do
+    it "renders one row per fixed GROUPING_OPTIONS key, pre-filled from the stored map" do
+      Settings.set(:documents, "student_groupings" => { "class" => "Whole Class" })
+
+      get settings_path
+
+      expect(response).to have_http_status(:ok)
+      DocTemplate::Tables::Activity::GROUPING_OPTIONS.each do |key|
+        expect(response.body).to include(%(name="student_groupings[#{key}]"))
+      end
+      expect(response.body).to include("Whole Class")
+    end
+
+    it "persists submitted labels as a key => label Hash" do
+      patch settings_path, params: {
+        student_groupings: { "class" => "Whole Class", "small group" => "Small Groups" }
+      }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["student_groupings"]).to eq(
+        "class" => "Whole Class",
+        "small group" => "Small Groups"
+      )
+    end
+
+    it "drops blank labels, leaving unconfigured keys absent" do
+      patch settings_path, params: {
+        student_groupings: { "class" => "Whole Class", "individual" => "" }
+      }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["student_groupings"]).to eq("class" => "Whole Class")
+    end
+
+    it "ignores a key outside the fixed GROUPING_OPTIONS vocabulary" do
+      patch settings_path, params: {
+        student_groupings: { "class" => "Whole Class", "bogus" => "Nope" }
+      }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["student_groupings"]).to eq("class" => "Whole Class")
+    end
+
+    it "leaves the stored map untouched when the field is omitted" do
+      Settings.set(:documents, "student_groupings" => { "class" => "Whole Class" })
+
+      patch settings_path, params: { copyright_text: "© Acme" }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["student_groupings"]).to eq("class" => "Whole Class")
+    end
+  end
+
+  describe "documents callout_types field (:callout_list)" do
+    it "renders a row per existing entry, plus the submitted sentinel" do
+      Settings.set(:documents, "callout_types" => [{ "type" => "tip", "title" => "Teaching Tip" }])
+
+      get settings_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('name="callout_types[][type]"')
+      expect(response.body).to include('name="callout_types[][title]"')
+      expect(response.body).to include('name="callout_types[][image]"')
+      expect(response.body).to include('name="callout_types_submitted"')
+      expect(response.body).to include("Teaching Tip")
+    end
+
+    it "persists submitted rows as an ordered Array of type/title/image Hashes" do
+      patch settings_path, params: {
+        callout_types_submitted: "1",
+        callout_types: [
+          { type: "tip", title: "Teaching Tip" },
+          { type: "custom", title: "Custom Type" }
+        ]
+      }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["callout_types"]).to eq(
+        [
+          { "type" => "tip", "title" => "Teaching Tip", "image" => nil },
+          { "type" => "custom", "title" => "Custom Type", "image" => nil }
+        ]
+      )
+    end
+
+    it "drops rows with a blank type" do
+      patch settings_path, params: {
+        callout_types_submitted: "1",
+        callout_types: [
+          { type: "tip", title: "Teaching Tip" },
+          { type: "", title: "Missing type" }
+        ]
+      }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["callout_types"]).to eq(
+        [{ "type" => "tip", "title" => "Teaching Tip", "image" => nil }]
+      )
+    end
+
+    it "leaves the stored list untouched when the field is omitted" do
+      Settings.set(:documents, "callout_types" => [{ "type" => "tip", "title" => "Teaching Tip" }])
+
+      patch settings_path, params: { copyright_text: "© Acme" }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["callout_types"]).to eq(
+        [{ "type" => "tip", "title" => "Teaching Tip" }]
+      )
+    end
+
+    it "clears the list when the sentinel is submitted with no rows" do
+      Settings.set(:documents, "callout_types" => [{ "type" => "tip", "title" => "Teaching Tip" }])
+
+      patch settings_path, params: { callout_types_submitted: "1" }
+
+      expect(response).to redirect_to(settings_path)
+      expect(Setting.find_by(key: "documents").value["callout_types"]).to eq([])
+    end
+
+    context "with an icon upload" do
+      let(:uploader) { instance_double(ImageUploader, store!: true, url: "/uploads/settings/tip.png") }
+      let(:image_file) do
+        Tempfile.new(["tip_icon", ".png"]).tap do |f|
+          f.binmode
+          f.write("\x89PNG\r\n\x1a\n")
+          f.rewind
+        end
+      end
+      let(:uploaded_file) { Rack::Test::UploadedFile.new(image_file.path, "image/png") }
+
+      before do
+        allow(ImageUploader).to receive(:new).and_return(uploader)
+      end
+
+      after { image_file.close! }
+
+      it "uploads the new file and stores its URL for that row" do
+        patch settings_path, params: {
+          callout_types_submitted: "1",
+          callout_types: [{ type: "tip", title: "Teaching Tip", image: uploaded_file }]
+        }
+
+        expect(response).to redirect_to(settings_path)
+        expect(uploader).to have_received(:store!)
+        expect(Setting.find_by(key: "documents").value["callout_types"]).to eq(
+          [{ "type" => "tip", "title" => "Teaching Tip", "image" => "/uploads/settings/tip.png" }]
+        )
+      end
+
+      it "keeps the existing icon (looked up by type) when the row carries no new upload" do
+        Settings.set(:documents, "callout_types" => [
+          { "type" => "tip", "title" => "Teaching Tip", "image" => "/uploads/settings/old.png" }
+        ])
+
+        patch settings_path, params: {
+          callout_types_submitted: "1",
+          callout_types: [{ type: "tip", title: "Renamed Tip" }]
+        }
+
+        expect(response).to redirect_to(settings_path)
+        expect(uploader).not_to have_received(:store!)
+        expect(Setting.find_by(key: "documents").value["callout_types"]).to eq(
+          [{ "type" => "tip", "title" => "Renamed Tip", "image" => "/uploads/settings/old.png" }]
+        )
+      end
+
+      it "never persists a client-supplied image URL string" do
+        patch settings_path, params: {
+          callout_types_submitted: "1",
+          callout_types: [{ type: "tip", title: "Teaching Tip", image: "https://evil.example.com/x.png" }]
+        }
+
+        expect(response).to redirect_to(settings_path)
+        expect(uploader).not_to have_received(:store!)
+        expect(Setting.find_by(key: "documents").value["callout_types"]).to eq(
+          [{ "type" => "tip", "title" => "Teaching Tip", "image" => nil }]
+        )
+      end
+    end
+  end
+
   describe "admin_view_links form group" do
     before { Settings.set(:admin_view_links, Settings::DEFAULTS[:admin_view_links].deep_stringify_keys) }
 

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -380,7 +380,9 @@ RSpec.describe "Admin::Settings", type: :request do
     end
 
     context "with an icon upload" do
-      let(:uploader) { instance_double(ImageUploader, store!: true, url: "/uploads/settings/tip.png") }
+      # Callout icons go through CalloutIconUploader (the downscaling subclass),
+      # not ImageUploader.
+      let(:uploader) { instance_double(CalloutIconUploader, store!: true, url: "/uploads/settings/tip.png") }
       let(:image_file) do
         Tempfile.new(["tip_icon", ".png"]).tap do |f|
           f.binmode
@@ -391,7 +393,7 @@ RSpec.describe "Admin::Settings", type: :request do
       let(:uploaded_file) { Rack::Test::UploadedFile.new(image_file.path, "image/png") }
 
       before do
-        allow(ImageUploader).to receive(:new).and_return(uploader)
+        allow(CalloutIconUploader).to receive(:new).and_return(uploader)
       end
 
       after { image_file.close! }

--- a/spec/services/document_build_service_spec.rb
+++ b/spec/services/document_build_service_spec.rb
@@ -73,5 +73,11 @@ describe DocumentBuildService do
       subject
       expect(document.reload.active).to be_truthy
     end
+
+    it "clears stale preview links so a re-import regenerates fresh" do
+      document.update!(preview_links: { "preview" => { "gdoc" => { "url" => "old-cached-url" } } })
+      subject
+      expect(document.reload.preview_links).to eq({})
+    end
   end
 end

--- a/spec/services/google/script_service_spec.rb
+++ b/spec/services/google/script_service_spec.rb
@@ -24,12 +24,33 @@ describe Google::ScriptService do
       allow(service).to receive(:service).and_return(script_service)
       allow(script_service).to receive(:run_script).and_return(response)
       allow(ENV).to receive(:fetch).with("GOOGLE_APPLICATION_TEMPLATE_PORTRAIT").and_return("template_id")
+      allow(ENV).to receive(:fetch).with("GOOGLE_APPLICATION_SCRIPT_DEV_MODE", "false").and_return("false")
     end
 
     it "creates an execution request and runs the script" do
       expect(script_service).to receive(:run_script)
         .with(described_class::SCRIPT_ID, instance_of(::Google::Apis::ScriptV1::ExecutionRequest))
         .and_return(response)
+
+      service.execute(document_id)
+    end
+
+    it "runs the deployed version by default (dev_mode off)" do
+      expect(script_service).to receive(:run_script) do |_script_id, request|
+        expect(request.dev_mode).to be false
+        response
+      end
+
+      service.execute(document_id)
+    end
+
+    it "runs the latest saved version when GOOGLE_APPLICATION_SCRIPT_DEV_MODE is true" do
+      allow(ENV).to receive(:fetch).with("GOOGLE_APPLICATION_SCRIPT_DEV_MODE", "false").and_return("true")
+
+      expect(script_service).to receive(:run_script) do |_script_id, request|
+        expect(request.dev_mode).to be true
+        response
+      end
 
       service.execute(document_id)
     end

--- a/spec/services/html_sanitizer_spec.rb
+++ b/spec/services/html_sanitizer_spec.rb
@@ -62,6 +62,29 @@ describe HtmlSanitizer do
         expect(subject.scan("sup").size).to eq 4
       end
     end
+
+    context "with authored text color" do
+      let(:html) { %(<p><span style="color:#ff0000">red</span></p>) }
+
+      it "preserves the authored color (L1)" do
+        expect(subject).to include("ff0000")
+      end
+    end
+
+    context "with a styled header cell" do
+      let(:html) do
+        <<-HTML
+          <table>
+            <tr><th style="background-color:#cccccc;text-align:right">Head</th></tr>
+          </table>
+        HTML
+      end
+
+      it "keeps inline style on th (L2)" do
+        expect(subject).to include("background-color")
+        expect(subject).to include("text-align")
+      end
+    end
   end
 
   describe ".clean_content" do

--- a/spec/services/html_sanitizer_spec.rb
+++ b/spec/services/html_sanitizer_spec.rb
@@ -200,4 +200,31 @@ describe HtmlSanitizer do
       end
     end
   end
+
+  # Google Docs indents nested list items by 36pt per level and the sanitizer
+  # drops the margin, so depth has to survive as a class the stylesheets can
+  # act on (.u-ld-indent--lN in pdf.scss / gdoc.scss).
+  describe "nested list indent levels" do
+    def level_class(margin)
+      html = %(<ul><li style="margin-left:#{margin}pt"><span>x</span></li></ul>)
+      Nokogiri::HTML.fragment(described_class.sanitize(html)).at_css("li")["class"]
+    end
+
+    it "leaves the first level unclassed — that is the list's own indent" do
+      expect(level_class(36)).to be_nil
+    end
+
+    it "maps each 36pt step to the next level, skipping none" do
+      classes = [72, 108, 144, 180, 216].map { |m| level_class(m) }
+
+      expect(classes).to eq(%w(u-ld-indent--l2 u-ld-indent--l3 u-ld-indent--l4
+                               u-ld-indent--l5 u-ld-indent--l6))
+    end
+
+    it "ignores a list item with no margin" do
+      html = "<ul><li><span>x</span></li></ul>"
+
+      expect(Nokogiri::HTML.fragment(described_class.sanitize(html)).at_css("li")["class"]).to be_nil
+    end
+  end
 end

--- a/spec/uploaders/callout_icon_uploader_spec.rb
+++ b/spec/uploaders/callout_icon_uploader_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CalloutIconUploader do
+  # Exercises the real MiniMagick processing rather than stubbing it: the point
+  # of this class is that an oversized upload comes back downscaled, and a stub
+  # would assert nothing about that.
+  let(:uploader) { described_class.new }
+  let(:tmpdir) { Dir.mktmpdir }
+
+  after do
+    uploader.remove!
+    FileUtils.remove_entry(tmpdir)
+  end
+
+  def source(width, height)
+    path = File.join(tmpdir, "icon-#{width}x#{height}.png")
+    # Shelling out to ImageMagick directly: mini_magick 5 reworked the
+    # MiniMagick::Tool API, and generating the fixture is not what is under test.
+    raise "failed to build fixture" unless system("convert", "-size", "#{width}x#{height}", "xc:orange", path)
+
+    File.open(path)
+  end
+
+  def stored_dimensions
+    image = MiniMagick::Image.open(uploader.file.path)
+    [image.width, image.height]
+  end
+
+  it "downscales an oversized square icon to the max edge" do
+    uploader.store!(source(1024, 1024))
+
+    expect(stored_dimensions).to eq([described_class::MAX_EDGE, described_class::MAX_EDGE])
+  end
+
+  it "preserves aspect ratio for a non-square icon" do
+    uploader.store!(source(1024, 512))
+
+    width, height = stored_dimensions
+    expect(width).to eq(described_class::MAX_EDGE)
+    expect(height).to eq(described_class::MAX_EDGE / 2)
+  end
+
+  it "leaves an already-small icon untouched rather than upscaling it" do
+    uploader.store!(source(48, 48))
+
+    expect(stored_dimensions).to eq([48, 48])
+  end
+
+  it "inherits the parent's raster-only extension allowlist" do
+    # SVG stays excluded (stored XSS via inline script) — see ImageUploader.
+    expect(uploader.extension_allowlist).to match_array(%w(jpg jpeg png gif webp))
+  end
+end

--- a/spec/views/documents/pdf/_header.html.erb_spec.rb
+++ b/spec/views/documents/pdf/_header.html.erb_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "documents/pdf/_header", type: :view do
+  let(:document) do
+    create(:document, metadata: {
+      "lesson_title" => "Common Method Bias",
+      "grade" => "3",
+      "unit_id" => "1",
+      "section_number" => "1",
+      "lesson_number" => "5",
+      "subject" => "math",
+      "lesson_type" => "AP"
+    })
+  end
+  let(:presenter) { DocumentPresenter.new(document, content_type: :default) }
+
+  before { Settings.set(:documents, "lesson_types" => { "AP" => "Anchoring Phenomenon" }) }
+
+  def render_header
+    render "documents/pdf/header", document: presenter
+  end
+
+  it "renders the Unit Title on the right of the banner strip" do
+    render_header
+    expect(rendered).to have_css("td.c-lesson-banner__unit", text: "Unit 1")
+  end
+
+  it "places the Unit Title above the Lesson Type" do
+    render_header
+    expect(rendered.index("c-lesson-banner__unit")).to be < rendered.index("c-lesson-banner__type")
+  end
+
+  it "renders the Lesson Type and Estimated Time lines" do
+    render_header
+    expect(rendered).to have_css("td.c-lesson-banner__type", text: "Anchoring Phenomenon")
+    expect(rendered).to have_css("td.c-lesson-banner__time")
+  end
+
+  it "spans the brandmark cell across all three right-hand lines" do
+    render_header
+    expect(rendered).to have_css("td.c-lesson-banner__brand[rowspan='3']")
+  end
+
+  it "renders the Lesson Title below the divider, prefixed with the lesson number" do
+    render_header
+    expect(rendered).to have_css("hr.c-lesson-banner__divider")
+    expect(rendered).to have_css("h1.c-lesson-banner__title", text: "Lesson 5: Common Method Bias")
+  end
+
+  context "when activities define vocabulary" do
+    let(:document) do
+      create(:document,
+             metadata: {
+               "lesson_title" => "Common Method Bias",
+               "grade" => "3",
+               "unit_id" => "1",
+               "section_number" => "1",
+               "lesson_number" => "5",
+               "subject" => "math"
+             },
+             activity_metadata: [{ "vocabulary" => "observe, natural" }])
+    end
+
+    it "renders a bold label with the terms in italics" do
+      render_header
+      expect(rendered).to have_css("p.c-lesson-vocabulary strong", text: "Vocabulary:")
+      expect(rendered).to have_css("p.c-lesson-vocabulary em", text: "observe, natural")
+    end
+  end
+
+  context "when the lesson defines preparation directions and a prep time" do
+    let(:document) do
+      create(:document, metadata: {
+        "lesson_title" => "Common Method Bias",
+        "grade" => "3",
+        "unit_id" => "1",
+        "section_number" => "1",
+        "lesson_number" => "5",
+        "subject" => "math",
+        "lesson_prep" => {
+          "lesson-prep-time" => "30",
+          "lesson-prep-directions" => "<ol><li>Review slides</li></ol>"
+        }
+      })
+    end
+
+    it "carries the prep time in the section heading" do
+      render_header
+      expect(rendered).to have_css("h2.c-lesson-prep__heading", text: "Lesson Preparation (30 minutes)")
+    end
+  end
+end

--- a/spec/views/materials/gdoc/_header.html.erb_spec.rb
+++ b/spec/views/materials/gdoc/_header.html.erb_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "materials/gdoc/_header", type: :view do
+  let(:material) do
+    Material.new(metadata: { "material-title" => "Document Title", "material-type" => "handout" })
+  end
+  let(:presenter) { MaterialPresenter.new(material, content_type: :default) }
+
+  def render_header
+    render "materials/gdoc/header", document: presenter
+  end
+
+  it "renders the Material Type (titleized) on the right of the banner strip" do
+    render_header
+    expect(rendered).to have_css("td.c-lesson-banner__type", text: "Handout")
+  end
+
+  it "renders the banner divider" do
+    render_header
+    expect(rendered).to have_css("hr.c-lesson-banner__divider")
+  end
+
+  it "renders the Document Title from material-title" do
+    render_header
+    expect(rendered).to have_css("h1 span.o-gdoc-h1", text: "Document Title")
+  end
+
+  it "inlines the brandmark image when configured" do
+    Settings.set(:documents, "brandmark" => "https://example.com/logo.png")
+    allow(AssetHelper).to receive(:inline_data_uri).and_return("data:image/png;base64,AAAA")
+
+    render_header
+    expect(rendered).to have_css("img.c-lesson-banner__brand-img[src^='data:image/png']")
+  end
+
+  it "does not render the Name/Date row by default" do
+    render_header
+    expect(rendered).not_to have_css("table.o-m-namedate")
+  end
+
+  context "when material-metadata name-date is Yes" do
+    let(:material) do
+      Material.new(metadata: {
+        "material-title" => "Document Title", "material-type" => "handout", "name-date" => "Yes"
+      })
+    end
+
+    it "renders the Name/Date fill-in row" do
+      render_header
+      expect(rendered).to have_css("table.o-m-namedate td.o-m-namedate__label", text: "Name:")
+      expect(rendered).to have_css("table.o-m-namedate td.o-m-namedate__label", text: "Date:")
+    end
+
+    it "places the Name/Date row above the Document Title" do
+      render_header
+      expect(rendered.index("o-m-namedate")).to be < rendered.index("o-gdoc-h1")
+    end
+  end
+end

--- a/spec/views/materials/pdf/_header.html.erb_spec.rb
+++ b/spec/views/materials/pdf/_header.html.erb_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "materials/pdf/_header", type: :view do
+  let(:material) do
+    Material.new(metadata: { "material-title" => "Document Title", "material-type" => "handout" })
+  end
+  let(:presenter) { MaterialPresenter.new(material, content_type: :default) }
+
+  def render_header
+    render "materials/pdf/header", document: presenter
+  end
+
+  it "renders the Material Type (titleized) on the right of the banner strip" do
+    render_header
+    expect(rendered).to have_css("td.c-lesson-banner__type", text: "Handout")
+  end
+
+  it "renders the banner divider" do
+    render_header
+    expect(rendered).to have_css("hr.c-lesson-banner__divider")
+  end
+
+  it "renders the Document Title from material-title" do
+    render_header
+    expect(rendered).to have_css("h1.c-lesson-banner__title", text: "Document Title")
+  end
+
+  it "inlines the brandmark image when configured" do
+    Settings.set(:documents, "brandmark" => "https://example.com/logo.png")
+    allow(AssetHelper).to receive(:inline_data_uri).and_return("data:image/png;base64,AAAA")
+
+    render_header
+    expect(rendered).to have_css("img.c-lesson-banner__brand-img[src^='data:image/png']")
+  end
+
+  it "does not render the Name/Date row by default" do
+    render_header
+    expect(rendered).not_to have_css("table.o-m-namedate")
+  end
+
+  context "when material-metadata name-date is Yes" do
+    let(:material) do
+      Material.new(metadata: {
+        "material-title" => "Document Title", "material-type" => "handout", "name-date" => "Yes"
+      })
+    end
+
+    it "renders the Name/Date fill-in row" do
+      render_header
+      expect(rendered).to have_css("table.o-m-namedate td.o-m-namedate__label", text: "Name:")
+      expect(rendered).to have_css("table.o-m-namedate td.o-m-namedate__label", text: "Date:")
+    end
+
+    it "places the Name/Date row above the Document Title" do
+      render_header
+      expect(rendered.index("o-m-namedate")).to be < rendered.index("c-lesson-banner__title")
+    end
+  end
+end

--- a/spec/views/units/gdoc/show.html.erb_spec.rb
+++ b/spec/views/units/gdoc/show.html.erb_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "units/gdoc/show", type: :view do
+  let(:metadata) { { "acknowledgements" => acknowledgements } }
+  let(:unit) { UnitPresenter.new(Resource.new(metadata: metadata)) }
+
+  before { assign(:unit, unit) }
+
+  context "when the unit has acknowledgements" do
+    let(:acknowledgements) do
+      "<h3>Steering Committee</h3><p>Name Name, Organization</p>"
+    end
+
+    it "renders the injected Acknowledgements heading" do
+      render
+      expect(rendered).to have_css("h1 span.o-gdoc-h1", text: "Acknowledgements")
+    end
+
+    it "renders the authored sub-sections and names verbatim" do
+      render
+      expect(rendered).to include("<h3>Steering Committee</h3>")
+      expect(rendered).to include("Name Name, Organization")
+    end
+  end
+
+  context "when the unit has no acknowledgements" do
+    let(:acknowledgements) { "" }
+
+    it "renders nothing" do
+      render
+      expect(rendered.strip).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Implements default styling for lesson, unit, and material exports across both PDF and Google Doc formats, plus a new plugin for exporting PDFs via the Google Docs API.
